### PR TITLE
Disable password validators locally

### DIFF
--- a/bakerydemo/settings/dev.py
+++ b/bakerydemo/settings/dev.py
@@ -6,3 +6,5 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # BASE_URL required for notification emails
 BASE_URL = 'http://localhost:8000'
+
+AUTH_PASSWORD_VALIDATORS = []


### PR DESCRIPTION
Based on the `wagtail-2.0` branch, which was the default one within `vagrant-wagtail-develop`.