### PR TITLE
Move elasticsearch requirements to an appropriate place

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,5 @@
 Django>=2.1,<2.2
 django-dotenv==1.4.1
-# elasticsearch==2.x.x chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
-# instance types on AWS (Elasticsearch 2.3). Adjust for your deployment as needed.
-elasticsearch==2.4.1
-
 wagtail>=2.3,<2.4
 wagtailfontawesome>=1.1.3,<1.2
 Pillow==4.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,7 @@
 -r base.txt
+# elasticsearch==2.x.x chosen for compatibility with t2.micro.elasticsearch and t2.small.elasticsearch
+# instance types on AWS (Elasticsearch 2.3). Adjust for your deployment as needed.
+elasticsearch==2.4.1
 # Additional dependencies for Heroku deployment
 dj-database-url==0.4.1
 uwsgi==2.0.17.1


### PR DESCRIPTION
- elasticsearch is used only on production settings by default
- for development purposes elasticsearch is installed by a `provision.sh` script in a separate repo: https://github.com/wagtail/vagrant-wagtail-develop