### PR TITLE
Remove erroneous index.SearchField('title') entries from search_fields

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -89,7 +89,6 @@ class BlogPage(Page):
     ]
 
     search_fields = Page.search_fields + [
-        index.SearchField('title'),
         index.SearchField('body'),
     ]
 

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -141,7 +141,6 @@ class BreadPage(Page):
     ]
 
     search_fields = Page.search_fields + [
-        index.SearchField('title'),
         index.SearchField('body'),
     ]
 


### PR DESCRIPTION
title is already included in Page.search_fields, so adding it again A) is redundant and B) makes it fail when run against Elasticsearch, due to the two occurrences having different indexing parameters.