### PR TITLE
Upgrade to Django 3.2

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -80,6 +80,7 @@ MIDDLEWARE = [
 
 ]
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 ROOT_URLCONF = 'bakerydemo.urls'
 
 TEMPLATES = [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django>=3.1,<3.2
+Django>=3.2,<3.3
 django-dotenv==1.4.1
 wagtail>=2.13,<2.14
 wagtailfontawesome>=1.1.3,<1.2


### PR DESCRIPTION
Set DEFAULT_AUTO_FIELD to prevent deprecation warnings (Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField')