### PR TITLE
Add an example local.py for use with docker-wagtail-develop

### DIFF
--- a/bakerydemo/settings/local.py.docker-compose-example
+++ b/bakerydemo/settings/local.py.docker-compose-example
@@ -1,0 +1,6 @@
+from bakerydemo.settings.dev import *   # noqa
+import dj_database_url
+
+# Override settings here
+db_from_env = dj_database_url.config(conn_max_age=500)
+DATABASES['default'].update(db_from_env)


### PR DESCRIPTION
I want to make it easier to get docker-wagtail-develop working the first time. This example file will allow users to copy an example file that will connect bakerydemo to the postgres database created by docker-compose. This needs to be a new file because local.py needs to be different when installing bakerydemo from docker-wagtail-develop vs vagrant-wagtail-develop