### PR TITLE
Place sqlite file in conventional PROJECT_ROOT path

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -13,8 +13,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+PROJECT_ROOT = os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
@@ -106,7 +106,7 @@ WSGI_APPLICATION = 'bakerydemo.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'bakerydemodb')
+        'NAME': os.path.join(PROJECT_ROOT, 'bakerydemodb')
     }
 }
 


### PR DESCRIPTION
Fixes #37: sqlite db file should be in the root directory of the entire project:

`/path/to/bakerydemo`

NOT

`/path/to/bakerydemo/bakerydemo`

Once merged, you'll need to move your current DB up one level else a new one will be created.
