### PR TITLE
Enable sitemap and API

### DIFF
--- a/bakerydemo/api.py
+++ b/bakerydemo/api.py
@@ -1,0 +1,15 @@
+from wagtail.api.v2.endpoints import PagesAPIEndpoint
+from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.images.api.v2.endpoints import ImagesAPIEndpoint
+from wagtail.documents.api.v2.endpoints import DocumentsAPIEndpoint
+
+# Create the router. "wagtailapi" is the URL namespace
+api_router = WagtailAPIRouter('wagtailapi')
+
+# Add the three endpoints using the "register_endpoint" method.
+# The first parameter is the name of the endpoint (eg. pages, images). This
+# is used in the URL of the endpoint
+# The second parameter is the endpoint class that handles the requests
+api_router.register_endpoint('pages', PagesAPIEndpoint)
+api_router.register_endpoint('images', ImagesAPIEndpoint)
+api_router.register_endpoint('documents', DocumentsAPIEndpoint)

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sitemaps',
 ]
 
 MIDDLEWARE = [

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
+    'wagtail.api.v2',
     'wagtail.contrib.modeladmin',
     'wagtail.contrib.routable_page',
     'wagtail.core',

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -8,6 +8,7 @@ from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core import urls as wagtail_urls
 
 from bakerydemo.search import views as search_views
+from .api import api_router
 
 urlpatterns = [
     url(r'^django-admin/', admin.site.urls),
@@ -18,6 +19,7 @@ urlpatterns = [
     url(r'^search/$', search_views.search, name='search'),
 
     url('^sitemap\.xml$', sitemap),
+    url(r'^api/v2/', api_router.urls),
 ]
 
 

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core import urls as wagtail_urls
 
 from bakerydemo.search import views as search_views
@@ -16,6 +17,7 @@ urlpatterns = [
 
     url(r'^search/$', search_views.search, name='search'),
 
+    url('^sitemap\.xml$', sitemap),
 ]
 
 


### PR DESCRIPTION
When developing against bakerydemo it's helpful to have as many batteries included as possible, and it can't hurt for people evaluating Wagtail to see these features in action...