### PR TITLE
height :auto, for displaying images without distortion.

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -161,6 +161,11 @@ img {
   display: block;
   width: 100%;
 }
+figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
 
 /* Generic detail page styles */
 .intro {


### PR DESCRIPTION
When resizing browser window, images get some distortion, when seen from mobile its doesnt look nice. Suggest to auto height,  for displaying images of stream field in blog page without distortions. 