### PR TITLE
push built images to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 env:
   global:
     - GREP_TIMEOUT=360
+    - secure: 2RbSs34h/+D7SOr/vfxxNqRolEHcvWIZX/ihnq75h62owhqUsO7iN2YAvtYb97nvtC4FiPPuxUtXGajjvf/VIC2wXtxtocOlHTdi+t8mY2wGJOe3GkLD3LfPR2nTngD6Av2BXxPVpkpnRFPj1UkyN92vDKVn7IZMifGFNSL3sRe82Ku7yP0hkc1Fh0nobiIbLo1gaXccWQLswWJcaVD+K7kutA5Q4xiNdIpLwC0d+0Ctef9FQ9TwVTytVntFt68gvfxgXdYl4CStnAIdFJaosOOfhkpAQN8OlW24j5eOANcBCuTR1ifmbY4n/JPdw/Q1pwsFVES+iyqiq4VKi1NTQAsTcOcvKFhANBDXBRr2zINXbW+7qDHCCaFuPXVpnveYFpIfzfKHPwsAThjKaVG+K5yNO7AuXBE5v2xur+NRVjOARkzgLKf9MzLjsp/fiAVHGtbS9jd+x4/+tHrEUMZzyKzdZsV+SzyWcluGKx+jNcTNYCHGsYPwt59HJbvYU9z3RbTmAl74H2+9api1JZiyyPOuaBzqykyZSZAupH1PufqUOpu5pRYe6Q7X0Q2nIKrkZ/VJW19gpjGWc/bEcr0JYuQKOWGJudJ19P5qpnB2OEpDClYALt/sf2KntOgKcZ2BdP8ux4oaRiJK2tqEMG7JKFzFXvRVOvFRoe6VdqZ0dMM=
+    - secure: 0fBpu3GAJtbcycOffphhLUlvbn48Qx3AxIZtqKHQuhNvExU5ydz6i3LWUVe3/1JyLPiUAGmbDNIMzeAbd7kKi8kRrZ7EsqK/pIHzAp1qjI+DhnQehT3lZ/vFLW6meyNjsrou0YPTnZ8s0+9Qbe8MnIHcZMYUXjxv6a6sW8FUim55dWRYJM5cERGkcHHHZwn94zV5BRgpbD4vvM3zSlCuhm0u4uDA1yi//Qc0O2h23xV7Qf9FpcCFt4yl5t1uxG1g/nhTl91/GGPBYWci6VgoC3hO8PCJdvqFnRD34bsjtt7IGTO9kFZW+wY9wqczOg3pJwsjk/yUJnQxzKmzzvxww08Iz2QTw6egNP1SpRlID0xp30ZkRWSi1M7KZWm61tRjI0rXG8HobFmSW3okmKfy7qbk4hHPx9n7ot39YoFTjezJitd+pmZn9p4nPa/FEbUFg0pcBHLfrGM8mXI5sAQPXlJpRlTx9AUq+VuMlY4d4ewOXaOXC/AfQzb+WPWgMQFQXk6Bdse5Vx5giET41I+v3fTUT5Ig+6X7Is8zZeZ21XOn0Q2CuE3Wj/cAtpIxEgi1mOaa05A6W6aZ35fbKJhekV+Z5DkowjriZx/w6BnOsIfopGn4aU/CdjOAkixe9qavn1KFdApW/g3zcbKqTcSpgk2XdB/JwwcWCbOd+Nc15CM=
 
 before_install:
   - sudo apt-get update
@@ -22,3 +24,9 @@ script:
 after_script:
   - docker-compose logs
   - docker images
+
+deploy:
+  provider: script
+  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin && docker tag bakerydemo_app wagtail/bakerydemo:latest && docker tag bakerydemo_app wagtail/bakerydemo:release-$(git rev-parse --short ${TRAVIS_COMMIT}) && docker push wagtail/bakerydemo
+  on:
+    branch: master


### PR DESCRIPTION
Sample successful build: https://travis-ci.org/wagtail/bakerydemo/builds/583898186

I know you can configure Docker Hub to auto-build from a GitHub repo too, but I prefer this since we can run our checks on it first. Also, I don't have permissions to link the Docker Hub to the GitHub repo. 🙂 