### PR TITLE
Bump awscli to be compatible with Py37

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,9 +7,9 @@ whitenoise==3.2.2
 boto==2.45.0
 django-storages==1.6.5
 # For retrieving credentials and signing requests to Elasticsearch
-botocore==1.7.10
+botocore==1.12.33
 aws-requests-auth==0.4.0
 django-redis==4.8.0
 django_cache_url==2.0.0
 # For copying initial media to S3 bucket
-awscli==1.11.23
+awscli==1.16.43


### PR DESCRIPTION
`awscli` version we used to pin depends on `pyyaml` that doesn't support py37

The issue got fixed in https://github.com/aws/aws-cli/pull/3430

`botocore` is also updated as `awscli` and `botocore` should usually be synchronized (before doing that I was getting HTTP 500 on Heroku).