### PR TITLE
Correct the html element main

### DIFF
--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -25,10 +25,10 @@
     {% breadcrumbs %}
 {% endblock breadcrumbs %}
 
-<content role="main">
+<main role="main">
     {% block content %}
     {% endblock content %}
-</content>
+</main>
 
     <hr>
 


### PR DESCRIPTION
Correct the HTML5 element 'content' to 'main'. 'content' is obsolete and wasn't meant to be used in ordinary HTML. 
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/content