### PR TITLE
Set site name to Wagtail Bakery

### DIFF
--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -1187,7 +1187,7 @@
   "fields": {
     "hostname": "127.0.0.1",
     "port": 8000,
-    "site_name": "Main",
+    "site_name": "Wagtail Bakery",
     "root_page": 60,
     "is_default_site": true
   }


### PR DESCRIPTION
'Main' isn't really suitable as a site name, because it results in a limited-permission user (e.g. an editor with edit permission on the Blog section only) receiving the welcome message "Welcome to the Main Wagtail CMS".