### PR TITLE
Add CloudFront support

### DIFF
--- a/bakerydemo/base/context_processors.py
+++ b/bakerydemo/base/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def global_settings(request):
+    # Add below any settings needed from the templates
+    return {
+        'ENABLE_USER_BAR': settings.ENABLE_USER_BAR,
+    }

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -92,6 +92,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'bakerydemo.base.context_processors.global_settings',
             ],
         },
     },
@@ -175,3 +176,6 @@ WAGTAILSEARCH_BACKENDS = {
 
 # Wagtail settings
 WAGTAIL_SITE_NAME = "bakerydemo"
+
+# Allow disabling user bar, e.g., in case we're using a frontend cache
+ENABLE_USER_BAR = True

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -100,6 +100,17 @@ if 'AWS_STORAGE_BUCKET_NAME' in os.environ:
     MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
+if 'CLOUDFRONT_DISTRIBUTION_ID' in os.environ:
+    CLOUDFRONT_DISTRIBUTION_ID = os.getenv('CLOUDFRONT_DISTRIBUTION_ID')
+    INSTALLED_APPS.append('wagtail.contrib.wagtailfrontendcache')
+    WAGTAILFRONTENDCACHE = {
+        'cloudfront': {
+            'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.CloudfrontBackend',
+            'DISTRIBUTION_ID': CLOUDFRONT_DISTRIBUTION_ID,
+        },
+    }
+    ENABLE_USER_BAR = False
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -5,7 +5,9 @@
 {% endblock head %}
 
 <body class="{% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}">
-{% wagtailuserbar %}
+{% if ENABLE_USER_BAR %}
+    {% wagtailuserbar %}
+{% endif %}
 
 {% block header %}
     {# Header contains the main_navigation block #}

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,16 @@ the above), you can use the AWS CLI included with the requirements:
 
     heroku run aws s3 sync bakerydemo/media/original_images/ s3://<bucket-name>/original_images/
 
+### CloudFront Support
+
+To enable CloudFront support, simply set the `CLOUDFRONT_DISTRIBUTION_ID` environment variable with the Distribution
+ID of your CloudFront distribution. For example, on Heroku:
+
+    heroku config:set CLOUDFRONT_DISTRIBUTION_ID=changeme
+
+This has the side effect of disabling the Wagtail User Bar, as this effectively breaks caching when it checks to see
+whether or not the current user is logged in.
+
 # Next steps
 
 Hopefully after you've experimented with the demo you'll want to create your own site. To do that you'll want to run the `wagtail start` command in your environment of choice. You can find more information in the [getting started Wagtail CMS docs](http://wagtail.readthedocs.io/en/latest/getting_started/index.html).

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,8 +6,8 @@ psycopg2==2.6.2
 whitenoise==3.2.2
 boto==2.45.0
 django-storages==1.5.2
-# For retrieving credentials and signing requests to Elasticsearch
-botocore==1.7.10
+# For API access to CloudFront, and for retrieving credentials and signing requests to Elasticsearch
+boto3==1.4.6
 aws-requests-auth==0.4.0
 django-redis==4.8.0
 django_cache_url==2.0.0


### PR DESCRIPTION
I think it'd be helpful to have an example of production-grade caching with this demo.

Note that CloudFront (and presumably other CDNs) have a default cache TTL which will take precedence if no `Cache-Control` header is set (the Wagtail default for non-admin pages).

This is running at https://wagtail-bakery.caktus-built.com/, e.g.:

	$ curl -I -i https://wagtail-bakery.caktus-built.com/breads/bhakri/
	HTTP/1.1 200 OK
	Content-Type: text/html; charset=utf-8
	Content-Length: 9481
	Connection: keep-alive
	Date: Sat, 14 Oct 2017 11:30:50 GMT
	Server: nginx
	X-Frame-Options: SAMEORIGIN
	Vary: Accept-Encoding
	X-Cache: Miss from cloudfront
	Via: 1.1 be6e9f1c9fc10c0ed71d69327915bac2.cloudfront.net (CloudFront)
	X-Amz-Cf-Id: sJ96bUzmn7KBtyWGfU22Nv25z03XLy7YsIaZFLHnYigi2l2CvuuW6A==

	$ curl -I -i https://wagtail-bakery.caktus-built.com/breads/bhakri/
	HTTP/1.1 200 OK
	Content-Type: text/html; charset=utf-8
	Content-Length: 9481
	Connection: keep-alive
	Date: Sat, 14 Oct 2017 11:30:50 GMT
	Server: nginx
	X-Frame-Options: SAMEORIGIN
	Age: 2
	Vary: Accept-Encoding
	X-Cache: Hit from cloudfront
	Via: 1.1 d1201a6f66026e2a6d778a9fd9208986.cloudfront.net (CloudFront)
	X-Amz-Cf-Id: VRXMk3rVi5FQEnfpXfUw_ghptulrFOwSITCh4ZNUxKOIe9VvNdgDyQ==