### PR TITLE
Add django-debug-toolbar

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -27,6 +27,10 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Uncomment this (and adjust as appropriate) to enable django-debug-toolbar
+# INTERNAL_IPS = [
+#     '127.0.0.1',
+# ]
 
 # Application definition
 
@@ -57,6 +61,7 @@ INSTALLED_APPS = [
     'modelcluster',
     'taggit',
     'wagtailfontawesome',
+    'debug_toolbar',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -68,6 +73,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
+import debug_toolbar
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.contrib.sitemaps.views import sitemap
@@ -20,6 +21,7 @@ urlpatterns = [
 
     path('sitemap.xml', sitemap),
     path('api/v2/', api_router.urls),
+    path('__debug__/', include(debug_toolbar.urls)),
 ]
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,4 @@ Django>=3.1,<3.2
 django-dotenv==1.4.1
 wagtail>=2.13,<2.14
 wagtailfontawesome>=1.1.3,<1.2
+django-debug-toolbar>=3.2,<4


### PR DESCRIPTION
Add django-debug-toolbar, disabled by default (because not everyone will want it and it's a performance hit). It frequently comes in useful during Wagtail core dev, but having to make local changes to bakerydemo means that we perhaps don't use it as much as we should...