### PR TITLE
Delete default homepage/site records before loading fixture

### DIFF
--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -12,13 +12,13 @@ class Command(BaseCommand):
         fixtures_dir = os.path.join(settings.BASE_DIR, 'base', 'fixtures')
         fixture_file = os.path.join(fixtures_dir, 'bakerydemo.json')
 
-        call_command('loaddata', fixture_file, verbosity=0)
-
         # Wagtail creates default Site and Page instances during install, but we already have
         # them in the data load. Remove the auto-generated ones.
         if Site.objects.filter(hostname='localhost').exists():
             Site.objects.get(hostname='localhost').delete()
         if Page.objects.filter(title='Welcome to your new Wagtail site!').exists():
             Page.objects.get(title='Welcome to your new Wagtail site!').delete()
+
+        call_command('loaddata', fixture_file, verbosity=0)
 
         print("Awesome. Your data is loaded! The bakery's doors are almost ready to open...")


### PR DESCRIPTION
Deleting them after loading means that the 'numchild' field of the root node (which the fixture correctly gives as 1, corresponding to the bakerydemo homepage) is wrongly decremented to zero, causing the page chooser modal to break (because it thinks root is a leaf node).