### PR TITLE
Docker will now force-remove rendition entries from db

### DIFF
--- a/bakerydemo/base/management/commands/delete_renditions.py
+++ b/bakerydemo/base/management/commands/delete_renditions.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+# Force removal of wagtail image rendition-entries in db will force wagtail to
+# regenerate renditions. Useful if renditions are removed, for instance when
+# using Docker where the file system is renewed on each build.
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT count(*) FROM wagtailimages_rendition")
+            row=cursor.fetchone()
+            cursor.execute("DELETE FROM wagtailimages_rendition")
+            print("{} renditions removed".format(row[0]))

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,9 @@ done
 
 if [ "$1" = '/venv/bin/uwsgi' ]; then
     /venv/bin/python manage.py migrate --noinput
+    # Since we are running docker, we need to delete rendition entries from db
+    # since the docker image will have a non-populated /media/image directory
+    /venv/bin/python manage.py delete_renditions
 fi
 
 if [ "x$DJANGO_LOAD_INITIAL_DATA" = 'xon' ]; then


### PR DESCRIPTION
Since Docker will use a new file system on a rebuild, old renditions in
$MEDIA/images will no longer be present. By removing rendition entries from db
Wagtail will be forced to generate new renditions, instead of providing dead
links to the old renditions.