### PR TITLE
Fix numchild value on root page

### DIFF
--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -1514,7 +1514,7 @@
   "fields": {
     "path": "0001",
     "depth": 1,
-    "numchild": 0,
+    "numchild": 1,
     "title": "Root",
     "draft_title": "Root",
     "slug": "root",


### PR DESCRIPTION
When set to 0, the homepage fails to appear in the explorer listing when viewing the root (because Treebeard thinks root is a leaf node and so doesn't bother querying the database for get_children).