### PR TITLE
Heroku python runtime not available issue 

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.7.9


### PR DESCRIPTION
Issue: https://github.com/wagtail/bakerydemo/issues/287
Change the python runtime from 3.7.6 to the Heroku supported 3.7.9 version