### PR TITLE
Remove homepage image stretching

### DIFF
--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -80,7 +80,7 @@
                         <li class="col-sm-4 feature-2-item">
                             <a href="{{childpage.url}}">
                                 <figure>
-                                    {% image childpage.image height-210 %}
+                                    {% image childpage.image fill-430x210-c100 %}
                                 </figure>
                             </a>
                             <div class="feature-2-text">
@@ -105,7 +105,7 @@
                         <li class="col-md-4">
                             <a href="{{childpage.url}}">
                                 <figure>
-                                    {% image childpage.image width-380 %}
+                                    {% image childpage.image fill-430x254-c100 %}
                                 </figure>
                                 <h3>{{childpage.title}}</h3>
                             </a>


### PR DESCRIPTION
The homepage images for the feature 2 and feature 3 items were using `width-nnn`. This changes to use `fill-nnn-nnn-c100` to that we crop to size.

@shacker if you're reviewing you may find it easiest copying the homepage code back into your bakerydemo fork since you can then look at the images.