### PR TITLE
Cleanup Search Form Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 /.vagrant/
 /Vagrantfile.local
 !.gitignore
+.python-version

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -12,8 +12,8 @@
                         <span class="icon-bar"></span>
                     </button>
 
-                <form action="/search" method="get" class="search" _lpchecked="1" role="search">
-                    <input name="q" type="text" placeholder="Search the site" id="" aria-label="Search the site" autocomplete="off">
+                <form action="/search" method="get" class="search" role="search">
+                    <input name="q" type="text" placeholder="Search the site" aria-label="Search the site" autocomplete="off">
                     <a href="#" class="search-icon">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 451 451"><path d="M447.05 428l-109.6-109.6c29.4-33.8 47.2-77.9 47.2-126.1C384.65 86.2 298.35 0 192.35 0 86.25 0 .05 86.3.05 192.3s86.3 192.3 192.3 192.3c48.2 0 92.3-17.8 126.1-47.2L428.05 447c2.6 2.6 6.1 4 9.5 4s6.9-1.3 9.5-4c5.2-5.2 5.2-13.8 0-19zM26.95 192.3c0-91.2 74.2-165.3 165.3-165.3 91.2 0 165.3 74.2 165.3 165.3s-74.1 165.4-165.3 165.4c-91.1 0-165.3-74.2-165.3-165.4z"></path></svg>
                     </a>


### PR DESCRIPTION
Remote empty id attribute from search input. Remove _lpchecked attribute from search form because it isn't part of standard HTML. https://stackoverflow.com/questions/8879303/what-is-lpchecked-1-for-in-a-form