### PR TITLE
add missing botocore dependency (needed for Elasticsearch on AWS)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,6 @@ django-dotenv==1.4.1
 # elasticsearch==2.3.0 chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
 # instance types on AWS. Adjust for your deployment as needed.
 elasticsearch==2.3.0
-requests-aws4auth==0.9
 wagtail==1.12
 wagtailfontawesome==1.0.6
 Pillow==4.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,3 +6,6 @@ psycopg2==2.6.2
 whitenoise==3.2.2
 boto==2.45.0
 django-storages==1.5.2
+# For retrieving credentials and signing requests to Elasticsearch
+botocore==1.7.2
+requests-aws4auth==0.9


### PR DESCRIPTION
…and move production settings dependencies to production.txt

    Traceback (most recent call last):
      File "manage.py", line 15, in <module>
        execute_from_command_line(sys.argv)
      File "/venv/lib/python3.5/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
        utility.execute()
      File "/venv/lib/python3.5/site-packages/django/core/management/__init__.py", line 307, in execute
        settings.INSTALLED_APPS
      File "/venv/lib/python3.5/site-packages/django/conf/__init__.py", line 56, in __getattr__
        self._setup(name)
      File "/venv/lib/python3.5/site-packages/django/conf/__init__.py", line 41, in _setup
        self._wrapped = Settings(settings_module)
      File "/venv/lib/python3.5/site-packages/django/conf/__init__.py", line 110, in __init__
        mod = importlib.import_module(self.SETTINGS_MODULE)
      File "/usr/local/lib/python3.5/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 985, in _gcd_import
      File "<frozen importlib._bootstrap>", line 968, in _find_and_load
      File "<frozen importlib._bootstrap>", line 957, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 697, in exec_module
      File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
      File "/code/bakerydemo/settings/production.py", line 68, in <module>
        from botocore.session import Session
    ImportError: No module named 'botocore'