### PR TITLE
Enable CSP

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -75,6 +75,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'csp.middleware.CSPMiddleware',
 
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -1,3 +1,4 @@
+from csp.decorators import csp
 from django.conf.urls import include, url
 from django.conf import settings
 from django.contrib import admin
@@ -6,14 +7,20 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core import urls as wagtail_urls
+from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 from bakerydemo.search import views as search_views
 from .api import api_router
 
-urlpatterns = [
+admin_urlpatterns = [
     url(r'^django-admin/', admin.site.urls),
-
     url(r'^admin/', include(wagtailadmin_urls)),
+]
+
+admin_urlpatterns = decorate_urlpatterns(admin_urlpatterns, csp(SCRIPT_SRC=["'self'", "'unsafe-inline'"]))
+
+urlpatterns = admin_urlpatterns + [
+
     url(r'^documents/', include(wagtaildocs_urls)),
 
     url(r'^search/$', search_views.search, name='search'),

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,3 +16,4 @@ django-redis==4.8.0
 django_cache_url==2.0.0
 # For copying initial media to S3 bucket
 awscli==1.16.43
+django-csp==3.5


### PR DESCRIPTION
This PR adds a ``Content-Security-Policy`` header to responses from the Wagtail admin. This should prevent any unsafe eval statements from running so we can catch these issues early.