### PR TITLE
Allow PROJECT_DIR to be overridden

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -2,7 +2,7 @@
 
 PROJECT_NAME=$1
 
-PROJECT_DIR=/vagrant
+: ${PROJECT_DIR:=/vagrant}
 VIRTUALENV_DIR=/home/vagrant/.virtualenvs/$PROJECT_NAME
 
 PYTHON=$VIRTUALENV_DIR/bin/python


### PR DESCRIPTION
When setting up bakerydemo as part of a [vagrant-wagtail-develop](https://github.com/wagtail/vagrant-wagtail-develop) environment, we'd like to be able to install the project at `/vagrant/bakerydemo` rather than `/vagrant`, so that the Wagtail codebase can sit alongside it at `/vagrant/wagtail`.

This change allows us to do that, by passing a custom `PROJECT_DIR` when invoking the bakerydemo provision script:

    BAKERYDEMO_ROOT=/vagrant/bakerydemo
    PROJECT_DIR=$BAKERYDEMO_ROOT $BAKERYDEMO_ROOT/vagrant/provision.sh bakerydemo