### PR TITLE
Add (optional) support for Elasticsearch

### DIFF
--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import render
 
@@ -13,25 +14,26 @@ def search(request):
     # Search
     search_query = request.GET.get('q', None)
     if search_query:
-        """
-        Because we can't use ElasticSearch for the demo, we use the native db search.
-        But native DB search can't search specific fields in our models on a `Page` query.
-        So for demo purposes ONLY, we hard-code in the model names we want to search.
-        In production, use ElasticSearch and a simplified search query, per
-        http://docs.wagtail.io/en/v1.8.1/topics/search/searching.html
-        """
+        if 'elasticsearch' in settings.WAGTAILSEARCH_BACKENDS['default']['BACKEND']:
+            # In production, use ElasticSearch and a simplified search query, per
+            # http://docs.wagtail.io/en/v1.12.1/topics/search/backends.html
+            # like this:
+            search_results = Page.objects.live().search(search_query)
+        else:
+            # If we aren't using ElasticSearch for the demo, fall back to native db search.
+            # But native DB search can't search specific fields in our models on a `Page` query.
+            # So for demo purposes ONLY, we hard-code in the model names we want to search.
+            blog_results = BlogPage.objects.live().search(search_query)
+            blog_page_ids = [p.page_ptr.id for p in blog_results]
 
-        blog_results = BlogPage.objects.live().search(search_query)
-        blog_page_ids = [p.page_ptr.id for p in blog_results]
+            bread_results = BreadPage.objects.live().search(search_query)
+            bread_page_ids = [p.page_ptr.id for p in bread_results]
 
-        bread_results = BreadPage.objects.live().search(search_query)
-        bread_page_ids = [p.page_ptr.id for p in bread_results]
+            location_results = LocationPage.objects.live().search(search_query)
+            location_result_ids = [p.page_ptr.id for p in location_results]
 
-        location_results = LocationPage.objects.live().search(search_query)
-        location_result_ids = [p.page_ptr.id for p in location_results]
-
-        page_ids = blog_page_ids + bread_page_ids + location_result_ids
-        search_results = Page.objects.live().filter(id__in=page_ids)
+            page_ids = blog_page_ids + bread_page_ids + location_result_ids
+            search_results = Page.objects.live().filter(id__in=page_ids)
 
         query = Query.get(search_query)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,19 +15,27 @@ services:
     image: redis:3.0
     expose:
       - "6379"
+  elasticsearch:
+    image: elasticsearch:2.3
+    restart: always
+    expose:
+      - "9200"
   app:
     environment:
       DJANGO_SECRET_KEY: changeme
       DATABASE_URL: postgres://app_user:changeme@db/app_db
-      REDIS_URL: redis://redis
+      CACHE_URL: redis://redis
+      ELASTICSEARCH_ENDPOINT: elasticsearch
     build:
       context: .
       dockerfile: ./Dockerfile
     links:
       - db:db
       - redis:redis
+      - elasticsearch:elasticsearch
     ports:
       - "8000:8000"
     depends_on:
       - db
       - redis
+      - elasticsearch

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,9 @@
 Django==1.11.3
 django-dotenv==1.4.1
-# http://docs.wagtail.io/en/v1.8.1/topics/search/backends.html#elasticsearch-backend
-# Not utilized by default; uncomment and review the above document if you require elasticsearch
-# elasticsearch==5.1.0
+# elasticsearch==2.3.0 chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
+# instance types on AWS. Adjust for your deployment as needed.
+elasticsearch==2.3.0
+requests-aws4auth==0.9
 wagtail==1.12
 wagtailfontawesome==1.0.6
 Pillow==4.0.0


### PR DESCRIPTION
This PR adds optional support for Elasticsearch and amends `docker-compose.yml` to show how it can be used. It's also fairly straight forward to configure on AWS.

Feedback welcome.