### PR TITLE
Standardize PROJECT_DIR and BASE_DIR with Wagtail defaults.

### DIFF
--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore.models import Site, Page
 
 class Command(BaseCommand):
     def handle(self, **options):
-        fixtures_dir = os.path.join(settings.BASE_DIR, 'base', 'fixtures')
+        fixtures_dir = os.path.join(settings.PROJECT_DIR, 'base', 'fixtures')
         fixture_file = os.path.join(fixtures_dir, 'bakerydemo.json')
 
         # Wagtail creates default Site and Page instances during install, but we already have

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -12,9 +12,9 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-PROJECT_ROOT = os.path.abspath(os.path.join(BASE_DIR, os.pardir))
+# Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
@@ -105,7 +105,7 @@ WSGI_APPLICATION = 'bakerydemo.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(PROJECT_ROOT, 'bakerydemodb')
+        'NAME': os.path.join(BASE_DIR, 'bakerydemodb')
     }
 }
 
@@ -152,13 +152,13 @@ STATICFILES_FINDERS = [
 ]
 
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static'),
+    os.path.join(PROJECT_DIR, 'static'),
 ]
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'collect_static')
+STATIC_ROOT = os.path.join(PROJECT_DIR, 'collect_static')
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
 MEDIA_URL = '/media/'
 
 # Override in local settings or replace with your own key. Please don't use our demo key in production!


### PR DESCRIPTION
A brand new wagtail 1.13.1 project creates a `settings/base.py` with the following constants:

```
PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
BASE_DIR = os.path.dirname(PROJECT_DIR)
```
It was confusing to me because this demo reverses these two constants. 