### PR TITLE
Allow 'vagrant' username to be configured by passing DEV_USER variable

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,25 +3,26 @@
 PROJECT_NAME=$1
 
 : ${PROJECT_DIR:=/vagrant}
-VIRTUALENV_DIR=/home/vagrant/.virtualenvs/$PROJECT_NAME
+: ${DEV_USER:=vagrant}
+VIRTUALENV_DIR=/home/$DEV_USER/.virtualenvs/$PROJECT_NAME
 
 PYTHON=$VIRTUALENV_DIR/bin/python
 PIP=$VIRTUALENV_DIR/bin/pip
 
 
 # Virtualenv setup for project
-su - vagrant -c "virtualenv --python=python3 $VIRTUALENV_DIR"
+su - $DEV_USER -c "virtualenv --python=python3 $VIRTUALENV_DIR"
 # Replace previous line with this if you are using Python 2
-# su - vagrant -c "virtualenv --python=python2 $VIRTUALENV_DIR"
+# su - $DEV_USER -c "virtualenv --python=python2 $VIRTUALENV_DIR"
 
-su - vagrant -c "echo $PROJECT_DIR > $VIRTUALENV_DIR/.project"
+su - $DEV_USER -c "echo $PROJECT_DIR > $VIRTUALENV_DIR/.project"
 
 
 # Upgrade PIP
-su - vagrant -c "$PIP install --upgrade pip"
+su - $DEV_USER -c "$PIP install --upgrade pip"
 
 # Install PIP requirements
-su - vagrant -c "$PIP install -r $PROJECT_DIR/requirements/base.txt"
+su - $DEV_USER -c "$PIP install -r $PROJECT_DIR/requirements/base.txt"
 
 
 # Set execute permissions on manage.py as they get lost if we build from a zip file
@@ -34,8 +35,8 @@ echo DJANGO_SETTINGS_MODULE=$PROJECT_NAME.settings.local > $PROJECT_DIR/.env
 
 if [ -n "$USE_POSTGRESQL" ]
 then
-    su - vagrant -c "createdb $PROJECT_NAME"
-    su - vagrant -c "$PIP install \"psycopg2>=2.7,<3\""
+    su - $DEV_USER -c "createdb $PROJECT_NAME"
+    su - $DEV_USER -c "$PIP install \"psycopg2>=2.7,<3\""
     cat << EOF >> $PROJECT_DIR/bakerydemo/settings/local.py
 DATABASES = {
     'default': {
@@ -47,13 +48,13 @@ EOF
 fi
 
 # Run syncdb/migrate/load_initial_data/update_index
-su - vagrant -c "$PYTHON $PROJECT_DIR/manage.py migrate --noinput && \
-                 $PYTHON $PROJECT_DIR/manage.py load_initial_data && \
-                 $PYTHON $PROJECT_DIR/manage.py update_index"
+su - $DEV_USER -c "$PYTHON $PROJECT_DIR/manage.py migrate --noinput && \
+                   $PYTHON $PROJECT_DIR/manage.py load_initial_data && \
+                   $PYTHON $PROJECT_DIR/manage.py update_index"
 
 
 # Add a couple of aliases to manage.py into .bashrc
-cat << EOF >> /home/vagrant/.bashrc
+cat << EOF >> /home/$DEV_USER/.bashrc
 export PYTHONPATH=$PROJECT_DIR
 
 alias dj="./manage.py"


### PR DESCRIPTION
This allows the script to work on official Ubuntu images, which use the username 'ubuntu' instead.