### PR TITLE
Blockquote amend

### DIFF
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -42,7 +42,7 @@ class BlockQuote(StructBlock):
     """
     text = TextBlock()
     attribute_name = CharBlock(
-        blank=True, required=False, label='e.g. Guy Picciotto')
+        blank=True, required=False, label='e.g. Mary Berry')
 
     class Meta:
         icon = "fa-quote-left"

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -426,6 +426,14 @@ blockquote p {
   margin: 0 0 10px;
 }
 
+blockquote footer::before {
+  display: none;
+}
+blockquote footer p {
+  font-size: 1.8em;
+  font-style: italic;
+}
+
 cite {
   font-family: 'Lato', sans-serif;
   text-transform: uppercase;


### PR DESCRIPTION
Ironically the `::before` element causing us the problem was from Bootstrap so I owe myself an apology for believing it was my fault. I've gone for the most simple way of differentiating between the quote and attribution possible.

![image](https://cloud.githubusercontent.com/assets/11335309/24418322/85fb8460-13e3-11e7-97b5-1264a286accb.png)
