### PR TITLE
Mobile styling amends

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -662,10 +662,12 @@ span.outline {
 /* Bread styles */
 /* Bread listview */
 .bread-list-item {
+  display: block;
   border: 1px solid rgba(0,0,0,0.1);
   border-radius: 3px;
   margin: 12px;
   overflow: hidden;
+  color: inherit;
 }
 
 .bread-list-item h2 {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -396,6 +396,12 @@ li.has-submenu a.allow-toggle {
     border-top: 1px solid rgba(255,255,255,.1);
     padding: 20px 0;
   }
+  li.has-submenu a.allow-toggle {
+    float: none;
+  }
+  li.has-submenu a.caret-custom {
+    display: none!important;
+  }
 }
 /* Custom page footer */
 .footer {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -749,6 +749,14 @@ span.outline {
   display: block;
   min-width: 450px;
   max-width: 450px;
+  padding: 5px;
+}
+@media (max-width: 766px) {
+  .form-page input, textarea, select {
+    border: 1px solid #ccc;
+    max-width: 100%;
+    min-width: 100%;
+  }
 }
 
 .form-page li input[type=checkbox], input[type=radio] {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -322,22 +322,22 @@ nav {
   border-top: 1px solid transparent;
 }
 /* The following is to stop a pixel shift on hover */
-.nav-pills>li.breads {
+.nav-pills>.breads {
   width: 90px;
 }
-.nav-pills>li.locations {
+.nav-pills>.locations {
   width: 140px;
 }
-.nav-pills>li.blog {
+.nav-pills>.blog {
   width: 86px;
 }
-.nav-pills>li.gallery {
+.nav-pills>.gallery {
   width: 115px;
 }
-.nav-pills>li.contactus {
+.nav-pills>.contactus {
   width: 148px;
 }
-.nav-pills>li.about {
+.nav-pills>.about {
   width: 88px;
 }
 .nav-pills>li.active>a, .nav-pills>li.active>a:focus, .nav-pills>li.active>a:hover,
@@ -387,10 +387,10 @@ li.has-submenu a.allow-toggle {
 }
 /* Mobile menu styling */
 @media (max-width: 768px) {
-  .nav-pills>li {
+  .nav-pills>.presentation {
     display: block;
     float: none;
-    width: 100%!important;
+    width: 100%;
   }
   .nav-pills> li > a {
     border-top: 1px solid rgba(255,255,255,.1);

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -751,10 +751,10 @@ span.outline {
   display: block;
   width: 450px;
   padding: 5px;
+  border: 1px solid #ccc;
 }
 @media (max-width: 766px) {
   .form-page input, textarea, select {
-    border: 1px solid #ccc;
     width: 100%;
   }
 }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -385,6 +385,18 @@ li.has-submenu a.allow-toggle {
 .caret-custom:after {
     content: "▼"!important;
 }
+/* Mobile menu styling */
+@media (max-width: 768px) {
+  .nav-pills>li {
+    display: block;
+    float: none;
+    width: 100%!important;
+  }
+  .nav-pills> li > a {
+    border-top: 1px solid rgba(255,255,255,.1);
+    padding: 20px 0;
+  }
+}
 /* Custom page footer */
 .footer {
   padding-top: 19px;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -747,15 +747,13 @@ span.outline {
 /* Form detail page */
 .form-page input, textarea, select {
   display: block;
-  min-width: 450px;
-  max-width: 450px;
+  width: 450px;
   padding: 5px;
 }
 @media (max-width: 766px) {
   .form-page input, textarea, select {
     border: 1px solid #ccc;
-    max-width: 100%;
-    min-width: 100%;
+    width: 100%;
   }
 }
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -321,7 +321,7 @@ nav {
 .nav-pills>li, .nav-pills>li, .nav>li>a, .nav>li>a {
   border-top: 1px solid transparent;
 }
-/* The following is to stop a pixel shift on hover */ 
+/* The following is to stop a pixel shift on hover */
 .nav-pills>li.breads {
   width: 90px;
 }
@@ -764,7 +764,7 @@ span.outline {
   margin-right: 10px;
 }
 
-.form-page .fieldWrapper ul, 
+.form-page .fieldWrapper ul,
 .form-page .fieldWrapper li {
   list-style: none;
   padding: 0;
@@ -1048,7 +1048,7 @@ span.outline {
   flex-wrap: wrap;
 }
 
-@media (min-width: 991px) {
+@media (min-width: 992px) {
   .hidden-md-up {
     display: none;
   }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -441,14 +441,6 @@ li.has-submenu a.allow-toggle {
   position: relative;
   z-index: 3;
 }
-.breadcrumb-container + content > .hero {
-  margin-top: -36px;
-}
-@media (max-width: 768px) {
-  .breadcrumb-container + content > .hero {
-    margin-top: 0px;
-  }
-}
 .breadcrumb {
   background-color: transparent;
   color: #ccc;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -388,7 +388,6 @@ li.has-submenu a.allow-toggle {
 /* Mobile menu styling */
 @media (max-width: 768px) {
   .nav-pills>.presentation {
-    display: block;
     float: none;
     width: 100%;
   }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -338,7 +338,7 @@ nav {
   width: 148px;
 }
 .nav-pills>li.about {
-  width: 98px;
+  width: 88px;
 }
 .nav-pills>li.active>a, .nav-pills>li.active>a:focus, .nav-pills>li.active>a:hover,
 .nav-pills>li.active, .nav-pills>li:hover, .nav>li>a:focus, .nav>li>a:hover {
@@ -426,6 +426,11 @@ li.has-submenu a.allow-toggle {
 }
 .breadcrumb-container + content > .hero {
   margin-top: -36px;
+}
+@media (max-width: 768px) {
+  .breadcrumb-container + content > .hero {
+    margin-top: 0px;
+  }
 }
 .breadcrumb {
   background-color: transparent;
@@ -665,7 +670,7 @@ span.outline {
   padding: 0;
 }
 
-.bread-list-item .image:hover img {
+.bread-list-item:hover img {
   opacity: 0.3;
 }
 
@@ -702,7 +707,7 @@ span.outline {
 }
 
 .bread-detail figure img {
-  width: auto;
+  height: auto;
 }
 
 .bread-detail ul.bread-meta {
@@ -994,6 +999,13 @@ span.outline {
 .row.no-gutters {
   margin-right: 0;
   margin-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+@media (max-width: 970px) {
+  .row.no-gutters {
+    display: block;
+  }
 }
 .row.no-gutters > [class^="col-"],
 .row.no-gutters > [class*=" col-"] {
@@ -1010,12 +1022,12 @@ span.outline {
   flex-wrap: wrap;
 }
 
-@media (min-width: 970px) {
+@media (min-width: 991px) {
   .hidden-md-up {
     display: none;
   }
 }
-@media (max-width: 970px) {
+@media (max-width: 991px) {
   .hidden-md-down {
     display: none;
   }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -1025,8 +1025,6 @@ span.outline {
 .row.no-gutters {
   margin-right: 0;
   margin-left: 0;
-  display: flex;
-  flex-wrap: wrap;
 }
 @media (max-width: 970px) {
   .row.no-gutters {

--- a/bakerydemo/templates/base/gallery_page.html
+++ b/bakerydemo/templates/base/gallery_page.html
@@ -2,23 +2,17 @@
 {% load wagtailimages_tags gallery_tags %}
 
 {% block content %}
-{% image self.image fill-1920x600 as hero_img %}
-<div class="container-fluid hero" style="background-image:url('{{ hero_img.url }}')">
-<div class="hero-gradient-mask"></div>
-    <div class="container">
-        <div class="row">
-            <div class="col-md-7 col-md-offset-2">
-                <h1>{{ page.title }}</h1>
-                <p class="stand-first">{{ page.subtitle }}</p>
-            </div>
-        </div>
-    </div>
-</div>
+    {% image self.image fill-1920x600 as hero_img %}
+        {% include "base/include/header-hero.html" %}
 
 <div class="container">
     <div class="row">
-        <div class="col-xs-12">
-            <h2>{{ page.introduction }}</h2>
+        <div class="col-md-8">
+            {% if page.introduction %}
+                    <p class="intro">{{ page.introduction }}</p>
+            {% endif %}
+        </div>
+        <div class="row">
             {% gallery page.collection %}
         </div>
     </div>

--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -14,19 +14,15 @@
     <div class="container">
         <div class="row bread-list">
         {% for bread in breads %}
-            <div class="col-xs-12 col-md-6 bread-list-item">
+            <a href="{% pageurl bread %}" class="col-xs-12 col-md-6 bread-list-item">
                 <div class="row">
                     <div class="col-xs-4 col-sm-4 image">
-                        <a href="{% pageurl bread %}">
-                            {% image bread.image fill-180x180-c100 as image %}
-                            <img src="{{ image.url }}" width="{{ image.width }}"
-                                height="{{ image.height }}" alt="{{ image.alt }}" class="" />
-                        </a>
+                        {% image bread.image fill-180x180-c100 as image %}
+                        <img src="{{ image.url }}" width="{{ image.width }}"
+                            height="{{ image.height }}" alt="{{ image.alt }}" class="" />
                     </div>
                     <div class="col-xs-6 col-sm-7">
-                        <a href="{% pageurl bread %}">
-                            <h2>{{ bread.title }}</h2>
-                        </a>
+                        <h2>{{ bread.title }}</h2>
                         <ul class="bread-meta">
                         {% if bread.origin %}
                             <li><span>Origin</span> {{ bread.origin }}</li>
@@ -37,7 +33,7 @@
                         </ul>
                     </div>
                 </div>
-            </div>
+            </a>
         {% endfor %}
         </div>
     </div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -4,32 +4,38 @@
 {% block title %}Search{% if search_results %} results{% endif %}{% endblock %}
 
 {% block content %}
-    <h1>
-        Search results
-    </h1>
+<div class="container">
+    <div class="row">
+        <div class="col-md-8">
+            <h1>
+                Search results
+            </h1>
 
-    {% if search_results %}
-    <p>You searched{% if search_query %} for “{{ search_query }}”{% endif %}</p>
-        <ul>
-            {% for result in search_results %}
-                <li>
-                    <h4>
-                        {% if result.specific.content_type.model == "blogpage" %}
-                            Blog post:
-                        {% elif result.specific.content_type.model == "locationpage" %}
-                            Location:
-                        {% else %}
-                            Bread
-                        {% endif %}
-                        <a href="{% pageurl result.specific %}">{{ result.specific }}</a>
-                    </h4>
-                        {% if result.specific.search_description %}{{ result.specific.search_description|safe }}{% endif %}
-                </li>
-            {% endfor %}
-        </ul>
-    {% elif search_query %}
-        No results found
-    {% else %}
-        You didn’t search for anything!
-    {% endif %}
+            {% if search_results %}
+                <p>You searched{% if search_query %} for “{{ search_query }}”{% endif %}</p>
+                <ul>
+                    {% for result in search_results %}
+                        <li>
+                            <h4>
+                                {% if result.specific.content_type.model == "blogpage" %}
+                                    Blog post:
+                                {% elif result.specific.content_type.model == "locationpage" %}
+                                    Location:
+                                {% else %}
+                                    Bread
+                                {% endif %}
+                                <a href="{% pageurl result.specific %}">{{ result.specific }}</a>
+                            </h4>
+                                {% if result.specific.search_description %}{{ result.specific.search_description|safe }}{% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% elif search_query %}
+                No results found
+            {% else %}
+                You didn’t search for anything!
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This PR:

- Gives a global mobile menu
- Hides child items on the global mobile menu
- Ensures the hero image doesn't obscure the navigation bar on mobile
- Uses a consistent hero include on gallery page
- Uses a consistent 12-col grid on search page

![image](https://cloud.githubusercontent.com/assets/11335309/25782798/3690fc2c-3349-11e7-919d-8021d44d3c4e.png)

Technically speaking `a730d7` and `e81f54e` apply beyond the mobile styling but seemed overkill to create a separate PR for those minor items.