### PR TITLE
Update Heroku Python runtime

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4


### PR DESCRIPTION
from 3.6.2 to 3.6.4, following Heroku recommendations