### PR TITLE
add support for CACHE_URL

### DIFF
--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -1,7 +1,9 @@
 import os
-import dj_database_url
 import random
 import string
+
+import dj_database_url
+import django_cache_url
 
 from .base import *
 
@@ -38,6 +40,9 @@ DATABASES['default'].update(db_from_env)
 AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', '')
 AWS_REGION = os.getenv('AWS_REGION', '')
+
+# configure CACHES from CACHE_URL environment variable (defaults to locmem if no CACHE_URL is set)
+CACHES = {'default': django_cache_url.config()}
 
 # Configure Elasticsearch, if present in os.environ
 ELASTICSEARCH_ENDPOINT = os.getenv('ELASTICSEARCH_ENDPOINT', '')

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,3 +9,5 @@ django-storages==1.5.2
 # For retrieving credentials and signing requests to Elasticsearch
 botocore==1.7.10
 aws-requests-auth==0.4.0
+django-redis==4.8.0
+django_cache_url==2.0.0


### PR DESCRIPTION
We might as well use the cache, if one is configured.

This is deployed to https://wagtail-bakery.caktus-built.com/ via Dokku and successfully picks up/uses the Redis ElastiCache instance there.