### PR TITLE
switch to python:3.7-slim (Debian-based) image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,40 @@
-FROM python:3.7-alpine
+FROM python:3.7-slim
+
+# Install packages needed to run your application (not build deps):
+# We need to recreate the /usr/share/man/man{1..8} directories first because
+# they were clobbered by a parent image.
+RUN set -ex \
+    && RUN_DEPS=" \
+        libexpat1 \
+        libjpeg62-turbo \
+        libpcre3 \
+        libpq5 \
+        mime-support \
+        postgresql-client \
+        zlib1g \
+    " \
+    && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
+    && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD requirements/ /requirements/
 RUN set -ex \
-    && apk add --no-cache --virtual .build-deps \
-        gcc \
-        g++ \
-        make \
-        libc-dev \
-        musl-dev \
-        linux-headers \
-        pcre-dev \
-        postgresql-dev \
-        libjpeg-turbo-dev \
-        zlib-dev \
-        expat-dev \
+    && BUILD_DEPS=" \
+        build-essential \
         git \
-    && pyvenv /venv \
+        libexpat1-dev \
+        libjpeg62-turbo-dev \
+        libpcre3-dev \
+        libpq-dev \
+        zlib1g-dev \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS \
+    && python3.7 -m venv /venv \
     && /venv/bin/pip install -U pip \
-    && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install -r /requirements/production.txt" \
-    && runDeps="$( \
-        scanelf --needed --nobanner --recursive /venv \
-            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-            | sort -u \
-            | xargs -r apk info --installed \
-            | sort -u \
-    )" \
-    && apk add --virtual .python-rundeps $runDeps \
-    && apk del .build-deps \
-    && apk add libjpeg-turbo pcre
-RUN apk add --no-cache postgresql-client
+    && /venv/bin/pip install --no-cache-dir -r /requirements/production.txt \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /code/
 WORKDIR /code/
 ADD . /code/
@@ -37,8 +43,17 @@ EXPOSE 8000
 # Add custom environment variables needed by Django or your settings file here:
 ENV DJANGO_SETTINGS_MODULE=bakerydemo.settings.production DJANGO_DEBUG=off
 
-# uWSGI configuration (customize as needed):
-ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=bakerydemo/wsgi_production.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=2 UWSGI_THREADS=8 UWSGI_UID=1000 UWSGI_GID=2000
+# Tell uWSGI where to find your wsgi file:
+ENV UWSGI_WSGI_FILE=bakerydemo/wsgi_production.py
+
+# Base uWSGI configuration (you shouldn't need to change these):
+ENV UWSGI_VIRTUALENV=/venv UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALIVE=1 UWSGI_UID=1000 UWSGI_GID=2000 UWSGI_LAZY_APPS=1 UWSGI_WSGI_ENV_BEHAVIOR=holy
+
+# Number of uWSGI workers and threads per worker (customize as needed):
+ENV UWSGI_WORKERS=2 UWSGI_THREADS=4
+
+# uWSGI uploaded media file serving configuration:
+ENV UWSGI_STATIC_MAP="/media/=/code/bakerydemo/media/"
 
 # Call collectstatic with dummy environment variables:
 RUN DATABASE_URL=postgres://none REDIS_URL=none /venv/bin/python manage.py collectstatic --noinput
@@ -46,6 +61,11 @@ RUN DATABASE_URL=postgres://none REDIS_URL=none /venv/bin/python manage.py colle
 # make sure static files are writable by uWSGI process
 RUN chown -R 1000:2000 /code/bakerydemo/media
 
+# mark the destination for images as a volume
+VOLUME ["/code/bakerydemo/media/images/"]
+
 # start uWSGI, using a wrapper script to allow us to easily add more commands to container startup:
 ENTRYPOINT ["/code/docker-entrypoint.sh"]
-CMD ["/venv/bin/uwsgi", "--http-auto-chunked", "--http-keepalive", "--static-map", "/media/=/code/bakerydemo/media/"]
+
+# Start uWSGI
+CMD ["/venv/bin/uwsgi", "--show-config"]


### PR DESCRIPTION
The Alpine base image is pain for a number of reasons (poor strftime support, weird libc issues that cause uwsgi to crash in some environments).

This switches to the standard Debian-based `python:3.7-slim` image. As it turns out, our docker image is actually _smaller_ after switching to Debian, too:

<img width="348" alt="Screen Shot 2019-09-11 at 10 03 17 PM" src="https://user-images.githubusercontent.com/160132/64748390-01d4d900-d4e0-11e9-8517-f0616621c12a.png">

Further explanation of this Dockerfile be found in my blog post about the topic (the original Dockerfile was based on an older version of this post): https://www.caktusgroup.com/blog/2017/03/14/production-ready-dockerfile-your-python-django-app/