### PR TITLE
Fix Elasticsearch authentication when using temporary AWS credentials

### DIFF
--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -40,42 +40,45 @@ AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', '')
 AWS_REGION = os.getenv('AWS_REGION', '')
 
 # Configure Elasticsearch, if present in os.environ
-if 'ELASTICSEARCH_ENDPOINT' in os.environ:
+ELASTICSEARCH_ENDPOINT = os.getenv('ELASTICSEARCH_ENDPOINT', '')
+
+if ELASTICSEARCH_ENDPOINT:
     from elasticsearch import RequestsHttpConnection
     WAGTAILSEARCH_BACKENDS = {
         'default': {
             'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch2',
             'HOSTS': [{
-                'host': os.getenv('ELASTICSEARCH_ENDPOINT', ''),
-                'port': os.getenv('ELASTICSEARCH_PORT', '9200'),
+                'host': ELASTICSEARCH_ENDPOINT,
+                'port': int(os.getenv('ELASTICSEARCH_PORT', '9200')),
+                'use_ssl': os.getenv('ELASTICSEARCH_USE_SSL', 'off') == 'on',
+                'verify_certs': os.getenv('ELASTICSEARCH_VERIFY_CERTS', 'off') == 'on',
             }],
-            'connection_class': RequestsHttpConnection,
+            'OPTIONS': {
+                'connection_class': RequestsHttpConnection,
+            },
         }
     }
 
     if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-        from requests_aws4auth import AWS4Auth
-        WAGTAILSEARCH_BACKENDS['default']['http_auth'] = AWS4Auth(
-            AWS_ACCESS_KEY_ID,
-            AWS_SECRET_ACCESS_KEY,
-            AWS_REGION,
-            'es'
+        from aws_requests_auth.aws_auth import AWSRequestsAuth
+        WAGTAILSEARCH_BACKENDS['default']['HOSTS'][0]['http_auth'] = AWSRequestsAuth(
+            aws_access_key=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            aws_token=os.getenv('AWS_SESSION_TOKEN', ''),
+            aws_host=ELASTICSEARCH_ENDPOINT,
+            aws_region=AWS_REGION,
+            aws_service='es',
         )
     elif AWS_REGION:
         # No API keys in the environ, so attempt to discover them with Boto instead, per:
         # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
         # This may be useful if your credentials are obtained via EC2 instance meta data.
-        from botocore.session import Session
-        from requests_aws4auth import AWS4Auth
-        aws_creds = Session().get_credentials()
-        if aws_creds:
-            WAGTAILSEARCH_BACKENDS['default']['http_auth'] = AWS4Auth(
-                aws_creds.access_key,
-                aws_creds.secret_key,
-                AWS_REGION,
-                'es',
-                aws_creds.token,
-            )
+        from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
+        WAGTAILSEARCH_BACKENDS['default']['HOSTS'][0]['http_auth'] = BotoAWSRequestsAuth(
+            aws_host=ELASTICSEARCH_ENDPOINT,
+            aws_region=AWS_REGION,
+            aws_service='es',
+        )
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,8 @@
 Django==1.11.5
 django-dotenv==1.4.1
-# elasticsearch==2.3.0 chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
-# instance types on AWS. Adjust for your deployment as needed.
-elasticsearch==2.3.0
-requests-aws4auth==0.9
+# elasticsearch==2.x.x chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
+# instance types on AWS (Elasticsearch 2.3). Adjust for your deployment as needed.
+elasticsearch==2.4.1
 wagtail==1.12.1
 wagtailfontawesome==1.0.6
 Pillow==4.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,5 +7,5 @@ whitenoise==3.2.2
 boto==2.45.0
 django-storages==1.5.2
 # For retrieving credentials and signing requests to Elasticsearch
-botocore==1.7.2
-requests-aws4auth==0.9
+botocore==1.7.10
+aws-requests-auth==0.4.0


### PR DESCRIPTION
It turned out `requests-aws4auth` did not properly support temporary AWS credentials as provided in EC2 instance metadata, let alone refresh those credentials. Support for refreshing has been added upstream in `aws-requests-auth==0.4.0` (see https://github.com/DavidMuller/aws-requests-auth/pull/29).

This PR switches to aws-requests-auth and updates a few related dependencies.

This code is currently live at: https://wagtail-bakery.caktus-built.com/ (via https://hub.docker.com/r/tmcnulty/bakerydemo/)