### PR TITLE
Add instructions & requirements for populating S3 bucket with demo data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,11 @@ environment, set the same environment variables there using the method appropria
 
 Once Heroku restarts your application or your Docker container is refreshed, you should have persistent media storage!
 
+To copy the initial data included with this demo to the S3 bucket (assuming you ran `./manage.py load_initial_data` per
+the above), you can use the AWS CLI included with the requirements:
+
+    heroku run aws s3 sync bakerydemo/media/original_images/ s3://<bucket-name>/original_images/
+
 # Next steps
 
 Hopefully after you've experimented with the demo you'll want to create your own site. To do that you'll want to run the `wagtail start` command in your environment of choice. You can find more information in the [getting started Wagtail CMS docs](http://wagtail.readthedocs.io/en/latest/getting_started/index.html).

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,3 +11,5 @@ botocore==1.7.10
 aws-requests-auth==0.4.0
 django-redis==4.8.0
 django_cache_url==2.0.0
+# For copying initial media to S3 bucket
+awscli==1.11.23


### PR DESCRIPTION
It turns out `DJANGO_SETTINGS_MODULE` must be set in the Heroku/Dokku environment (rather than just in the production WSGI file), because it's also needed for running management commands (and `manage.py` presumably should continue to point to the dev rather than production settings).

There is one minor improvement that we could make instead, which is to provide a mechanism for populating the S3 bucket with the demo media.