### PR TITLE
Allow all hosts in dev mode to simplify cross-browser testing

### DIFF
--- a/bakerydemo/settings/dev.py
+++ b/bakerydemo/settings/dev.py
@@ -6,3 +6,5 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # BASE_URL required for notification emails
 BASE_URL = 'http://localhost:8000'
+
+ALLOWED_HOSTS = '*'


### PR DESCRIPTION
This is needed to test with the demo site on mobile devices / Browserstack. In the past I’ve added this in my `local.py`, but it’s annoying to have to re-add this when resetting my environment, and I assume it doesn’t hurt to have this directly in the project’s settings.