### PR TITLE
Fix media files in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN DATABASE_URL=postgres://none REDIS_URL=none /venv/bin/python manage.py colle
 
 # start uWSGI, using a wrapper script to allow us to easily add more commands to container startup:
 ENTRYPOINT ["/code/docker-entrypoint.sh"]
-CMD ["/venv/bin/uwsgi", "--http-auto-chunked", "--http-keepalive"]
+CMD ["/venv/bin/uwsgi", "--http-auto-chunked", "--http-keepalive", "--static-map", "/media/=/code/bakerydemo/media/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=bakerydemo/wsgi_production.py UWSGI_H
 # Call collectstatic with dummy environment variables:
 RUN DATABASE_URL=postgres://none REDIS_URL=none /venv/bin/python manage.py collectstatic --noinput
 
+# make sure static files are writable by uWSGI process
+RUN chown -R 1000:2000 /code/bakerydemo/media
+
 # start uWSGI, using a wrapper script to allow us to easily add more commands to container startup:
 ENTRYPOINT ["/code/docker-entrypoint.sh"]
 CMD ["/venv/bin/uwsgi", "--http-auto-chunked", "--http-keepalive", "--static-map", "/media/=/code/bakerydemo/media/"]


### PR DESCRIPTION
At the moment, when starting bakerydemo with the Docker setup instructions, media files don't work and the homepage doesn't have any images.

I think there are two problems, both fixed here:
1. images aren't served from uWSGI (I've followed the change from 97409097552d6d31ec0e25bfce790b9a94a02f92)
1. images are owned by root (due to Docker's COPY command), but the code needs write access and runs as uid 1000