### PR TITLE
Add required libraries for Pillow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN set -ex \
 			| sort -u \
 	)" \
 	&& apk add --virtual .python-rundeps $runDeps \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& apk add libjpeg-turbo pcre
 RUN apk add --no-cache postgresql-client
 RUN mkdir /code/
 WORKDIR /code/


### PR DESCRIPTION
While running demo via docker, there are some errors due to missing libraries. This PR tries to fix this issue.

```
app_1            | SystemCheckError: System check identified some issues:
app_1            | 
app_1            | ERRORS:
app_1            | wagtailimages.Image.file: (fields.E210) Cannot use ImageField because Pillow is not installed.
app_1            |      HINT: Get Pillow at https://pypi.org/project/Pillow/ or run command "pip install Pillow".
app_1            | wagtailimages.Rendition.file: (fields.E210) Cannot use ImageField because Pillow is not installed.
app_1            |      HINT: Get Pillow at https://pypi.org/project/Pillow/ or run command "pip install Pillow".
app_1            | wagtailusers.UserProfile.avatar: (fields.E210) Cannot use ImageField because Pillow is not installed.
app_1            |      HINT: Get Pillow at https://pypi.org/project/Pillow/ or run command "pip install Pillow".
```

```
app_1            | Error loading shared library libpcre.so.1: No such file or directory (needed by /venv/bin/uwsgi)
app_1            | Error relocating /venv/bin/uwsgi: pcre_exec: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_config: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_fullinfo: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_compile: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_study: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_free_study: symbol not found
app_1            | Error relocating /venv/bin/uwsgi: pcre_free: symbol not found
```