### PR TITLE
Fix and update Gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+ENV PIP_USER=yes

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.dockerfile
 ports:
 - port: 8080
   onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,12 +4,12 @@ ports:
 - port: 8080
   onOpen: open-preview
 tasks:
-- init: >
-    cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py &&
-    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env &&
-    python -m pip install -r requirements.txt &&
-    python manage.py makemigrations &&
-    python manage.py migrate &&
+- init: |
+    cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py
+    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env
+    python -m pip install -r requirements.txt
+    python manage.py makemigrations
+    python manage.py migrate
     python manage.py load_initial_data
   command: >
     python manage.py runserver 0.0.0.0:8080

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,8 @@ tasks:
     python manage.py makemigrations
     python manage.py migrate
     python manage.py load_initial_data
-  command: >
+    echo "CSRF_TRUSTED_ORIGINS = ['https://*.gitpod.io']" >> bakerydemo/settings/local.py
+  command: |
     python manage.py runserver 0.0.0.0:8080
 github:
     prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,3 +17,6 @@ tasks:
 github:
     prebuilds:
         pullRequestsFromForks: true
+vscode:
+  extensions:
+    - ms-python.python


### PR DESCRIPTION
The Gitpod button is currently broken. This PR fixes that and modernised the Gitpod syntax. See commit messages.

Login to the admin was broken too. See [trusted origins] fix.(https://github.com/wagtail/bakerydemo/pull/327/commits/87c7ad1bb5544e9c7aaac2ef65d2dac4365be65a)

Test https://gitpod.io#https://github.com/allcaps/bakerydemo