### PR TITLE
fix requirements mismatch

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,7 +11,7 @@ boto3==1.9.189
 google-cloud-storage==1.20.0
 django-storages>=1.8,<1.9
 # For retrieving credentials and signing requests to Elasticsearch
-botocore==1.12.33
+botocore>=1.12.33,<1.13
 aws-requests-auth==0.4.0
 django-redis==4.11.0
 django_cache_url==2.0.0


### PR DESCRIPTION
When trying to follow the instructions for docker, there was an error while installing dependencies - boto3 required a higher version of botocore than we were installing. I made the smallest change I could manage (allowing more recent versions of botocore 1.12.x) and it fixed the problem.