### PR TITLE
Update Python runtime

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.8
+python-3.7.6


### PR DESCRIPTION
To prevent Heroku warnings. See https://devcenter.heroku.com/articles/python-support#supported-runtimes for currently supported runtimes.