### PR TITLE
Specify li for form-page 

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -801,7 +801,8 @@ span.outline {
   margin-right: 10px;
 }
 
-.form-page .fieldWrapper ul, li {
+.form-page .fieldWrapper ul, 
+.form-page .fieldWrapper li {
   list-style: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
fixes #106 

I wrote some very daft CSS that was globally impacting all `li` tags. Fixed the specificity so that it's effecting the correct class now.