### PR TITLE
Fix release phase

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "DJANGO_SECURE_SSL_REDIRECT": "on"
   },
   "scripts": {
-    "postdeploy": "django-admin.py migrate && django-admin.py load_initial_data && echo 'from wagtail.images.models import Rendition; Rendition.objects.all().delete()' | django-admin.py shell"
+    "postdeploy": "django-admin migrate && django-admin load_initial_data && echo 'from wagtail.images.models import Rendition; Rendition.objects.all().delete()' | django-admin shell"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"


### PR DESCRIPTION
[Django 4.0 removed `django-admin.py` entry point. ](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0)
This causes bakery demo heroku's postdeploy script to fail. 

This fixes that 