### PR TITLE
Update docker to current/supported tool versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 # Install packages needed to run your application (not build deps):
 # We need to recreate the /usr/share/man/man{1..8} directories first because
@@ -30,7 +30,7 @@ RUN set -ex \
         zlib1g-dev \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS \
-    && python3.7 -m venv /venv \
+    && python3.9 -m venv /venv \
     && /venv/bin/pip install -U pip \
     && /venv/bin/pip install --no-cache-dir -r /requirements/production.txt \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       POSTGRES_USER: app_user
       POSTGRES_PASSWORD: changeme
     restart: always
-    image: postgres:13.2
+    image: postgres:14.1
     expose:
       - "5432"
   redis:
     restart: always
-    image: redis:3.0
+    image: redis:6.2
     expose:
       - "6379"
   elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: app_user
       POSTGRES_PASSWORD: changeme
     restart: always
-    image: postgres:9.6
+    image: postgres:13.2
     expose:
       - "5432"
   redis:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,5 +11,5 @@ django-storages>=1.8,<1.9
 # For retrieving credentials and signing requests to Elasticsearch
 botocore>=1.12.33,<1.13
 aws-requests-auth==0.4.0
-django-redis==4.11.0
+django-redis==5.2.0
 django_cache_url==2.0.0


### PR DESCRIPTION
Closes https://github.com/wagtail/bakerydemo/issues/319

### Docker image updates:

- update postgres to 14.1
- update redis to 6.2

### Django 4.x requirements:

- update python to 3.9
- update django-redis to 5.2.0
