### PR TITLE
Docker: add zlib-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
 		pcre-dev \
 		postgresql-dev \
 		libjpeg-turbo-dev \
+		zlib-dev \
 		git \
 	&& pyvenv /venv \
 	&& /venv/bin/pip install -U pip \


### PR DESCRIPTION
Got an error while building through docker-compose.
Pillow was compiling (didn't get a precompiled wheel...?),
and it was complaining about missing zlib headers, so added it to the libraries list in Dockerfile.