### PR TITLE
Add expat-dev to Dockerfile packages install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,32 @@ FROM python:3.5-alpine
 
 ADD requirements/ /requirements/
 RUN set -ex \
-	&& apk add --no-cache --virtual .build-deps \
-		gcc \
-		g++ \
-		make \
-		libc-dev \
-		musl-dev \
-		linux-headers \
-		pcre-dev \
-		postgresql-dev \
-		libjpeg-turbo-dev \
-		zlib-dev \
-		git \
-	&& pyvenv /venv \
-	&& /venv/bin/pip install -U pip \
-	&& LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install -r /requirements/production.txt" \
-	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /venv \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
-	)" \
-	&& apk add --virtual .python-rundeps $runDeps \
-	&& apk del .build-deps \
-	&& apk add libjpeg-turbo pcre
+    && apk add --no-cache --virtual .build-deps \
+        gcc \
+        g++ \
+        make \
+        libc-dev \
+        musl-dev \
+        linux-headers \
+        pcre-dev \
+        postgresql-dev \
+        libjpeg-turbo-dev \
+        zlib-dev \
+        expat-dev \
+        git \
+    && pyvenv /venv \
+    && /venv/bin/pip install -U pip \
+    && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install -r /requirements/production.txt" \
+    && runDeps="$( \
+        scanelf --needed --nobanner --recursive /venv \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --virtual .python-rundeps $runDeps \
+    && apk del .build-deps \
+    && apk add libjpeg-turbo pcre
 RUN apk add --no-cache postgresql-client
 RUN mkdir /code/
 WORKDIR /code/


### PR DESCRIPTION
The diff on the Dockerfile is a bit of a mess due ~to the one-liner optimization~ to the change from tabs to spaces.

The only change occurs on line 16 where `expat-dev` has been added

This should fix issue #234