### PR TITLE
Format codebase with Black, isort, djhtml, Prettier, ESLint, and Stylelint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[Makefile]
+indent_style = tab
+
+[*.py]
+charset = utf-8
+indent_size = 4
+max_line_length = 120
+
+[*.js]
+charset = utf-8
+
+[*.{html,rst,md}]
+indent_size = 4
+
+[*.{js,ts,tsx,json,yml,yaml,css,scss}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+venv
+.venv

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    // allow no lines between single line members (e.g. static declarations)
+    "lines-between-class-members": [
+      "error",
+      "always",
+      {
+        "exceptAfterSingleLine": true
+      }
+    ],
+    // note you must disable the base rule as it can report incorrect errors
+    "no-use-before-define": "off",
+    "no-underscore-dangle": "error"
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Bakerydemo CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/development.txt
+      - name: Lint server
+        run: |
+          make lint-server
+  lint-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint client
+        run: |
+          make lint-client

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 common/CACHE
 bakerydemo/settings/local.py
 bakerydemodb
+node_modules
+venv
+.venv
 __pycache__
 .vagrant/
 /.vagrant/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,22 +1,22 @@
 image:
   file: .gitpod.dockerfile
 ports:
-- port: 8080
-  onOpen: open-preview
+  - port: 8080
+    onOpen: open-preview
 tasks:
-- init: |
-    cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py
-    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env
-    python -m pip install -r requirements.txt
-    python manage.py makemigrations
-    python manage.py migrate
-    python manage.py load_initial_data
-    echo "CSRF_TRUSTED_ORIGINS = ['https://*.gitpod.io']" >> bakerydemo/settings/local.py
-  command: |
-    python manage.py runserver 0.0.0.0:8080
+  - init: |
+      cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py
+      echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env
+      python -m pip install -r requirements.txt
+      python manage.py makemigrations
+      python manage.py migrate
+      python manage.py load_initial_data
+      echo "CSRF_TRUSTED_ORIGINS = ['https://*.gitpod.io']" >> bakerydemo/settings/local.py
+    command: |
+      python manage.py runserver 0.0.0.0:8080
 github:
-    prebuilds:
-        pullRequestsFromForks: true
+  prebuilds:
+    pullRequestsFromForks: true
 vscode:
   extensions:
     - ms-python.python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_language_version:
+  node: system
+  python: python3
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--target-version", "py37"]
+  - repo: https://github.com/timothycrosley/isort
+    # isort config is in setup.cfg
+    rev: 5.6.4
+    hooks:
+      - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
+    # flake8 config is in setup.cfg
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-comprehensions
+          - flake8-assertive
+  - repo: https://github.com/rtts/djhtml
+    rev: v1.4.13
+    hooks:
+      - id: djhtml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: ["--target-version", "py37"]
+        args: ['--target-version', 'py37']
   - repo: https://github.com/timothycrosley/isort
     # isort config is in setup.cfg
     rev: 5.6.4
@@ -25,3 +25,26 @@ repos:
     rev: v1.4.13
     hooks:
       - id: djhtml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.5.1
+    hooks:
+      - id: prettier
+        types_or: [css, javascript, json, yaml]
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.8.0
+    hooks:
+      - id: eslint
+        types: [file]
+        files: \.(js)$
+        args: [--report-unused-disable-directives]
+        additional_dependencies:
+          - eslint@8.8.0
+  - repo: https://github.com/thibaudcolas/pre-commit-stylelint
+    rev: v14.2.0
+    hooks:
+      - id: stylelint
+        files: \.css$
+        additional_dependencies:
+          - stylelint@14.9.1
+          - stylelint-config-standard@26.0.0
+          - stylelint-config-prettier@9.0.3

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Irrelevant files ignored for performance reasons.
+node_modules
+venv
+.venv
+*.min.css
+# File types which Prettier supports but we don’t want auto-formatting.
+*.md
+# Files which contain incompatible syntax.
+*.html

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "consistent",
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,4 @@
+node_modules
+venv
+.venv
+*.min.css

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,11 @@
+{
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"],
+  "rules": {
+    "no-descending-specificity": null,
+    "custom-property-pattern": "^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$",
+    "selector-class-pattern": [
+      "^[a-z]+[0-9]{0,2}(-[a-z0-9]+)*(__[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z0-9]+(-[a-z0-9]+)*)?$",
+      { "resolveNestedSelectors": true }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: lint format
+
+help:
+	@echo "lint - check style with black, flake8, sort python with isort, and indent html"
+	@echo "format - enforce a consistent code style across the codebase and sort python files with isort"
+
+lint:
+	black --target-version py37 --check --diff .
+	flake8
+	isort --check-only --diff .
+	curlylint --parse-only bakerydemo
+	git ls-files '*.html' | xargs djhtml --check
+
+format:
+	black --target-version py37 .
+	isort .
+	git ls-files '*.html' | xargs djhtml -i

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,27 @@ help:
 	@echo "lint - check style with black, flake8, sort python with isort, and indent html"
 	@echo "format - enforce a consistent code style across the codebase and sort python files with isort"
 
-lint:
+lint-server:
 	black --target-version py37 --check --diff .
 	flake8
 	isort --check-only --diff .
 	curlylint --parse-only bakerydemo
 	git ls-files '*.html' | xargs djhtml --check
 
-format:
+lint-client:
+	npm run lint:css --silent
+	npm run lint:js --silent
+	npm run lint:format --silent
+
+lint: lint-server lint-client
+
+format-server:
 	black --target-version py37 .
 	isort .
 	git ls-files '*.html' | xargs djhtml -i
+
+format-client:
+	npm run format
+	npm run fix:js
+
+format: format-server format-client

--- a/app.json
+++ b/app.json
@@ -11,7 +11,5 @@
   "scripts": {
     "postdeploy": "django-admin migrate && django-admin load_initial_data && echo 'from wagtail.images.models import Rendition; Rendition.objects.all().delete()' | django-admin shell"
   },
-  "addons": [
-    "heroku-postgresql:hobby-dev"
-  ]
+  "addons": ["heroku-postgresql:hobby-dev"]
 }

--- a/bakerydemo/api.py
+++ b/bakerydemo/api.py
@@ -4,12 +4,12 @@ from wagtail.images.api.v2.views import ImagesAPIViewSet
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
 
 # Create the router. "wagtailapi" is the URL namespace
-api_router = WagtailAPIRouter('wagtailapi')
+api_router = WagtailAPIRouter("wagtailapi")
 
 # Add the three endpoints using the "register_endpoint" method.
 # The first parameter is the name of the endpoint (eg. pages, images). This
 # is used in the URL of the endpoint
 # The second parameter is the endpoint class that handles the requests
-api_router.register_endpoint('pages', PagesAPIViewSet)
-api_router.register_endpoint('images', ImagesAPIViewSet)
-api_router.register_endpoint('documents', DocumentsAPIViewSet)
+api_router.register_endpoint("pages", PagesAPIViewSet)
+api_router.register_endpoint("images", ImagesAPIViewSet)
+api_router.register_endpoint("documents", DocumentsAPIViewSet)

--- a/bakerydemo/api.py
+++ b/bakerydemo/api.py
@@ -1,7 +1,7 @@
-from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.api.v2.router import WagtailAPIRouter
-from wagtail.images.api.v2.views import ImagesAPIViewSet
+from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
+from wagtail.images.api.v2.views import ImagesAPIViewSet
 
 # Create the router. "wagtailapi" is the URL namespace
 api_router = WagtailAPIRouter("wagtailapi")

--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -1,7 +1,12 @@
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.blocks import (
-    CharBlock, ChoiceBlock, RichTextBlock, StreamBlock, StructBlock, TextBlock,
+    CharBlock,
+    ChoiceBlock,
+    RichTextBlock,
+    StreamBlock,
+    StructBlock,
+    TextBlock,
 )
 
 
@@ -10,12 +15,13 @@ class ImageBlock(StructBlock):
     Custom `StructBlock` for utilizing images with associated caption and
     attribution data
     """
+
     image = ImageChooserBlock(required=True)
     caption = CharBlock(required=False)
     attribution = CharBlock(required=False)
 
     class Meta:
-        icon = 'image'
+        icon = "image"
         template = "blocks/image_block.html"
 
 
@@ -23,13 +29,18 @@ class HeadingBlock(StructBlock):
     """
     Custom `StructBlock` that allows the user to select h2 - h4 sizes for headers
     """
+
     heading_text = CharBlock(classname="title", required=True)
-    size = ChoiceBlock(choices=[
-        ('', 'Select a header size'),
-        ('h2', 'H2'),
-        ('h3', 'H3'),
-        ('h4', 'H4')
-    ], blank=True, required=False)
+    size = ChoiceBlock(
+        choices=[
+            ("", "Select a header size"),
+            ("h2", "H2"),
+            ("h3", "H3"),
+            ("h4", "H4"),
+        ],
+        blank=True,
+        required=False,
+    )
 
     class Meta:
         icon = "title"
@@ -40,9 +51,9 @@ class BlockQuote(StructBlock):
     """
     Custom `StructBlock` that allows the user to attribute a quote to the author
     """
+
     text = TextBlock()
-    attribute_name = CharBlock(
-        blank=True, required=False, label='e.g. Mary Berry')
+    attribute_name = CharBlock(blank=True, required=False, label="e.g. Mary Berry")
 
     class Meta:
         icon = "fa-quote-left"
@@ -54,14 +65,15 @@ class BaseStreamBlock(StreamBlock):
     """
     Define the custom blocks that `StreamField` will utilize
     """
+
     heading_block = HeadingBlock()
     paragraph_block = RichTextBlock(
-        icon="fa-paragraph",
-        template="blocks/paragraph_block.html"
+        icon="fa-paragraph", template="blocks/paragraph_block.html"
     )
     image_block = ImageBlock()
     block_quote = BlockQuote()
     embed_block = EmbedBlock(
-        help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks',
+        help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
         icon="fa-s15",
-        template="blocks/embed_block.html")
+        template="blocks/embed_block.html",
+    )

--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -1,5 +1,3 @@
-from wagtail.images.blocks import ImageChooserBlock
-from wagtail.embeds.blocks import EmbedBlock
 from wagtail.blocks import (
     CharBlock,
     ChoiceBlock,
@@ -8,6 +6,8 @@ from wagtail.blocks import (
     StructBlock,
     TextBlock,
 )
+from wagtail.embeds.blocks import EmbedBlock
+from wagtail.images.blocks import ImageChooserBlock
 
 
 class ImageBlock(StructBlock):

--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -1,3510 +1,3265 @@
 [
-{
-  "model": "base.people",
-  "pk": 1,
-  "fields": {
-    "first_name": "Roberta",
-    "last_name": "Johnson",
-    "job_title": "Editorial Manager",
-    "image": 8
-  }
-},
-{
-  "model": "base.people",
-  "pk": 2,
-  "fields": {
-    "first_name": "Olivia",
-    "last_name": "Ava",
-    "job_title": "Director",
-    "image": 52
-  }
-},
-{
-  "model": "base.people",
-  "pk": 3,
-  "fields": {
-    "first_name": "Lightnin'",
-    "last_name": "Hopkins",
-    "job_title": "Designer",
-    "image": 53
-  }
-},
-{
-  "model": "base.people",
-  "pk": 4,
-  "fields": {
-    "first_name": "Muddy",
-    "last_name": "Waters",
-    "job_title": "Assistant Editor",
-    "image": 51
-  }
-},
-{
-  "model": "base.footertext",
-  "pk": 1,
-  "fields": {
-    "body": "<p>Copyright <b>The Wagtail Bakery</b>, 2019. All rights reserved.<br/><i>\"If you read a lot you're well read / If you eat a lot you're well bread.\"</i></p>"
-  }
-},
-{
-  "model": "base.formfield",
-  "pk": 1,
-  "fields": {
-    "sort_order": 0,
-    "label": "Subject",
-    "clean_name": "subject",
-    "field_type": "singleline",
-    "required": true,
-    "choices": "",
-    "default_value": "",
-    "help_text": "",
-    "page": 69
-  }
-},
-{
-  "model": "base.formfield",
-  "pk": 2,
-  "fields": {
-    "sort_order": 1,
-    "label": "Your Name",
-    "clean_name": "your_name",
-    "field_type": "singleline",
-    "required": true,
-    "choices": "",
-    "default_value": "",
-    "help_text": "",
-    "page": 69
-  }
-},
-{
-  "model": "base.formfield",
-  "pk": 3,
-  "fields": {
-    "sort_order": 2,
-    "label": "Your Email",
-    "clean_name": "your_email",
-    "field_type": "email",
-    "required": true,
-    "choices": "",
-    "default_value": "you@example.com",
-    "help_text": "",
-    "page": 69
-  }
-},
-{
-  "model": "base.formfield",
-  "pk": 4,
-  "fields": {
-    "sort_order": 3,
-    "label": "Purpose",
-    "clean_name": "purpose",
-    "field_type": "dropdown",
-    "required": true,
-    "choices": "Comment, Question, Feedback",
-    "default_value": "",
-    "help_text": "",
-    "page": 69
-  }
-},
-{
-  "model": "base.formfield",
-  "pk": 5,
-  "fields": {
-    "sort_order": 4,
-    "label": "Body",
-    "clean_name": "body",
-    "field_type": "multiline",
-    "required": true,
-    "choices": "",
-    "default_value": "",
-    "help_text": "What's on your mind?",
-    "page": 69
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 2,
-  "fields": {
-    "sort_order": 0,
-    "page": 62,
-    "people": 1
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 3,
-  "fields": {
-    "sort_order": 0,
-    "page": 68,
-    "people": 2
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 4,
-  "fields": {
-    "sort_order": 0,
-    "page": 72,
-    "people": 3
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 5,
-  "fields": {
-    "sort_order": 0,
-    "page": 73,
-    "people": 3
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 6,
-  "fields": {
-    "sort_order": 0,
-    "page": 74,
-    "people": 1
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 7,
-  "fields": {
-    "sort_order": 1,
-    "page": 74,
-    "people": 3
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 8,
-  "fields": {
-    "sort_order": 1,
-    "page": 73,
-    "people": 1
-  }
-},
-{
-  "model": "blog.blogpeoplerelationship",
-  "pk": 9,
-  "fields": {
-    "sort_order": 0,
-    "page": 77,
-    "people": 2
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 52,
-  "fields": {
-    "tag": 3,
-    "content_object": 62
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 53,
-  "fields": {
-    "tag": 4,
-    "content_object": 62
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 76,
-  "fields": {
-    "tag": 10,
-    "content_object": 74
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 77,
-  "fields": {
-    "tag": 7,
-    "content_object": 74
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 87,
-  "fields": {
-    "tag": 3,
-    "content_object": 68
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 88,
-  "fields": {
-    "tag": 13,
-    "content_object": 68
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 89,
-  "fields": {
-    "tag": 8,
-    "content_object": 72
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 90,
-  "fields": {
-    "tag": 4,
-    "content_object": 72
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 94,
-  "fields": {
-    "tag": 8,
-    "content_object": 73
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 95,
-  "fields": {
-    "tag": 9,
-    "content_object": 73
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 96,
-  "fields": {
-    "tag": 3,
-    "content_object": 73
-  }
-},
-{
-  "model": "blog.blogpagetag",
-  "pk": 97,
-  "fields": {
-    "tag": 11,
-    "content_object": 77
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 1,
-  "fields": {
-    "title": "Egypt"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 2,
-  "fields": {
-    "title": "Slovenia"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 3,
-  "fields": {
-    "title": "United States (New England)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 4,
-  "fields": {
-    "title": "Japan"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 5,
-  "fields": {
-    "title": "India (Kerala)\nSri Lanka"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 6,
-  "fields": {
-    "title": "South America (Northern)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 7,
-  "fields": {
-    "title": "China (Northwestern Yunnan, Naxi people)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 8,
-  "fields": {
-    "title": "Polish/Ashkenazi Jewish"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 9,
-  "fields": {
-    "title": "France"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 10,
-  "fields": {
-    "title": "Tibet (Central)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 11,
-  "fields": {
-    "title": "Jamaica"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 12,
-  "fields": {
-    "title": "Scandinavia"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 13,
-  "fields": {
-    "title": "United Kingdom (Scotland)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 14,
-  "fields": {
-    "title": "United Kingdom (Wales)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 15,
-  "fields": {
-    "title": "Iran\nAfghanistan (northwestern)"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 16,
-  "fields": {
-    "title": "Ireland"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 17,
-  "fields": {
-    "title": "Italy"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 18,
-  "fields": {
-    "title": "Libya"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 19,
-  "fields": {
-    "title": "Turkey"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 20,
-  "fields": {
-    "title": "North America"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 21,
-  "fields": {
-    "title": "India\nPakistan"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 22,
-  "fields": {
-    "title": "Poland"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 23,
-  "fields": {
-    "title": "China"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 24,
-  "fields": {
-    "title": "Afghanistan"
-  }
-},
-{
-  "model": "breads.country",
-  "pk": 25,
-  "fields": {
-    "title": "Portugal (Madeira)"
-  }
-},
-{
-  "model": "breads.breadingredient",
-  "pk": 1,
-  "fields": {
-    "name": "Yeast"
-  }
-},
-{
-  "model": "breads.breadingredient",
-  "pk": 2,
-  "fields": {
-    "name": "Flour"
-  }
-},
-{
-  "model": "breads.breadingredient",
-  "pk": 3,
-  "fields": {
-    "name": "Water"
-  }
-},
-{
-  "model": "breads.breadingredient",
-  "pk": 4,
-  "fields": {
-    "name": "Cinnamon"
-  }
-},
-{
-  "model": "breads.breadingredient",
-  "pk": 5,
-  "fields": {
-    "name": "Salt"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 1,
-  "fields": {
-    "title": "asdf"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 2,
-  "fields": {
-    "title": "Flatbread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 3,
-  "fields": {
-    "title": "Buckwheat bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 4,
-  "fields": {
-    "title": "Yeast bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 5,
-  "fields": {
-    "title": "Sweet bun"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 6,
-  "fields": {
-    "title": "Varies widely"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 7,
-  "fields": {
-    "title": "Cornbread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 8,
-  "fields": {
-    "title": "Various thick, round breads"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 9,
-  "fields": {
-    "title": "Sweet bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 10,
-  "fields": {
-    "title": "Fruit bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 11,
-  "fields": {
-    "title": "Unleavened bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 12,
-  "fields": {
-    "title": "Quick or yeast bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 13,
-  "fields": {
-    "title": "Waffle"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 14,
-  "fields": {
-    "title": "Unleavened Flatbread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 15,
-  "fields": {
-    "title": "Yeast bread or unleavened"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 16,
-  "fields": {
-    "title": "Rye bread"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 17,
-  "fields": {
-    "title": "Bun"
-  }
-},
-{
-  "model": "breads.breadtype",
-  "pk": 18,
-  "fields": {
-    "title": "Pancake"
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 1,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "08:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 2,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": "08:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 3,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "08:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 4,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "08:00:00",
-    "closing_time": "17:00:00",
-    "closed": false,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 5,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 6,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": "09:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 7,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "06:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 8,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "09:00:00",
-    "closing_time": "22:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 9,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "06:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 10,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": "05:00:00",
-    "closing_time": "21:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 11,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "08:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 12,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "07:00:00",
-    "closing_time": "19:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 13,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "08:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 14,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 15,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 16,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 17,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 18,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": "07:00:00",
-    "closing_time": "13:00:00",
-    "closed": false,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 19,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 67
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 20,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 21,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": "09:00:00",
-    "closing_time": "13:00:00",
-    "closed": false,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 22,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 65
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 23,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": "08:00:00",
-    "closing_time": "17:00:00",
-    "closed": false,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 24,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 25,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 64
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 26,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 27,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": "07:00:00",
-    "closing_time": "19:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 28,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": "09:00:00",
-    "closing_time": "12:00:00",
-    "closed": false,
-    "location": 66
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 29,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 30,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": "09:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 31,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "06:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 32,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "09:00:00",
-    "closing_time": "22:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 33,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 34,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": "09:00:00",
-    "closing_time": "13:00:00",
-    "closed": false,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 35,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 78
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 36,
-  "fields": {
-    "sort_order": 0,
-    "day": "MON",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 37,
-  "fields": {
-    "sort_order": 1,
-    "day": "TUES",
-    "opening_time": "09:00:00",
-    "closing_time": "20:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 38,
-  "fields": {
-    "sort_order": 2,
-    "day": "WED",
-    "opening_time": "06:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 39,
-  "fields": {
-    "sort_order": 3,
-    "day": "THUR",
-    "opening_time": "09:00:00",
-    "closing_time": "22:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 40,
-  "fields": {
-    "sort_order": 4,
-    "day": "FRI",
-    "opening_time": "09:00:00",
-    "closing_time": "18:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 41,
-  "fields": {
-    "sort_order": 5,
-    "day": "SAT",
-    "opening_time": "09:00:00",
-    "closing_time": "13:00:00",
-    "closed": false,
-    "location": 79
-  }
-},
-{
-  "model": "locations.locationoperatinghours",
-  "pk": 42,
-  "fields": {
-    "sort_order": 6,
-    "day": "SUN",
-    "opening_time": null,
-    "closing_time": null,
-    "closed": true,
-    "location": 79
-  }
-},
-{
-  "model": "wagtailforms.formsubmission",
-  "pk": 1,
-  "fields": {
-    "form_data": {"purpose": "Feedback", "subject": "What's up?", "body": "Love what you guys are doing with the site so far.", "your_name": "Scot Hacker", "your_email": "shacker@birdhouse.org"},
-    "page": 69,
-    "submit_time": "2019-02-15T16:56:48.939Z"
-  }
-},
-{
-  "model": "wagtailsearch.query",
-  "pk": 1,
-  "fields": {
-    "query_string": "chocolate"
-  }
-},
-{
-  "model": "wagtailsearch.query",
-  "pk": 2,
-  "fields": {
-    "query_string": "london"
-  }
-},
-{
-  "model": "wagtailsearch.query",
-  "pk": 3,
-  "fields": {
-    "query_string": "circus"
-  }
-},
-{
-  "model": "wagtailsearch.querydailyhits",
-  "pk": 1,
-  "fields": {
-    "query": 1,
-    "date": "2019-02-11",
-    "hits": 2
-  }
-},
-{
-  "model": "wagtailsearch.querydailyhits",
-  "pk": 2,
-  "fields": {
-    "query": 2,
-    "date": "2019-02-15",
-    "hits": 1
-  }
-},
-{
-  "model": "wagtailsearch.querydailyhits",
-  "pk": 3,
-  "fields": {
-    "query": 3,
-    "date": "2019-02-24",
-    "hits": 1
-  }
-},
-{
-  "model": "wagtailcore.site",
-  "pk": 2,
-  "fields": {
-    "hostname": "127.0.0.1",
-    "port": 8000,
-    "site_name": "Wagtail Bakery",
-    "root_page": 60,
-    "is_default_site": true
-  }
-},
-{
-  "model": "wagtailcore.collection",
-  "pk": 1,
-  "fields": {
-    "path": "0001",
-    "depth": 1,
-    "numchild": 3,
-    "name": "Root"
-  }
-},
-{
-  "model": "wagtailcore.collection",
-  "pk": 2,
-  "fields": {
-    "path": "00010001",
-    "depth": 2,
-    "numchild": 0,
-    "name": "Bakeries"
-  }
-},
-{
-  "model": "wagtailcore.collection",
-  "pk": 3,
-  "fields": {
-    "path": "00010003",
-    "depth": 2,
-    "numchild": 0,
-    "name": "Other"
-  }
-},
-{
-  "model": "wagtailcore.collection",
-  "pk": 4,
-  "fields": {
-    "path": "00010002",
-    "depth": 2,
-    "numchild": 0,
-    "name": "BreadPage Images"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 1,
-  "fields": {
-    "name": "pineapple",
-    "slug": "pineapple"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 2,
-  "fields": {
-    "name": "bike",
-    "slug": "bike"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 3,
-  "fields": {
-    "name": "yeast",
-    "slug": "yeast"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 4,
-  "fields": {
-    "name": "fermentation",
-    "slug": "fermentation"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 5,
-  "fields": {
-    "name": "economics",
-    "slug": "economics"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 6,
-  "fields": {
-    "name": "europe",
-    "slug": "europe"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 7,
-  "fields": {
-    "name": "baking",
-    "slug": "baking"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 8,
-  "fields": {
-    "name": "grain",
-    "slug": "grain"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 9,
-  "fields": {
-    "name": "soda",
-    "slug": "soda"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 10,
-  "fields": {
-    "name": "sandwich",
-    "slug": "sandwich"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 11,
-  "fields": {
-    "name": "dessert",
-    "slug": "dessert"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 12,
-  "fields": {
-    "name": "pie",
-    "slug": "pie"
-  }
-},
-{
-  "model": "taggit.tag",
-  "pk": 13,
-  "fields": {
-    "name": "fire",
-    "slug": "fire"
-  }
-},
-{
-  "model": "auth.group",
-  "pk": 1,
-  "fields": {
-    "name": "Moderators",
-    "permissions": [
-      [
-        "access_admin",
-        "wagtailadmin",
-        "admin"
-      ],
-      [
-        "add_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "change_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "delete_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "add_image",
-        "wagtailimages",
-        "image"
-      ],
-      [
-        "change_image",
-        "wagtailimages",
-        "image"
-      ],
-      [
-        "delete_image",
-        "wagtailimages",
-        "image"
+  {
+    "model": "base.people",
+    "pk": 1,
+    "fields": {
+      "first_name": "Roberta",
+      "last_name": "Johnson",
+      "job_title": "Editorial Manager",
+      "image": 8
+    }
+  },
+  {
+    "model": "base.people",
+    "pk": 2,
+    "fields": {
+      "first_name": "Olivia",
+      "last_name": "Ava",
+      "job_title": "Director",
+      "image": 52
+    }
+  },
+  {
+    "model": "base.people",
+    "pk": 3,
+    "fields": {
+      "first_name": "Lightnin'",
+      "last_name": "Hopkins",
+      "job_title": "Designer",
+      "image": 53
+    }
+  },
+  {
+    "model": "base.people",
+    "pk": 4,
+    "fields": {
+      "first_name": "Muddy",
+      "last_name": "Waters",
+      "job_title": "Assistant Editor",
+      "image": 51
+    }
+  },
+  {
+    "model": "base.footertext",
+    "pk": 1,
+    "fields": {
+      "body": "<p>Copyright <b>The Wagtail Bakery</b>, 2019. All rights reserved.<br/><i>\"If you read a lot you're well read / If you eat a lot you're well bread.\"</i></p>"
+    }
+  },
+  {
+    "model": "base.formfield",
+    "pk": 1,
+    "fields": {
+      "sort_order": 0,
+      "label": "Subject",
+      "clean_name": "subject",
+      "field_type": "singleline",
+      "required": true,
+      "choices": "",
+      "default_value": "",
+      "help_text": "",
+      "page": 69
+    }
+  },
+  {
+    "model": "base.formfield",
+    "pk": 2,
+    "fields": {
+      "sort_order": 1,
+      "label": "Your Name",
+      "clean_name": "your_name",
+      "field_type": "singleline",
+      "required": true,
+      "choices": "",
+      "default_value": "",
+      "help_text": "",
+      "page": 69
+    }
+  },
+  {
+    "model": "base.formfield",
+    "pk": 3,
+    "fields": {
+      "sort_order": 2,
+      "label": "Your Email",
+      "clean_name": "your_email",
+      "field_type": "email",
+      "required": true,
+      "choices": "",
+      "default_value": "you@example.com",
+      "help_text": "",
+      "page": 69
+    }
+  },
+  {
+    "model": "base.formfield",
+    "pk": 4,
+    "fields": {
+      "sort_order": 3,
+      "label": "Purpose",
+      "clean_name": "purpose",
+      "field_type": "dropdown",
+      "required": true,
+      "choices": "Comment, Question, Feedback",
+      "default_value": "",
+      "help_text": "",
+      "page": 69
+    }
+  },
+  {
+    "model": "base.formfield",
+    "pk": 5,
+    "fields": {
+      "sort_order": 4,
+      "label": "Body",
+      "clean_name": "body",
+      "field_type": "multiline",
+      "required": true,
+      "choices": "",
+      "default_value": "",
+      "help_text": "What's on your mind?",
+      "page": 69
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 2,
+    "fields": {
+      "sort_order": 0,
+      "page": 62,
+      "people": 1
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 3,
+    "fields": {
+      "sort_order": 0,
+      "page": 68,
+      "people": 2
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 4,
+    "fields": {
+      "sort_order": 0,
+      "page": 72,
+      "people": 3
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 5,
+    "fields": {
+      "sort_order": 0,
+      "page": 73,
+      "people": 3
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 6,
+    "fields": {
+      "sort_order": 0,
+      "page": 74,
+      "people": 1
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 7,
+    "fields": {
+      "sort_order": 1,
+      "page": 74,
+      "people": 3
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 8,
+    "fields": {
+      "sort_order": 1,
+      "page": 73,
+      "people": 1
+    }
+  },
+  {
+    "model": "blog.blogpeoplerelationship",
+    "pk": 9,
+    "fields": {
+      "sort_order": 0,
+      "page": 77,
+      "people": 2
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 52,
+    "fields": {
+      "tag": 3,
+      "content_object": 62
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 53,
+    "fields": {
+      "tag": 4,
+      "content_object": 62
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 76,
+    "fields": {
+      "tag": 10,
+      "content_object": 74
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 77,
+    "fields": {
+      "tag": 7,
+      "content_object": 74
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 87,
+    "fields": {
+      "tag": 3,
+      "content_object": 68
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 88,
+    "fields": {
+      "tag": 13,
+      "content_object": 68
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 89,
+    "fields": {
+      "tag": 8,
+      "content_object": 72
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 90,
+    "fields": {
+      "tag": 4,
+      "content_object": 72
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 94,
+    "fields": {
+      "tag": 8,
+      "content_object": 73
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 95,
+    "fields": {
+      "tag": 9,
+      "content_object": 73
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 96,
+    "fields": {
+      "tag": 3,
+      "content_object": 73
+    }
+  },
+  {
+    "model": "blog.blogpagetag",
+    "pk": 97,
+    "fields": {
+      "tag": 11,
+      "content_object": 77
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 1,
+    "fields": {
+      "title": "Egypt"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 2,
+    "fields": {
+      "title": "Slovenia"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 3,
+    "fields": {
+      "title": "United States (New England)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 4,
+    "fields": {
+      "title": "Japan"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 5,
+    "fields": {
+      "title": "India (Kerala)\nSri Lanka"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 6,
+    "fields": {
+      "title": "South America (Northern)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 7,
+    "fields": {
+      "title": "China (Northwestern Yunnan, Naxi people)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 8,
+    "fields": {
+      "title": "Polish/Ashkenazi Jewish"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 9,
+    "fields": {
+      "title": "France"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 10,
+    "fields": {
+      "title": "Tibet (Central)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 11,
+    "fields": {
+      "title": "Jamaica"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 12,
+    "fields": {
+      "title": "Scandinavia"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 13,
+    "fields": {
+      "title": "United Kingdom (Scotland)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 14,
+    "fields": {
+      "title": "United Kingdom (Wales)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 15,
+    "fields": {
+      "title": "Iran\nAfghanistan (northwestern)"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 16,
+    "fields": {
+      "title": "Ireland"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 17,
+    "fields": {
+      "title": "Italy"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 18,
+    "fields": {
+      "title": "Libya"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 19,
+    "fields": {
+      "title": "Turkey"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 20,
+    "fields": {
+      "title": "North America"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 21,
+    "fields": {
+      "title": "India\nPakistan"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 22,
+    "fields": {
+      "title": "Poland"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 23,
+    "fields": {
+      "title": "China"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 24,
+    "fields": {
+      "title": "Afghanistan"
+    }
+  },
+  {
+    "model": "breads.country",
+    "pk": 25,
+    "fields": {
+      "title": "Portugal (Madeira)"
+    }
+  },
+  {
+    "model": "breads.breadingredient",
+    "pk": 1,
+    "fields": {
+      "name": "Yeast"
+    }
+  },
+  {
+    "model": "breads.breadingredient",
+    "pk": 2,
+    "fields": {
+      "name": "Flour"
+    }
+  },
+  {
+    "model": "breads.breadingredient",
+    "pk": 3,
+    "fields": {
+      "name": "Water"
+    }
+  },
+  {
+    "model": "breads.breadingredient",
+    "pk": 4,
+    "fields": {
+      "name": "Cinnamon"
+    }
+  },
+  {
+    "model": "breads.breadingredient",
+    "pk": 5,
+    "fields": {
+      "name": "Salt"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 1,
+    "fields": {
+      "title": "asdf"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 2,
+    "fields": {
+      "title": "Flatbread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 3,
+    "fields": {
+      "title": "Buckwheat bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 4,
+    "fields": {
+      "title": "Yeast bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 5,
+    "fields": {
+      "title": "Sweet bun"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 6,
+    "fields": {
+      "title": "Varies widely"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 7,
+    "fields": {
+      "title": "Cornbread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 8,
+    "fields": {
+      "title": "Various thick, round breads"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 9,
+    "fields": {
+      "title": "Sweet bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 10,
+    "fields": {
+      "title": "Fruit bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 11,
+    "fields": {
+      "title": "Unleavened bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 12,
+    "fields": {
+      "title": "Quick or yeast bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 13,
+    "fields": {
+      "title": "Waffle"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 14,
+    "fields": {
+      "title": "Unleavened Flatbread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 15,
+    "fields": {
+      "title": "Yeast bread or unleavened"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 16,
+    "fields": {
+      "title": "Rye bread"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 17,
+    "fields": {
+      "title": "Bun"
+    }
+  },
+  {
+    "model": "breads.breadtype",
+    "pk": 18,
+    "fields": {
+      "title": "Pancake"
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 1,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "08:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 2,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": "08:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 3,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "08:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 4,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "08:00:00",
+      "closing_time": "17:00:00",
+      "closed": false,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 5,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 6,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": "09:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 7,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "06:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 8,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "09:00:00",
+      "closing_time": "22:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 9,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "06:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 10,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": "05:00:00",
+      "closing_time": "21:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 11,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "08:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 12,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "07:00:00",
+      "closing_time": "19:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 13,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "08:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 14,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 15,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 16,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 17,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 18,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": "07:00:00",
+      "closing_time": "13:00:00",
+      "closed": false,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 19,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 67
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 20,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 21,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": "09:00:00",
+      "closing_time": "13:00:00",
+      "closed": false,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 22,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 65
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 23,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": "08:00:00",
+      "closing_time": "17:00:00",
+      "closed": false,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 24,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 25,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 64
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 26,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 27,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": "07:00:00",
+      "closing_time": "19:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 28,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": "09:00:00",
+      "closing_time": "12:00:00",
+      "closed": false,
+      "location": 66
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 29,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 30,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": "09:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 31,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "06:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 32,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "09:00:00",
+      "closing_time": "22:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 33,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 34,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": "09:00:00",
+      "closing_time": "13:00:00",
+      "closed": false,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 35,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 78
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 36,
+    "fields": {
+      "sort_order": 0,
+      "day": "MON",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 37,
+    "fields": {
+      "sort_order": 1,
+      "day": "TUES",
+      "opening_time": "09:00:00",
+      "closing_time": "20:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 38,
+    "fields": {
+      "sort_order": 2,
+      "day": "WED",
+      "opening_time": "06:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 39,
+    "fields": {
+      "sort_order": 3,
+      "day": "THUR",
+      "opening_time": "09:00:00",
+      "closing_time": "22:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 40,
+    "fields": {
+      "sort_order": 4,
+      "day": "FRI",
+      "opening_time": "09:00:00",
+      "closing_time": "18:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 41,
+    "fields": {
+      "sort_order": 5,
+      "day": "SAT",
+      "opening_time": "09:00:00",
+      "closing_time": "13:00:00",
+      "closed": false,
+      "location": 79
+    }
+  },
+  {
+    "model": "locations.locationoperatinghours",
+    "pk": 42,
+    "fields": {
+      "sort_order": 6,
+      "day": "SUN",
+      "opening_time": null,
+      "closing_time": null,
+      "closed": true,
+      "location": 79
+    }
+  },
+  {
+    "model": "wagtailforms.formsubmission",
+    "pk": 1,
+    "fields": {
+      "form_data": {
+        "purpose": "Feedback",
+        "subject": "What's up?",
+        "body": "Love what you guys are doing with the site so far.",
+        "your_name": "Scot Hacker",
+        "your_email": "shacker@birdhouse.org"
+      },
+      "page": 69,
+      "submit_time": "2019-02-15T16:56:48.939Z"
+    }
+  },
+  {
+    "model": "wagtailsearch.query",
+    "pk": 1,
+    "fields": {
+      "query_string": "chocolate"
+    }
+  },
+  {
+    "model": "wagtailsearch.query",
+    "pk": 2,
+    "fields": {
+      "query_string": "london"
+    }
+  },
+  {
+    "model": "wagtailsearch.query",
+    "pk": 3,
+    "fields": {
+      "query_string": "circus"
+    }
+  },
+  {
+    "model": "wagtailsearch.querydailyhits",
+    "pk": 1,
+    "fields": {
+      "query": 1,
+      "date": "2019-02-11",
+      "hits": 2
+    }
+  },
+  {
+    "model": "wagtailsearch.querydailyhits",
+    "pk": 2,
+    "fields": {
+      "query": 2,
+      "date": "2019-02-15",
+      "hits": 1
+    }
+  },
+  {
+    "model": "wagtailsearch.querydailyhits",
+    "pk": 3,
+    "fields": {
+      "query": 3,
+      "date": "2019-02-24",
+      "hits": 1
+    }
+  },
+  {
+    "model": "wagtailcore.site",
+    "pk": 2,
+    "fields": {
+      "hostname": "127.0.0.1",
+      "port": 8000,
+      "site_name": "Wagtail Bakery",
+      "root_page": 60,
+      "is_default_site": true
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 3,
+      "name": "Root"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 2,
+    "fields": {
+      "path": "00010001",
+      "depth": 2,
+      "numchild": 0,
+      "name": "Bakeries"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 3,
+    "fields": {
+      "path": "00010003",
+      "depth": 2,
+      "numchild": 0,
+      "name": "Other"
+    }
+  },
+  {
+    "model": "wagtailcore.collection",
+    "pk": 4,
+    "fields": {
+      "path": "00010002",
+      "depth": 2,
+      "numchild": 0,
+      "name": "BreadPage Images"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 1,
+    "fields": {
+      "name": "pineapple",
+      "slug": "pineapple"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 2,
+    "fields": {
+      "name": "bike",
+      "slug": "bike"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 3,
+    "fields": {
+      "name": "yeast",
+      "slug": "yeast"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 4,
+    "fields": {
+      "name": "fermentation",
+      "slug": "fermentation"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 5,
+    "fields": {
+      "name": "economics",
+      "slug": "economics"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 6,
+    "fields": {
+      "name": "europe",
+      "slug": "europe"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 7,
+    "fields": {
+      "name": "baking",
+      "slug": "baking"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 8,
+    "fields": {
+      "name": "grain",
+      "slug": "grain"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 9,
+    "fields": {
+      "name": "soda",
+      "slug": "soda"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 10,
+    "fields": {
+      "name": "sandwich",
+      "slug": "sandwich"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 11,
+    "fields": {
+      "name": "dessert",
+      "slug": "dessert"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 12,
+    "fields": {
+      "name": "pie",
+      "slug": "pie"
+    }
+  },
+  {
+    "model": "taggit.tag",
+    "pk": 13,
+    "fields": {
+      "name": "fire",
+      "slug": "fire"
+    }
+  },
+  {
+    "model": "auth.group",
+    "pk": 1,
+    "fields": {
+      "name": "Moderators",
+      "permissions": [
+        ["access_admin", "wagtailadmin", "admin"],
+        ["add_document", "wagtaildocs", "document"],
+        ["change_document", "wagtaildocs", "document"],
+        ["delete_document", "wagtaildocs", "document"],
+        ["add_image", "wagtailimages", "image"],
+        ["change_image", "wagtailimages", "image"],
+        ["delete_image", "wagtailimages", "image"]
       ]
-    ]
-  }
-},
-{
-  "model": "auth.group",
-  "pk": 2,
-  "fields": {
-    "name": "Editors",
-    "permissions": [
-      [
-        "access_admin",
-        "wagtailadmin",
-        "admin"
-      ],
-      [
-        "add_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "change_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "delete_document",
-        "wagtaildocs",
-        "document"
-      ],
-      [
-        "add_image",
-        "wagtailimages",
-        "image"
-      ],
-      [
-        "change_image",
-        "wagtailimages",
-        "image"
-      ],
-      [
-        "delete_image",
-        "wagtailimages",
-        "image"
+    }
+  },
+  {
+    "model": "auth.group",
+    "pk": 2,
+    "fields": {
+      "name": "Editors",
+      "permissions": [
+        ["access_admin", "wagtailadmin", "admin"],
+        ["add_document", "wagtaildocs", "document"],
+        ["change_document", "wagtaildocs", "document"],
+        ["delete_document", "wagtaildocs", "document"],
+        ["add_image", "wagtailimages", "image"],
+        ["change_image", "wagtailimages", "image"],
+        ["delete_image", "wagtailimages", "image"]
       ]
-    ]
+    }
+  },
+  {
+    "model": "auth.user",
+    "pk": 3,
+    "fields": {
+      "password": "pbkdf2_sha256$30000$eIoVnauBvLhA$aPWJSlHK+F/rW7SKunxJ/RnXNQHx0uh6K/kVRyPn0XY=",
+      "last_login": "2019-04-23T19:58:19.460Z",
+      "is_superuser": true,
+      "username": "admin",
+      "first_name": "Admin",
+      "last_name": "User",
+      "email": "admin@example.com",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-02-17T07:37:53.700Z",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 1,
+    "fields": {
+      "group": ["Moderators"],
+      "page": 1,
+      "permission_type": "add"
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 2,
+    "fields": {
+      "group": ["Moderators"],
+      "page": 1,
+      "permission_type": "edit"
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 3,
+    "fields": {
+      "group": ["Moderators"],
+      "page": 1,
+      "permission_type": "publish"
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 4,
+    "fields": {
+      "group": ["Editors"],
+      "page": 1,
+      "permission_type": "add"
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 5,
+    "fields": {
+      "group": ["Editors"],
+      "page": 1,
+      "permission_type": "edit"
+    }
+  },
+  {
+    "model": "wagtailcore.grouppagepermission",
+    "pk": 6,
+    "fields": {
+      "group": ["Moderators"],
+      "page": 1,
+      "permission_type": "lock"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 1,
+    "fields": {
+      "path": "0001",
+      "depth": 1,
+      "numchild": 1,
+      "title": "Root",
+      "draft_title": "Root",
+      "slug": "root",
+      "content_type": ["wagtailcore", "page"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": null,
+      "latest_revision_created_at": null
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 3,
+    "fields": {
+      "path": "000100020001",
+      "depth": 3,
+      "numchild": 11,
+      "title": "Breads",
+      "draft_title": "Breads",
+      "slug": "breads",
+      "content_type": ["breads", "breadsindexpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T11:34:11.560Z",
+      "latest_revision_created_at": "2019-03-22T06:54:24.677Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 34,
+    "fields": {
+      "path": "0001000200010003",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Anadama",
+      "draft_title": "Anadama",
+      "slug": "anadama-bread",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/anadama-bread/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:21.882Z",
+      "latest_revision_created_at": "2019-02-25T08:27:47.625Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 35,
+    "fields": {
+      "path": "0001000200010004",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Anpan",
+      "draft_title": "Anpan",
+      "slug": "anpan",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/anpan/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:21.931Z",
+      "latest_revision_created_at": "2019-02-23T08:31:07.640Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 36,
+    "fields": {
+      "path": "0001000200010005",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Appam",
+      "draft_title": "Appam",
+      "slug": "appam-hoppers",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/appam-hoppers/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:21.980Z",
+      "latest_revision_created_at": "2019-02-23T08:14:23.196Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 37,
+    "fields": {
+      "path": "0001000200010006",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Arepa",
+      "draft_title": "Arepa",
+      "slug": "arepa",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/arepa/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.029Z",
+      "latest_revision_created_at": "2019-02-23T08:10:31.068Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 39,
+    "fields": {
+      "path": "0001000200010008",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bagel",
+      "draft_title": "Bagel",
+      "slug": "bagel",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/bagel/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.127Z",
+      "latest_revision_created_at": "2019-02-23T08:01:54.867Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 40,
+    "fields": {
+      "path": "0001000200010009",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Baguette",
+      "draft_title": "Baguette",
+      "slug": "baguette-french-stick-french-bread",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/baguette-french-stick-french-bread/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.180Z",
+      "latest_revision_created_at": "2019-02-23T08:04:51.407Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 42,
+    "fields": {
+      "path": "000100020001000B",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bammy",
+      "draft_title": "Bammy",
+      "slug": "bammy",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/bammy/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.274Z",
+      "latest_revision_created_at": "2019-02-23T08:01:15.242Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 49,
+    "fields": {
+      "path": "000100020001000I",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bazin",
+      "draft_title": "Bazin",
+      "slug": "bazin",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/bazin/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.655Z",
+      "latest_revision_created_at": "2019-02-23T08:28:25.337Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 53,
+    "fields": {
+      "path": "000100020001000M",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bhakri",
+      "draft_title": "Bhakri",
+      "slug": "bhakri",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/bhakri/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:22.866Z",
+      "latest_revision_created_at": "2019-02-23T08:26:10.026Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 57,
+    "fields": {
+      "path": "000100020001000Q",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Black bread",
+      "draft_title": "Black bread",
+      "slug": "black-bread",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/black-bread/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:23.065Z",
+      "latest_revision_created_at": "2019-02-23T08:20:09.645Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 59,
+    "fields": {
+      "path": "000100020001000S",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bolani",
+      "draft_title": "Bolani",
+      "slug": "bolani",
+      "content_type": ["breads", "breadpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/breads/bolani/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T13:00:23.169Z",
+      "latest_revision_created_at": "2019-02-23T08:08:39.568Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 60,
+    "fields": {
+      "path": "00010002",
+      "depth": 2,
+      "numchild": 6,
+      "title": "Welcome to the Wagtail Bakery!",
+      "draft_title": "Welcome to the Wagtail Bakery!",
+      "slug": "home",
+      "content_type": ["base", "homepage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/",
+      "owner": null,
+      "seo_title": "Home",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T16:24:31.388Z",
+      "latest_revision_created_at": "2019-03-29T18:24:51.618Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 61,
+    "fields": {
+      "path": "000100020004",
+      "depth": 3,
+      "numchild": 6,
+      "title": "Blog",
+      "draft_title": "Blog",
+      "slug": "blog",
+      "content_type": ["blog", "blogindexpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/blog/",
+      "owner": null,
+      "seo_title": "Wagtail Bakeries Blog",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T16:25:47.179Z",
+      "latest_revision_created_at": "2019-04-23T20:04:30.432Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 62,
+    "fields": {
+      "path": "0001000200040001",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Tracking Wild Yeast",
+      "draft_title": "Tracking Wild Yeast",
+      "slug": "wild-yeast",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": true,
+      "url_path": "/home/blog/wild-yeast/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T16:26:58.040Z",
+      "latest_revision_created_at": "2019-04-01T07:35:45.288Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 63,
+    "fields": {
+      "path": "000100020003",
+      "depth": 3,
+      "numchild": 6,
+      "title": "Locations",
+      "draft_title": "Locations",
+      "slug": "locations",
+      "content_type": ["locations", "locationsindexpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T16:39:04.527Z",
+      "latest_revision_created_at": "2019-03-06T02:26:16.335Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 64,
+    "fields": {
+      "path": "0001000200030001",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Hof",
+      "draft_title": "Hof",
+      "slug": "new-york",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/new-york/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-10T16:39:55.909Z",
+      "latest_revision_created_at": "2019-03-29T17:50:19.047Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 65,
+    "fields": {
+      "path": "0001000200030002",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Reykjavik",
+      "draft_title": "Reykjavik",
+      "slug": "reykjavik",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/reykjavik/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-11T23:10:22.386Z",
+      "latest_revision_created_at": "2019-03-29T17:33:10.041Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 66,
+    "fields": {
+      "path": "0001000200030003",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Vik",
+      "draft_title": "Vik",
+      "slug": "london",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/london/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-11T23:13:20.488Z",
+      "latest_revision_created_at": "2019-03-29T18:03:09.098Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 67,
+    "fields": {
+      "path": "0001000200030004",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Selfoss",
+      "draft_title": "Selfoss",
+      "slug": "wellington",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/wellington/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-11T23:15:58.149Z",
+      "latest_revision_created_at": "2019-03-29T17:29:33.457Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 68,
+    "fields": {
+      "path": "0001000200040002",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Bread and Circuses",
+      "draft_title": "Bread and Circuses",
+      "slug": "bread-circuses",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/blog/bread-circuses/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-15T07:42:52.978Z",
+      "latest_revision_created_at": "2019-03-29T06:19:57.009Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 69,
+    "fields": {
+      "path": "000100020006",
+      "depth": 3,
+      "numchild": 0,
+      "title": "Contact Us",
+      "draft_title": "Contact Us",
+      "slug": "contact-us",
+      "content_type": ["base", "formpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/contact-us/",
+      "owner": null,
+      "seo_title": "",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-15T16:55:56.085Z",
+      "latest_revision_created_at": "2019-02-15T17:08:05.684Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 70,
+    "fields": {
+      "path": "000100020005",
+      "depth": 3,
+      "numchild": 0,
+      "title": "Gallery",
+      "draft_title": "Gallery",
+      "slug": "gallery",
+      "content_type": ["base", "gallerypage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/gallery/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-17T07:51:47.230Z",
+      "latest_revision_created_at": "2019-02-22T07:57:12.151Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 72,
+    "fields": {
+      "path": "0001000200040003",
+      "depth": 4,
+      "numchild": 0,
+      "title": "The Great Icelandic Baking Show",
+      "draft_title": "The Great Icelandic Baking Show",
+      "slug": "icelandic-baking",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/blog/icelandic-baking/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-21T08:07:11.832Z",
+      "latest_revision_created_at": "2019-03-29T06:52:34.448Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 73,
+    "fields": {
+      "path": "0001000200040004",
+      "depth": 4,
+      "numchild": 0,
+      "title": "The Joy of (Baking) Soda",
+      "draft_title": "The Joy of (Baking) Soda",
+      "slug": "joy-baking-soda",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/blog/joy-baking-soda/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-21T08:12:04.176Z",
+      "latest_revision_created_at": "2019-03-29T06:58:56.151Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 74,
+    "fields": {
+      "path": "0001000200040005",
+      "depth": 4,
+      "numchild": 0,
+      "title": "The Greatest Thing Since Sliced Bread",
+      "draft_title": "The Greatest Thing Since Sliced Bread",
+      "slug": "sliced-bread",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": true,
+      "url_path": "/home/blog/sliced-bread/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-21T08:17:21.604Z",
+      "latest_revision_created_at": "2019-04-01T07:35:26.199Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 76,
+    "fields": {
+      "path": "000100020007",
+      "depth": 3,
+      "numchild": 0,
+      "title": "About",
+      "draft_title": "About",
+      "slug": "about",
+      "content_type": ["base", "standardpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/about/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": true,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-03-17T07:03:16.637Z",
+      "latest_revision_created_at": "2019-03-17T07:47:50.894Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 77,
+    "fields": {
+      "path": "0001000200040006",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Desserts with Benefits",
+      "draft_title": "Desserts with Benefits",
+      "slug": "desserts-benefits",
+      "content_type": ["blog", "blogpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/blog/desserts-benefits/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-03-22T06:31:05.324Z",
+      "latest_revision_created_at": "2019-04-23T20:03:47.050Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 78,
+    "fields": {
+      "path": "0001000200030005",
+      "depth": 4,
+      "numchild": 0,
+      "title": "H\u00f6fn",
+      "draft_title": "H\u00f6fn",
+      "slug": "hofn",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/hofn/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-11T23:10:22.386Z",
+      "latest_revision_created_at": "2019-03-29T18:05:47.930Z"
+    }
+  },
+  {
+    "model": "wagtailcore.page",
+    "pk": 79,
+    "fields": {
+      "path": "0001000200030006",
+      "depth": 4,
+      "numchild": 0,
+      "title": "Akranes",
+      "draft_title": "Akranes",
+      "slug": "akranes",
+      "content_type": ["locations", "locationpage"],
+      "live": true,
+      "has_unpublished_changes": false,
+      "url_path": "/home/locations/akranes/",
+      "owner": ["admin"],
+      "seo_title": "",
+      "show_in_menus": false,
+      "search_description": "",
+      "go_live_at": null,
+      "expire_at": null,
+      "expired": false,
+      "locked": false,
+      "first_published_at": "2019-02-11T23:10:22.386Z",
+      "latest_revision_created_at": "2019-03-29T18:09:44.290Z"
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 8,
+    "fields": {
+      "collection": 3,
+      "title": "Roberta Johnson",
+      "file": "original_images/roberta_johnson.jpeg",
+      "width": 300,
+      "height": 282,
+      "created_at": "2019-02-17T07:43:46.304Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 17829
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 9,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 1",
+      "file": "original_images/breads1.jpg",
+      "width": 1080,
+      "height": 831,
+      "created_at": "2019-02-17T08:10:34.237Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 173675
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 10,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 2",
+      "file": "original_images/breads2.jpg",
+      "width": 1080,
+      "height": 1151,
+      "created_at": "2019-02-17T08:10:34.344Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 506419
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 11,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 3",
+      "file": "original_images/breads3.jpg",
+      "width": 1080,
+      "height": 1080,
+      "created_at": "2019-02-17T08:10:34.580Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 166505
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 12,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 4",
+      "file": "original_images/breads4.jpg",
+      "width": 1080,
+      "height": 1240,
+      "created_at": "2019-02-17T08:10:34.723Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 174743
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 14,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 5",
+      "file": "original_images/bread5.jpg",
+      "width": 800,
+      "height": 600,
+      "created_at": "2019-02-19T08:08:37.723Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 127107
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 15,
+    "fields": {
+      "collection": 2,
+      "title": "Breads 6",
+      "file": "original_images/bread6.jpg",
+      "width": 1008,
+      "height": 756,
+      "created_at": "2019-02-19T08:08:38.028Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 247052
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 21,
+    "fields": {
+      "collection": 2,
+      "title": "Yeast",
+      "file": "original_images/yeast.jpg",
+      "width": 1024,
+      "height": 682,
+      "created_at": "2019-02-21T07:50:10.793Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 122348
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 22,
+    "fields": {
+      "collection": 2,
+      "title": "Bedouins",
+      "file": "original_images/Bedouins_making_bread.jpg",
+      "width": 1000,
+      "height": 669,
+      "created_at": "2019-02-21T07:59:50.671Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 408107
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 23,
+    "fields": {
+      "collection": 2,
+      "title": "\u00d8landshvedebr\u00f8d",
+      "file": "original_images/Olandshvedebrod_6082070226.jpg",
+      "width": 1000,
+      "height": 664,
+      "created_at": "2019-02-21T08:05:08.529Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 137708
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 24,
+    "fields": {
+      "collection": 2,
+      "title": "Soda Bread",
+      "file": "original_images/soda_bread.jpg",
+      "width": 733,
+      "height": 481,
+      "created_at": "2019-02-21T08:10:30.772Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 73964
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 25,
+    "fields": {
+      "collection": 2,
+      "title": "Sandwich Bread",
+      "file": "original_images/sliced.jpg",
+      "width": 1024,
+      "height": 677,
+      "created_at": "2019-02-21T08:15:16.080Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 297826
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 26,
+    "fields": {
+      "collection": 4,
+      "title": "Anadama_bread",
+      "file": "original_images/Anadama_bread_1.jpg",
+      "width": 1200,
+      "height": 800,
+      "created_at": "2019-02-23T07:48:33.730Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 72910
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 28,
+    "fields": {
+      "collection": 4,
+      "title": "Appam",
+      "file": "original_images/Appam_served_with_Coconut_Milk_in_Tamil_Nadu.JPG",
+      "width": 1200,
+      "height": 541,
+      "created_at": "2019-02-23T07:48:34.056Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 79398
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 29,
+    "fields": {
+      "collection": 4,
+      "title": "Arepa",
+      "file": "original_images/Arepa_asada.JPG",
+      "width": 1200,
+      "height": 900,
+      "created_at": "2019-02-23T07:48:34.189Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 56891
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 30,
+    "fields": {
+      "collection": 4,
+      "title": "Bagel",
+      "file": "original_images/Bagel.jpg",
+      "width": 1200,
+      "height": 1038,
+      "created_at": "2019-02-23T07:48:34.296Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 104030
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 31,
+    "fields": {
+      "collection": 4,
+      "title": "Baguette",
+      "file": "original_images/Baguette_de_pain_WikiCheese_Lausanne.jpg",
+      "width": 1200,
+      "height": 583,
+      "created_at": "2019-02-23T07:48:34.417Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 41014
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 32,
+    "fields": {
+      "collection": 4,
+      "title": "Bammies",
+      "file": "original_images/Bammies.jpg",
+      "width": 1200,
+      "height": 1078,
+      "created_at": "2019-02-23T07:48:34.498Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 137317
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 33,
+    "fields": {
+      "collection": 4,
+      "title": "Bazin",
+      "file": "original_images/Bazin.jpg",
+      "width": 1200,
+      "height": 900,
+      "created_at": "2019-02-23T07:48:34.571Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 112991
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 34,
+    "fields": {
+      "collection": 4,
+      "title": "Bunanpankatori",
+      "file": "original_images/Bean-jam-bunanpankatori-cityjapan.JPG",
+      "width": 800,
+      "height": 640,
+      "created_at": "2019-02-23T07:48:34.650Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 60721
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 35,
+    "fields": {
+      "collection": 4,
+      "title": "Belgian Waffle",
+      "file": "original_images/Belgische_waffeln.jpg",
+      "width": 1200,
+      "height": 910,
+      "created_at": "2019-02-23T07:48:34.735Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 151259
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 36,
+    "fields": {
+      "collection": 4,
+      "title": "Afghan Bolani",
+      "file": "original_images/Bolani_Afghan_bread_01.jpg",
+      "width": 1280,
+      "height": 960,
+      "created_at": "2019-02-23T07:48:34.809Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 104969
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 37,
+    "fields": {
+      "collection": 4,
+      "title": "Misc Breads",
+      "file": "original_images/Breads_1.jpg",
+      "width": 1200,
+      "height": 796,
+      "created_at": "2019-02-23T07:48:34.909Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 167917
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 39,
+    "fields": {
+      "collection": 4,
+      "title": "Rye Bread",
+      "file": "original_images/Sourdough_rye_with_walnuts.jpg",
+      "width": 1200,
+      "height": 773,
+      "created_at": "2019-02-23T08:18:10.895Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 213288
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 40,
+    "fields": {
+      "collection": 4,
+      "title": "Bhakri",
+      "file": "original_images/Bhakri_1.jpg",
+      "width": 1200,
+      "height": 900,
+      "created_at": "2019-02-23T08:25:03.822Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 193665
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 41,
+    "fields": {
+      "collection": 3,
+      "title": "Sprint Crew",
+      "file": "original_images/sprint_crew.jpg",
+      "width": 1000,
+      "height": 750,
+      "created_at": "2019-02-24T08:01:50.590Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 121235
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 42,
+    "fields": {
+      "collection": 3,
+      "title": "Baking Soda",
+      "file": "original_images/bakingsoda.jpg",
+      "width": 1024,
+      "height": 678,
+      "created_at": "2019-03-22T06:13:09.773Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 87095
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 43,
+    "fields": {
+      "collection": 3,
+      "title": "Boston Cream Pie",
+      "file": "original_images/bostoncream.jpg",
+      "width": 1024,
+      "height": 683,
+      "created_at": "2019-03-22T06:29:18.751Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 117057
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 44,
+    "fields": {
+      "collection": 1,
+      "title": "Image by \u00c6var Gu\u00f0mundsson",
+      "file": "original_images/aevar-gudmundsson-selfoss.jpg",
+      "width": 1400,
+      "height": 932,
+      "created_at": "2019-03-29T17:27:55.769Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 167793
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 45,
+    "fields": {
+      "collection": 1,
+      "title": "Image by Sverrir Thorolfsson",
+      "file": "original_images/reykjavik-sverrir-thorolfsson.jpg",
+      "width": 992,
+      "height": 971,
+      "created_at": "2019-03-29T17:31:36.429Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 206071
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 46,
+    "fields": {
+      "collection": 1,
+      "title": "Glacier descending near Hof",
+      "file": "original_images/hof-cornell-university-filter.jpg",
+      "width": 1200,
+      "height": 948,
+      "created_at": "2019-03-29T17:46:14.914Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": 518,
+      "focal_point_y": 248,
+      "focal_point_width": 1031,
+      "focal_point_height": 496,
+      "file_size": 279068
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 47,
+    "fields": {
+      "collection": 1,
+      "title": "Old buildings above Vik",
+      "file": "original_images/vik.jpg",
+      "width": 1400,
+      "height": 981,
+      "created_at": "2019-03-29T18:00:33.977Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 207895
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 48,
+    "fields": {
+      "collection": 1,
+      "title": "Höfn from above",
+      "file": "original_images/Hofn.jpg",
+      "width": 1200,
+      "height": 800,
+      "created_at": "2019-03-29T18:04:27.068Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 369123
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 49,
+    "fields": {
+      "collection": 1,
+      "title": "Akranes",
+      "file": "original_images/Akranes.jpg",
+      "width": 1200,
+      "height": 800,
+      "created_at": "2019-03-29T18:08:27.770Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": 578,
+      "focal_point_y": 476,
+      "focal_point_width": 1031,
+      "focal_point_height": 537,
+      "file_size": 225856
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 51,
+    "fields": {
+      "collection": 3,
+      "title": "Muddy Waters",
+      "file": "original_images/muddy_waters_hUPkmSW.jpg",
+      "width": 611,
+      "height": 672,
+      "created_at": "2019-03-31T06:36:23.486Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 189650
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 52,
+    "fields": {
+      "collection": 3,
+      "title": "Olivia Ava",
+      "file": "original_images/olivia_ava.jpeg",
+      "width": 300,
+      "height": 294,
+      "created_at": "2019-04-01T07:30:10.713Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 46112
+    }
+  },
+  {
+    "model": "wagtailimages.image",
+    "pk": 53,
+    "fields": {
+      "collection": 3,
+      "title": "Lightnin' Hopkins",
+      "file": "original_images/lightnin_hopkins.jpg",
+      "width": 150,
+      "height": 162,
+      "created_at": "2019-04-01T07:31:21.251Z",
+      "uploaded_by_user": ["admin"],
+      "focal_point_x": null,
+      "focal_point_y": null,
+      "focal_point_width": null,
+      "focal_point_height": null,
+      "file_size": 18521
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 64,
+    "fields": {
+      "introduction": "Pie gingerbread cake caramels chocolate cake tiramisu wafer. Gummi bears chupa chups chocolate. Topping chupa chups bonbon cake pie caramels. Pie gingerbread cake caramels chocolate cake tiramisu wafer.",
+      "image": 46,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Chocolate bar I love marzipan chupa chups souffl\\u00e9 chocolate bar. Biscuit caramels lollipop cookie. Macaroon I love tart pudding topping I love. Jujubes macaroon gummies pudding icing cake pastry. Candy canes candy chocolate cake I love chocolate carrot cake halvah. I love croissant I love donut. Chocolate sweet chocolate cake cotton candy souffl\\u00e9 caramels pie tiramisu I love. Lemon drops topping caramels. Pudding candy cotton candy gingerbread jelly beans jelly-o tiramisu cotton candy souffl\\u00e9. Cake bear claw cupcake pastry gummi bears cake.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"Never say no to more\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Muffin wafer chocolate cake bonbon icing chupa chups cupcake. Pudding drag\\u00e9e souffl\\u00e9 icing caramels chupa chups sweet muffin. Pastry fruitcake pastry dessert chupa chups. Sugar plum wafer chupa chups tootsie roll candy chocolate bar souffl\\u00e9 sesame snaps jelly-o. Dessert macaroon jelly fruitcake jujubes marshmallow cake. Gummies souffl\\u00e9 cotton candy candy pastry powder topping muffin cotton candy. I love jelly beans I love I love chocolate cake fruitcake oat cake drag\\u00e9e dessert.</p><p>Chupa chups marzipan pie caramels cotton candy jelly-o. Pie sweet cake souffl\\u00e9 apple pie cake. Chocolate cake chupa chups bear claw cotton candy. I love marshmallow chocolate sweet I love. Drag\\u00e9e donut cotton candy jujubes ice cream. Marshmallow gummies gingerbread marzipan. Caramels tootsie roll cake. Macaroon chocolate liquorice ice cream. Candy biscuit chupa chups chocolate cake cake danish. Sesame snaps I love macaroon cupcake bear claw chocolate cake I love candy canes.</p>\"}]",
+      "address": "Hof 2,\r\nL\u00e6kjarh\u00fas,\r\n785 \u00d6r\u00e6fi,\r\nIceland",
+      "lat_long": "63.9095213,-16.7093877"
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 65,
+    "fields": {
+      "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
+      "image": 45,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
+      "address": "Laugavegur 36,\r\n101 Reykjav\u00edk,\r\nIceland",
+      "lat_long": "64.144018, -21.950953"
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 66,
+    "fields": {
+      "introduction": "Chocolate bar tiramisu toffee. Topping pie powder candy canes jujubes liquorice. Apple pie muffin marshmallow tiramisu powder cotton candy topping. Apple pie tiramisu marshmallow sesame snaps.",
+      "image": 47,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Cupcake ipsum dolor sit. Amet cake bear claw cheesecake marshmallow donut topping. Bonbon tootsie roll tiramisu drag\\u00e9e. Sweet macaroon gummies tootsie roll toffee cupcake jujubes gingerbread. Chocolate bar cupcake danish muffin donut cookie souffl\\u00e9 carrot cake. Cake cake macaroon muffin sesame snaps marzipan apple pie cheesecake.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"Now with sugar\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Chocolate caramels cupcake jelly beans icing gummi bears fruitcake gingerbread. Cupcake drag\\u00e9e tootsie roll cheesecake chocolate. Jelly lemon drops lemon drops chocolate. Sesame snaps chocolate bar cheesecake tiramisu gummi bears sweet sesame snaps wafer. Pie cake macaroon sugar plum toffee icing. Bonbon sweet roll cupcake sesame snaps toffee candy fruitcake.</p><p>Cupcake cupcake souffl\\u00e9 jelly beans chocolate cake lemon drops. Dessert chocolate bar cotton candy. Pastry icing oat cake wafer. Marshmallow topping gummies cotton candy cake gingerbread. Donut macaroon carrot cake. Pie candy canes cupcake powder marzipan. Sweet oat cake jelly beans apple pie ice cream. Brownie caramels chupa chups marzipan. Biscuit biscuit croissant fruitcake pastry pastry.</p>\"}]",
+      "address": "Klettsvegi 1,\r\n870 V\u00edk,\r\nIceland",
+      "lat_long": "63.419061,-19.0064982"
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 67,
+    "fields": {
+      "introduction": "Gummies dessert cake pastry jujubes cotton candy apple pie chocolate bar muffin. Bonbon souffl\u00e9 icing brownie cheesecake candy canes. Sesame snaps chocolate pudding souffl\u00e9 powder pastry pastry jelly beans. Chocolate cake caramels gingerbread bear claw gingerbread jelly-o.",
+      "image": 44,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Jelly-o marzipan fruitcake. Candy marshmallow candy canes macaroon marshmallow marshmallow sesame snaps. Cookie croissant wafer jelly beans. Bonbon sesame snaps danish chocolate bar. Pudding marzipan tootsie roll lollipop sesame snaps souffl\\u00e9 fruitcake. Tootsie roll jujubes cookie chocolate topping cupcake. Pudding cake gummies chupa chups jelly beans gingerbread sesame snaps gummi bears gummies. Chocolate chupa chups jelly candy canes carrot cake croissant ice cream. Bonbon sugar plum jelly beans cake tiramisu. Carrot cake gummies carrot cake macaroon wafer cake cupcake.</p><p>Jelly-o candy canes macaroon chocolate cake cheesecake cake lollipop cookie. Halvah candy topping sugar plum topping sesame snaps cotton candy topping. Sesame snaps brownie chocolate cake. Lemon drops sweet roll cookie drag\\u00e9e chocolate bar sugar plum jelly-o. Liquorice toffee jujubes chocolate cake cheesecake biscuit. Marshmallow chocolate bar oat cake wafer souffl\\u00e9 brownie fruitcake. Oat cake icing cheesecake liquorice caramels.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"An awesome heading\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Brownie marzipan marshmallow tart pudding carrot cake. Cheesecake jelly beans gingerbread lollipop. Marshmallow tiramisu jelly beans apple pie gingerbread candy bonbon carrot cake. Pastry candy gummies danish pudding topping. Tart jelly-o chocolate wafer pastry brownie chocolate bar oat cake. Cookie sugar plum liquorice jelly beans. Sweet jujubes candy canes sweet chocolate chocolate cookie chocolate cookie. Cookie pudding toffee tart.</p>\"}]",
+      "address": "Eyravegur,\r\n800 Selfoss,\r\nIceland",
+      "lat_long": "63.9375899, -21.0419085"
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 78,
+    "fields": {
+      "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
+      "image": 48,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
+      "address": "Hafnarbraut,\r\n780 H\u00f6fn \u00ed Hornafir\u00f0i,\r\nIceland",
+      "lat_long": "64.2518583,-15.2037097"
+    }
+  },
+  {
+    "model": "locations.locationpage",
+    "pk": 79,
+    "fields": {
+      "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
+      "image": 49,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
+      "address": "Skagabraut 43,\r\n300 Akranes,\r\nIceland",
+      "lat_long": "64.3214253,-22.0674947"
+    }
+  },
+  {
+    "model": "locations.locationsindexpage",
+    "pk": 63,
+    "fields": {
+      "introduction": "You can find our fine bakeries in friendly cities all over the world.",
+      "image": 10
+    }
+  },
+  {
+    "model": "breads.breadsindexpage",
+    "pk": 3,
+    "fields": {
+      "introduction": "We feature outlandishly delicious breads sourced from every continent (except Antarctica)",
+      "image": 9
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 34,
+    "fields": {
+      "introduction": "It is not readily agreed exactly when or where the bread originated, except it existed before 1850 in Rockport, Massachusetts. It is thought to have come from the local fishing community, but it may have come through the Finnish community of local stonecutters.",
+      "image": 26,
+      "body": "[]",
+      "origin": 3,
+      "bread_type": 4,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 35,
+    "fields": {
+      "introduction": "Anpan was first made in 1875, during the Meiji period, by a man called Yasubei Kimura, a samurai who lost his job with the rise of the conscript Imperial Army and the dissolution of the samurai as a social class.",
+      "image": 34,
+      "body": "[]",
+      "origin": 4,
+      "bread_type": 5,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 36,
+    "fields": {
+      "introduction": "Appam is a type of pancake made with fermented rice batter and coconut milk. It is a common food in Kerala, Tamil Nadu and Sri Lanka. It is eaten most frequently for breakfast or dinner.",
+      "image": 28,
+      "body": "[]",
+      "origin": 5,
+      "bread_type": 6,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 37,
+    "fields": {
+      "introduction": "Arepa  is a type of food made of ground maize dough or cooked flour prominent in the cuisine of Colombia and Venezuela.",
+      "image": 29,
+      "body": "[]",
+      "origin": 6,
+      "bread_type": 7,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 39,
+    "fields": {
+      "introduction": "Though the origins of bagels are somewhat obscure, it is known that they were widely consumed in eastern European Jewish communities from the 17th century.",
+      "image": 30,
+      "body": "[]",
+      "origin": 8,
+      "bread_type": 4,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 40,
+    "fields": {
+      "introduction": "A baguette has a diameter of about 5 or 6 centimetres  and a usual length of about 65 centimetres (26 in), although a baguette can be up to a metre (39 in) long.",
+      "image": 31,
+      "body": "[]",
+      "origin": 9,
+      "bread_type": 4,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 42,
+    "fields": {
+      "introduction": "Bammies, like wheat bread and tortillas, are served at any meal or consumed as a snack.",
+      "image": 32,
+      "body": "[]",
+      "origin": 11,
+      "bread_type": 2,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 49,
+    "fields": {
+      "introduction": "When consumed, bazin may be \"crumpled and eaten with the fingers.\"",
+      "image": 33,
+      "body": "[]",
+      "origin": 18,
+      "bread_type": 11,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 53,
+    "fields": {
+      "introduction": "Bhakri  is a round flat unleavened bread often used in the cuisine of the state of mainly Maharashtra, but also in Gujarat.",
+      "image": 40,
+      "body": "[]",
+      "origin": 21,
+      "bread_type": 14,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 57,
+    "fields": {
+      "introduction": "Rye bread is a type of bread made with various proportions of flour from rye grain",
+      "image": 39,
+      "body": "[]",
+      "origin": 12,
+      "bread_type": 16,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "breads.breadpage",
+    "pk": 59,
+    "fields": {
+      "introduction": "Perakai is made for special occasions like birthday parties, engagement parties or holidays.",
+      "image": 36,
+      "body": "[]",
+      "origin": 24,
+      "bread_type": 2,
+      "ingredients": []
+    }
+  },
+  {
+    "model": "blog.blogindexpage",
+    "pk": 61,
+    "fields": {
+      "introduction": "Welcome to our blog",
+      "image": 11
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 62,
+    "fields": {
+      "introduction": "Yeasts, with their single-celled growth habit, can be contrasted with molds, which grow hyphae. Fungal species that can take both forms (depending on temperature or other conditions) are called dimorphic fungi (\"dimorphic\" means \"having two forms\").",
+      "image": 21,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Yeasts are eukaryotic, single-celled microorganisms classified as members of the fungus kingdom. The yeast lineage[which?] originated hundreds of millions of years ago, and 1,500 species are currently identified.[1][2][3] They are estimated to constitute 1% of all described fungal species.[4] Yeasts are unicellular organisms which evolved from multicellular ancestors,[5] with some species having the ability to develop multicellular characteristics by forming strings of connected budding cells known as pseudohyphae or false hyphae.[6] Yeast sizes vary greatly, depending on species and environment, typically measuring 3\\u20134 \\u00b5m in diameter, although some yeasts can grow to 40 \\u00b5m in size.[7] Most yeasts reproduce asexually by mitosis, and many do so by the asymmetric division process known as budding.</p><h3>Contrast with Molds</h3><p>Yeasts, with their single-celled growth habit, can be contrasted with molds, which grow hyphae. Fungal species that can take both forms (depending on temperature or other conditions) are called dimorphic fungi (\\\"dimorphic\\\" means \\\"having two forms\\\").<br/></p><p>By fermentation, the yeast species Saccharomyces cerevisiae converts carbohydrates to carbon dioxide and alcohols \\u2013 for thousands of years the carbon dioxide has been used in baking and the alcohol in alcoholic beverages.[8] It is also a centrally important model organism in modern cell biology research, and is one of the most thoroughly researched eukaryotic microorganisms. Researchers have used it to gather information about the biology of the eukaryotic cell and ultimately human biology.[9] Other species of yeasts, such as Candida albicans, are opportunistic pathogens and can cause infections in humans. Yeasts have recently been used to generate electricity in microbial fuel cells,[10] and produce ethanol for the biofuel industry.<br/></p><p>Yeasts do not form a single taxonomic or phylogenetic grouping. The term \\\"yeast\\\" is often taken as a synonym for Saccharomyces cerevisiae,[11] but the phylogenetic diversity of yeasts is shown by their placement in two separate phyla: the Ascomycota and the Basidiomycota. The budding yeasts (\\\"true yeasts\\\") are classified in the order Saccharomycetales,[12] within the phylum Ascomycota.<br/></p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 39, \"attribution\": \"Creative Commons\", \"caption\": \"Raised Yummy\"}}]",
+      "subtitle": "The art of cultivating yeast",
+      "date_published": "2019-01-12"
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 68,
+    "fields": {
+      "introduction": "Baking is a method of cooking food that uses prolonged dry heat, normally in an oven, but also in hot ashes, or on hot stones. The most common baked item is bread but many other types of foods are baked.",
+      "image": 22,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Heat is <b>gradually</b> transferred \\\"from the surface of cakes, cookies, and breads to their centre. As heat travels through it transforms batters and doughs into baked goods with a firm dry crust and a softer centre\\\".[2] Baking can be combined with grilling to produce a hybrid barbecue variant by using both methods simultaneously, or one after the other. Baking is related to barbecuing because the concept of the masonry oven is similar to that of a smoke pit.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 24, \"attribution\": \"Creative Commons\", \"caption\": \"Soda Bread\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Because of historical social and familial roles,\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Baking\\\">baking</a>\\u00a0has traditionally been performed at home by women for domestic consumption and by men in bakeries and restaurants for local consumption. When production was industrialized, baking was automated by machines in large factories. The art of baking remains a fundamental skill and is important for nutrition, as baked goods, especially breads, are a common but important food, both from an economic and cultural point of view. A person who prepares baked goods as a profession is called a baker.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 12, \"attribution\": \"\", \"caption\": \"\"}}]",
+      "subtitle": "The art of baking",
+      "date_published": "2019-02-14"
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 72,
+    "fields": {
+      "introduction": "Nordic bread culture has existed in Denmark, Finland, Norway, and Sweden from prehistoric time through to the present.",
+      "image": 23,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Four grain types dominated in the Nordic countries: barley and rye are the oldest; wheat and oats are more recent. During the Iron Age (500 AD \\u2013 1050 AD), rye became the most commonly used grain, followed by barley and oats. Rye was also the most commonly used grain for bread up until the beginning of the 20th century. Today, older grain types such as emmer and spelt are once again being cultivated and new bread types are being developed from these grains.</p><p>Archaeological finds in Denmark indicate use of the two triticum (wheat) species, emmer and einkorn, during the Mesolithic Period (8900 BC \\u2013 3900 BC). There is no direct evidence of bread-making, but cereals have been crushed, cooked and served as porridge since at least 4,200 BC. During the Neolithic Period (3900 BC \\u2013 1800 BC), when agriculture was introduced, barley seems to have taken over to some extent, and ceramic plates apparently used for baking are found. Moulded cereals, with water added to make a dough and baked or fried in the shape of bread, are known as burial gifts in Iron Age graves (200 AD onwards) in the M\\u00e4lardalen area of central Sweden. However, it is not certain that this bread was eaten; it could just have been a burial gift. During the Bronze Age (1800 BC \\u2013 500 AD), oats and the triticum species spelt seem to have been the most commonly used grains, and we see the first real ovens, probably used for baking small loaves and perhaps the first bread (probably around 400 AD).</p><p><br/></p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 42, \"attribution\": \"Creative Commons\", \"caption\": \"Baking Soda\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Scandinavian soldiers in Roman times apparently learned baking techniques when working as mercenaries in the Roman army (200\\u2013400 AD). They subsequently took the technique home with them to show that they had been employed in high status work on the continent[citation needed]. Early Christian traditions promoted an interest in bread. Culturally, German traditions have influenced most of the bread types in the Nordic countries. In the eastern part of Finland, there is a cultural link to Russia and Slavic bread traditions.</p><p>In the Nordic countries, bread was the main part of a meal until the late 18th century. Four different bread regions can be found in the Nordic area in the late 19th century. In the south, soft rye bread dominated. Further north came crisp bread, usually baked with rye, then thin and crispy barley bread. In the far north, soft barley loaves dominated. During the 19th century, potatoes began to become the centrepiece of meals and bread was put aside as an extra source of carbohydrates in a meal. Bread still retained its key function for breakfast, as the open sandwich is a starter for most Nordic people today and potatoes are used as a centrepiece in lunches and dinners.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 14, \"attribution\": \"Creative Commons\", \"caption\": \"Fresh baked\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>A history of Nordic bread from around 1000 AD and some contemporary types and bread innovations is presented below. Countries are presented in alphabetic order (Denmark, Finland, Iceland, Norway and Sweden). The names of the bread types are mostly given in both the contemporary national language and in English.</p>\"}]",
+      "subtitle": "Viking bakeries and Norse donuts",
+      "date_published": "2019-03-21"
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 73,
+    "fields": {
+      "introduction": "During the early years of European settlement of the Americas, settlers and some groups of Indigenous peoples of the Americas used soda or pearl ash, more commonly known as potash (pot ash) or potassium carbonate, as a leavening agent (the forerunner to baking soda) in quick breads.",
+      "image": 42,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Since it has long been known and is widely used, the salt has many related names such as baking soda, bread soda, cooking soda, and bicarbonate of soda. In colloquial usage, the names sodium bicarbonate and bicarbonate of soda are often truncated. Forms such as sodium bicarb, bicarb soda, bicarbonate, bicarb, or even bica are common. The word saleratus, from Latin <i>sal \\u00e6ratus</i> meaning \\\"aerated salt\\\", was widely used in the 19th century for both sodium bicarbonate and potassium bicarbonate.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 15, \"attribution\": \"Creative Commons\", \"caption\": \"Fresh baked\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>The prefix, bi, in bicarbonate comes from an outdated naming system and is based on the observation that there is twice as much carbonate (CO3) per sodium in\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Sodium_bicarbonate\\\">sodium bicarbonate</a>\\u00a0(NaHCO3) as there is carbonate per sodium in sodium carbonate (Na2CO3) and other carbonates. The modern way of analyzing the situation based on the exact chemical composition (which was unknown when the name sodium bicarbonate was coined) says this the other way around: there is half as much sodium in NaHCO3 as in Na2CO3 (Na versus Na2).</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 37, \"attribution\": \"Creative Commons\", \"caption\": \"Cornucopia of Breads\"}}]",
+      "subtitle": "The ingredients of traditional soda bread are flour, bread soda, salt, and buttermilk.",
+      "date_published": "2019-02-08"
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 74,
+    "fields": {
+      "introduction": "Sandwich bread (also referred to as sandwich loaf)  is bread that is prepared specifically to be used for the preparation of sandwiches.",
+      "image": 25,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Sandwich breads are produced in many varieties, such as white, whole wheat, sourdough, rye, multigrain and others. Sandwich bread may be formulated to slice easily,[8] cleanly or uniformly, and may have a fine crumb (the soft, inner part of bread) and a light texture.[4] Sandwich bread may be designed to have a balanced proportion of crumb and crust, whereby the bread holds and supports fillings in place and reduces drips and messiness. <a href=\\\"https://en.wikipedia.org/wiki/Sandwich_bread\\\">Some may be designed</a> to not become crumbly, hardened, dried or have too squishy a texture.</p>\"}, {\"type\": \"block_quote\", \"value\": {\"attribute_name\": \"Jim Davis\", \"text\": \"Vegetables are a must on a diet. I suggest carrot cake, zucchini bread, and pumpkin pie.\"}}, {\"type\": \"image_block\", \"value\": {\"image\": 35, \"attribution\": \"Creative Commons\", \"caption\": \"Belgian Waffle\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Sandwich bread can refer to cross-sectionally square, sliced white and wheat bread, which has been described as \\\"perfectly designed for holding square luncheon meat\\\".[10] The bread used for preparing finger sandwiches is sometimes referred to as sandwich bread.[10] Pan de molde is a sandwich loaf.[11][12] Some sandwich breads are designed for use in the creation of specific types of sandwiches, such as the submarine sandwich.[13] For barbecuing, use of a high-quality white sandwich bread has been described as suitable for toasting over a fire.[14] Gluten-free sandwich bread may be prepared using gluten-free flour, teff flour.[15][16] and other ingredients.<br/></p><p>In the 1930s in the United States, the term sandwich loaf referred to sliced bread.[10] In contemporary times, U.S. consumers sometimes refer to white bread such as Wonder Bread as sandwich bread and sandwich loaf.[1] Wonder Bread produced and marketed a bread called Wonder Round sandwich bread, which was designed to be used with round-shaped cold cuts and other fillings such as eggs and hamburgers, but it was discontinued due to low consumer demand.[17] American sandwich breads have historically included some fat derived from the use of milk or oil to enrich the bread.</p>\"}]",
+      "subtitle": "Innovation in the brick oven",
+      "date_published": "2019-02-02"
+    }
+  },
+  {
+    "model": "blog.blogpage",
+    "pk": 77,
+    "fields": {
+      "introduction": "A Boston cream pie is a yellow butter cake that is filled with custard or cream and topped with chocolate glaze.",
+      "image": 43,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Despite its name, it is in fact a cake, and not a pie.[2] The dessert acquired its name when cakes and pies were cooked in the same pans, and the words were used interchangeably.[3] In the latter part of the 19th century, this type of cake was variously called a \\\"cream pie\\\", a \\\"chocolate cream pie\\\", or a \\\"custard cake\\\".[3]</p><p>Owners of the Parker House Hotel in Boston claim that the Boston cream pie was first created at the hotel by Armenian-French chef M. Sanzian in 1856.[4] Called a \\\"Chocolate Cream Pie\\\", this cake consisted of two layers of French butter sponge cake filled with cr\\u00e8me p\\u00e2tissi\\u00e8re and brushed with a rum syrup, its side coated with cr\\u00e8me p\\u00e2tissi\\u00e8re overlain with toasted sliced almonds, and the top coated with chocolate fondant.[5] However, historians dispute this claim to primacy; while this cake may have been served then, there is no specific contemporaneous evidence of it, and custard-filled cake was already popular at that time.[3]</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 15, \"attribution\": \"Creative Commons\", \"caption\": \"Central Bakery\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>The cake is likely derived from the Washington pie, a two-layer yellow cake filled with jam and topped with confectioner's sugar, for which pastry cream of custard eventually replaced the jam, and a chocolate glaze replaced the confectioner's sugar.[2] Today, the cake is topped with a chocolate glaze (such as ganache) and sometimes powdered sugar or a cherry.</p><p>The name first appeared in the 1872 Methodist Almanac.[3] Another early printed use of the term \\\"Boston cream pie\\\" occurred in the Granite Iron Ware Cook Book, printed in 1878.[2] The earliest known recipe of the modern variant was printed in Miss Parloa's Kitchen Companion in 1887 as \\\"Chocolate Cream Pie\\\".[2]</p>\"}]",
+      "subtitle": "Banana toffee chocolate pie?",
+      "date_published": "2019-02-24"
+    }
+  },
+  {
+    "model": "base.formpage",
+    "pk": 69,
+    "fields": {
+      "to_address": "us@example.com",
+      "from_address": "you@example.com",
+      "subject": "Contact message from Wagtail Demo site",
+      "image": null,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>We'd love to hear from you! Drop us a line to let us know what you liked or didn't like about your recent store visit, or if you have comments or questions about this site.\\u00a0</p><p>This form is for demo purposes only - email goes nowhere. Developers: \\u00a0Edit the \\\"To Address\\\" field in the Form object in the Wagtail admin, and see the Email notes in the project readme to make your instance send live email.</p>\"}]",
+      "thank_you_text": "<p>Thanks!</p><p>We've received your message and will get back to you shortly.</p>"
+    }
+  },
+  {
+    "model": "base.gallerypage",
+    "pk": 70,
+    "fields": {
+      "introduction": "Some of our best-baked images, from around the world.",
+      "image": 23,
+      "body": "[]",
+      "collection": 2
+    }
+  },
+  {
+    "model": "base.homepage",
+    "pk": 60,
+    "fields": {
+      "image": 9,
+      "hero_text": "A sample site designed to demonstrate the capabilities of the Wagtail Content Management System.",
+      "hero_cta": "Learn more about Wagtail",
+      "hero_cta_link": 76,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><b>Bread</b>\\u00a0is a\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Staple_food\\\">staple food</a>\\u00a0prepared from a\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Dough\\\">dough</a>\\u00a0of\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Flour\\\">flour</a>\\u00a0and\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Water\\\">water</a>, usually by\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Baking\\\">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Agriculture#History\\\">agriculture</a>.</p><p>Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Leaven\\\">leavened</a>\\u00a0by processes such as reliance on naturally occurring\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Sourdough\\\">sourdough</a>\\u00a0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.</p>\"}]",
+      "promo_image": 37,
+      "promo_title": "Our most excellent bread",
+      "promo_text": "<p>There's a lot that we can say about our bread but frankly we think you need to taste it to believe it. Crafted from lines of Python, Django and the old staples of HTML, CSS and JS we think you'll love what we're baking. With our demonstrations across our fair Island you're never far from a treat. Come visit us whenever you're nearby.</p>",
+      "featured_section_1_title": "Breads",
+      "featured_section_1": 3,
+      "featured_section_2_title": "Locations",
+      "featured_section_2": 63,
+      "featured_section_3_title": "Blog",
+      "featured_section_3": 61
+    }
+  },
+  {
+    "model": "base.standardpage",
+    "pk": 76,
+    "fields": {
+      "introduction": "Things to know about this demo site",
+      "image": 41,
+      "body": "[{\"type\": \"paragraph_block\", \"value\": \"<h2>Welcome to the Wagtail Demo Site!</h2><p>If you've gotten this far, congratulations - you're running an instance of a killer content management system written for and on top of Django, <i>the framework for perfectionists with deadlines.</i></p><p>What does Wagtail get you that Django alone does not?\\u00a0</p><p></p><ul><li>Focus on content creators/managers, rather than developers (but developer-friendly!)</li><li>\\\"Page-centric\\\" content modeling</li><li>Beautiful, modern, intuitive user interface optimized for content people</li><li>Super-powerful hierarchical content management (\\\"content trees\\\")</li><li>User- and group-based permissions system attached to content hierarchies</li><li>Flexible image resizing with a ton of image display helpers</li><li>Innovative \\\"<a href=\\\"https://torchbox.com/blog/rich-text-fields-and-faster-horses/\\\">StreamFields</a>\\\" as an alternative to traditional \\\"anything goes\\\" rich text fields</li><li>Intuitive choosers for embedded Pages, Images, Documents and other content</li><li>Native integration with ElasticSearch to help you build powerful search features</li><li>Template tags to help create image renditions, smart links, and to navigate content trees</li></ul><p>If you're new to Wagtail, there are two primary paths to learning:</p><p></p><ul><li>The source code that powers this demo site</li><li>The official <a href=\\\"https://docs.wagtail.org/en/stable/getting_started/index.html\\\">tutorial</a></li></ul><p></p><p></p>\"}]"
+    }
   }
-},
-{
-  "model": "auth.user",
-  "pk": 3,
-  "fields": {
-    "password": "pbkdf2_sha256$30000$eIoVnauBvLhA$aPWJSlHK+F/rW7SKunxJ/RnXNQHx0uh6K/kVRyPn0XY=",
-    "last_login": "2019-04-23T19:58:19.460Z",
-    "is_superuser": true,
-    "username": "admin",
-    "first_name": "Admin",
-    "last_name": "User",
-    "email": "admin@example.com",
-    "is_staff": true,
-    "is_active": true,
-    "date_joined": "2019-02-17T07:37:53.700Z",
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 1,
-  "fields": {
-    "group": [
-      "Moderators"
-    ],
-    "page": 1,
-    "permission_type": "add"
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 2,
-  "fields": {
-    "group": [
-      "Moderators"
-    ],
-    "page": 1,
-    "permission_type": "edit"
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 3,
-  "fields": {
-    "group": [
-      "Moderators"
-    ],
-    "page": 1,
-    "permission_type": "publish"
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 4,
-  "fields": {
-    "group": [
-      "Editors"
-    ],
-    "page": 1,
-    "permission_type": "add"
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 5,
-  "fields": {
-    "group": [
-      "Editors"
-    ],
-    "page": 1,
-    "permission_type": "edit"
-  }
-},
-{
-  "model": "wagtailcore.grouppagepermission",
-  "pk": 6,
-  "fields": {
-    "group": [
-      "Moderators"
-    ],
-    "page": 1,
-    "permission_type": "lock"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 1,
-  "fields": {
-    "path": "0001",
-    "depth": 1,
-    "numchild": 1,
-    "title": "Root",
-    "draft_title": "Root",
-    "slug": "root",
-    "content_type": [
-      "wagtailcore",
-      "page"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": null,
-    "latest_revision_created_at": null
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 3,
-  "fields": {
-    "path": "000100020001",
-    "depth": 3,
-    "numchild": 11,
-    "title": "Breads",
-    "draft_title": "Breads",
-    "slug": "breads",
-    "content_type": [
-      "breads",
-      "breadsindexpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T11:34:11.560Z",
-    "latest_revision_created_at": "2019-03-22T06:54:24.677Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 34,
-  "fields": {
-    "path": "0001000200010003",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Anadama",
-    "draft_title": "Anadama",
-    "slug": "anadama-bread",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/anadama-bread/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:21.882Z",
-    "latest_revision_created_at": "2019-02-25T08:27:47.625Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 35,
-  "fields": {
-    "path": "0001000200010004",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Anpan",
-    "draft_title": "Anpan",
-    "slug": "anpan",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/anpan/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:21.931Z",
-    "latest_revision_created_at": "2019-02-23T08:31:07.640Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 36,
-  "fields": {
-    "path": "0001000200010005",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Appam",
-    "draft_title": "Appam",
-    "slug": "appam-hoppers",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/appam-hoppers/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:21.980Z",
-    "latest_revision_created_at": "2019-02-23T08:14:23.196Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 37,
-  "fields": {
-    "path": "0001000200010006",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Arepa",
-    "draft_title": "Arepa",
-    "slug": "arepa",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/arepa/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.029Z",
-    "latest_revision_created_at": "2019-02-23T08:10:31.068Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 39,
-  "fields": {
-    "path": "0001000200010008",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bagel",
-    "draft_title": "Bagel",
-    "slug": "bagel",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/bagel/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.127Z",
-    "latest_revision_created_at": "2019-02-23T08:01:54.867Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 40,
-  "fields": {
-    "path": "0001000200010009",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Baguette",
-    "draft_title": "Baguette",
-    "slug": "baguette-french-stick-french-bread",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/baguette-french-stick-french-bread/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.180Z",
-    "latest_revision_created_at": "2019-02-23T08:04:51.407Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 42,
-  "fields": {
-    "path": "000100020001000B",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bammy",
-    "draft_title": "Bammy",
-    "slug": "bammy",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/bammy/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.274Z",
-    "latest_revision_created_at": "2019-02-23T08:01:15.242Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 49,
-  "fields": {
-    "path": "000100020001000I",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bazin",
-    "draft_title": "Bazin",
-    "slug": "bazin",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/bazin/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.655Z",
-    "latest_revision_created_at": "2019-02-23T08:28:25.337Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 53,
-  "fields": {
-    "path": "000100020001000M",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bhakri",
-    "draft_title": "Bhakri",
-    "slug": "bhakri",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/bhakri/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:22.866Z",
-    "latest_revision_created_at": "2019-02-23T08:26:10.026Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 57,
-  "fields": {
-    "path": "000100020001000Q",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Black bread",
-    "draft_title": "Black bread",
-    "slug": "black-bread",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/black-bread/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:23.065Z",
-    "latest_revision_created_at": "2019-02-23T08:20:09.645Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 59,
-  "fields": {
-    "path": "000100020001000S",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bolani",
-    "draft_title": "Bolani",
-    "slug": "bolani",
-    "content_type": [
-      "breads",
-      "breadpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/breads/bolani/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T13:00:23.169Z",
-    "latest_revision_created_at": "2019-02-23T08:08:39.568Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 60,
-  "fields": {
-    "path": "00010002",
-    "depth": 2,
-    "numchild": 6,
-    "title": "Welcome to the Wagtail Bakery!",
-    "draft_title": "Welcome to the Wagtail Bakery!",
-    "slug": "home",
-    "content_type": [
-      "base",
-      "homepage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/",
-    "owner": null,
-    "seo_title": "Home",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T16:24:31.388Z",
-    "latest_revision_created_at": "2019-03-29T18:24:51.618Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 61,
-  "fields": {
-    "path": "000100020004",
-    "depth": 3,
-    "numchild": 6,
-    "title": "Blog",
-    "draft_title": "Blog",
-    "slug": "blog",
-    "content_type": [
-      "blog",
-      "blogindexpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/blog/",
-    "owner": null,
-    "seo_title": "Wagtail Bakeries Blog",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T16:25:47.179Z",
-    "latest_revision_created_at": "2019-04-23T20:04:30.432Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 62,
-  "fields": {
-    "path": "0001000200040001",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Tracking Wild Yeast",
-    "draft_title": "Tracking Wild Yeast",
-    "slug": "wild-yeast",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": true,
-    "url_path": "/home/blog/wild-yeast/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T16:26:58.040Z",
-    "latest_revision_created_at": "2019-04-01T07:35:45.288Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 63,
-  "fields": {
-    "path": "000100020003",
-    "depth": 3,
-    "numchild": 6,
-    "title": "Locations",
-    "draft_title": "Locations",
-    "slug": "locations",
-    "content_type": [
-      "locations",
-      "locationsindexpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T16:39:04.527Z",
-    "latest_revision_created_at": "2019-03-06T02:26:16.335Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 64,
-  "fields": {
-    "path": "0001000200030001",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Hof",
-    "draft_title": "Hof",
-    "slug": "new-york",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/new-york/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-10T16:39:55.909Z",
-    "latest_revision_created_at": "2019-03-29T17:50:19.047Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 65,
-  "fields": {
-    "path": "0001000200030002",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Reykjavik",
-    "draft_title": "Reykjavik",
-    "slug": "reykjavik",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/reykjavik/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-11T23:10:22.386Z",
-    "latest_revision_created_at": "2019-03-29T17:33:10.041Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 66,
-  "fields": {
-    "path": "0001000200030003",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Vik",
-    "draft_title": "Vik",
-    "slug": "london",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/london/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-11T23:13:20.488Z",
-    "latest_revision_created_at": "2019-03-29T18:03:09.098Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 67,
-  "fields": {
-    "path": "0001000200030004",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Selfoss",
-    "draft_title": "Selfoss",
-    "slug": "wellington",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/wellington/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-11T23:15:58.149Z",
-    "latest_revision_created_at": "2019-03-29T17:29:33.457Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 68,
-  "fields": {
-    "path": "0001000200040002",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Bread and Circuses",
-    "draft_title": "Bread and Circuses",
-    "slug": "bread-circuses",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/blog/bread-circuses/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-15T07:42:52.978Z",
-    "latest_revision_created_at": "2019-03-29T06:19:57.009Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 69,
-  "fields": {
-    "path": "000100020006",
-    "depth": 3,
-    "numchild": 0,
-    "title": "Contact Us",
-    "draft_title": "Contact Us",
-    "slug": "contact-us",
-    "content_type": [
-      "base",
-      "formpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/contact-us/",
-    "owner": null,
-    "seo_title": "",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-15T16:55:56.085Z",
-    "latest_revision_created_at": "2019-02-15T17:08:05.684Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 70,
-  "fields": {
-    "path": "000100020005",
-    "depth": 3,
-    "numchild": 0,
-    "title": "Gallery",
-    "draft_title": "Gallery",
-    "slug": "gallery",
-    "content_type": [
-      "base",
-      "gallerypage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/gallery/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-17T07:51:47.230Z",
-    "latest_revision_created_at": "2019-02-22T07:57:12.151Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 72,
-  "fields": {
-    "path": "0001000200040003",
-    "depth": 4,
-    "numchild": 0,
-    "title": "The Great Icelandic Baking Show",
-    "draft_title": "The Great Icelandic Baking Show",
-    "slug": "icelandic-baking",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/blog/icelandic-baking/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-21T08:07:11.832Z",
-    "latest_revision_created_at": "2019-03-29T06:52:34.448Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 73,
-  "fields": {
-    "path": "0001000200040004",
-    "depth": 4,
-    "numchild": 0,
-    "title": "The Joy of (Baking) Soda",
-    "draft_title": "The Joy of (Baking) Soda",
-    "slug": "joy-baking-soda",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/blog/joy-baking-soda/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-21T08:12:04.176Z",
-    "latest_revision_created_at": "2019-03-29T06:58:56.151Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 74,
-  "fields": {
-    "path": "0001000200040005",
-    "depth": 4,
-    "numchild": 0,
-    "title": "The Greatest Thing Since Sliced Bread",
-    "draft_title": "The Greatest Thing Since Sliced Bread",
-    "slug": "sliced-bread",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": true,
-    "url_path": "/home/blog/sliced-bread/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-21T08:17:21.604Z",
-    "latest_revision_created_at": "2019-04-01T07:35:26.199Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 76,
-  "fields": {
-    "path": "000100020007",
-    "depth": 3,
-    "numchild": 0,
-    "title": "About",
-    "draft_title": "About",
-    "slug": "about",
-    "content_type": [
-      "base",
-      "standardpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/about/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": true,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-03-17T07:03:16.637Z",
-    "latest_revision_created_at": "2019-03-17T07:47:50.894Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 77,
-  "fields": {
-    "path": "0001000200040006",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Desserts with Benefits",
-    "draft_title": "Desserts with Benefits",
-    "slug": "desserts-benefits",
-    "content_type": [
-      "blog",
-      "blogpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/blog/desserts-benefits/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-03-22T06:31:05.324Z",
-    "latest_revision_created_at": "2019-04-23T20:03:47.050Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 78,
-  "fields": {
-    "path": "0001000200030005",
-    "depth": 4,
-    "numchild": 0,
-    "title": "H\u00f6fn",
-    "draft_title": "H\u00f6fn",
-    "slug": "hofn",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/hofn/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-11T23:10:22.386Z",
-    "latest_revision_created_at": "2019-03-29T18:05:47.930Z"
-  }
-},
-{
-  "model": "wagtailcore.page",
-  "pk": 79,
-  "fields": {
-    "path": "0001000200030006",
-    "depth": 4,
-    "numchild": 0,
-    "title": "Akranes",
-    "draft_title": "Akranes",
-    "slug": "akranes",
-    "content_type": [
-      "locations",
-      "locationpage"
-    ],
-    "live": true,
-    "has_unpublished_changes": false,
-    "url_path": "/home/locations/akranes/",
-    "owner": [
-      "admin"
-    ],
-    "seo_title": "",
-    "show_in_menus": false,
-    "search_description": "",
-    "go_live_at": null,
-    "expire_at": null,
-    "expired": false,
-    "locked": false,
-    "first_published_at": "2019-02-11T23:10:22.386Z",
-    "latest_revision_created_at": "2019-03-29T18:09:44.290Z"
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 8,
-  "fields": {
-    "collection": 3,
-    "title": "Roberta Johnson",
-    "file": "original_images/roberta_johnson.jpeg",
-    "width": 300,
-    "height": 282,
-    "created_at": "2019-02-17T07:43:46.304Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 17829
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 9,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 1",
-    "file": "original_images/breads1.jpg",
-    "width": 1080,
-    "height": 831,
-    "created_at": "2019-02-17T08:10:34.237Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 173675
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 10,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 2",
-    "file": "original_images/breads2.jpg",
-    "width": 1080,
-    "height": 1151,
-    "created_at": "2019-02-17T08:10:34.344Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 506419
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 11,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 3",
-    "file": "original_images/breads3.jpg",
-    "width": 1080,
-    "height": 1080,
-    "created_at": "2019-02-17T08:10:34.580Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 166505
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 12,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 4",
-    "file": "original_images/breads4.jpg",
-    "width": 1080,
-    "height": 1240,
-    "created_at": "2019-02-17T08:10:34.723Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 174743
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 14,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 5",
-    "file": "original_images/bread5.jpg",
-    "width": 800,
-    "height": 600,
-    "created_at": "2019-02-19T08:08:37.723Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 127107
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 15,
-  "fields": {
-    "collection": 2,
-    "title": "Breads 6",
-    "file": "original_images/bread6.jpg",
-    "width": 1008,
-    "height": 756,
-    "created_at": "2019-02-19T08:08:38.028Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 247052
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 21,
-  "fields": {
-    "collection": 2,
-    "title": "Yeast",
-    "file": "original_images/yeast.jpg",
-    "width": 1024,
-    "height": 682,
-    "created_at": "2019-02-21T07:50:10.793Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 122348
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 22,
-  "fields": {
-    "collection": 2,
-    "title": "Bedouins",
-    "file": "original_images/Bedouins_making_bread.jpg",
-    "width": 1000,
-    "height": 669,
-    "created_at": "2019-02-21T07:59:50.671Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 408107
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 23,
-  "fields": {
-    "collection": 2,
-    "title": "\u00d8landshvedebr\u00f8d",
-    "file": "original_images/Olandshvedebrod_6082070226.jpg",
-    "width": 1000,
-    "height": 664,
-    "created_at": "2019-02-21T08:05:08.529Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 137708
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 24,
-  "fields": {
-    "collection": 2,
-    "title": "Soda Bread",
-    "file": "original_images/soda_bread.jpg",
-    "width": 733,
-    "height": 481,
-    "created_at": "2019-02-21T08:10:30.772Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 73964
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 25,
-  "fields": {
-    "collection": 2,
-    "title": "Sandwich Bread",
-    "file": "original_images/sliced.jpg",
-    "width": 1024,
-    "height": 677,
-    "created_at": "2019-02-21T08:15:16.080Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 297826
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 26,
-  "fields": {
-    "collection": 4,
-    "title": "Anadama_bread",
-    "file": "original_images/Anadama_bread_1.jpg",
-    "width": 1200,
-    "height": 800,
-    "created_at": "2019-02-23T07:48:33.730Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 72910
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 28,
-  "fields": {
-    "collection": 4,
-    "title": "Appam",
-    "file": "original_images/Appam_served_with_Coconut_Milk_in_Tamil_Nadu.JPG",
-    "width": 1200,
-    "height": 541,
-    "created_at": "2019-02-23T07:48:34.056Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 79398
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 29,
-  "fields": {
-    "collection": 4,
-    "title": "Arepa",
-    "file": "original_images/Arepa_asada.JPG",
-    "width": 1200,
-    "height": 900,
-    "created_at": "2019-02-23T07:48:34.189Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 56891
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 30,
-  "fields": {
-    "collection": 4,
-    "title": "Bagel",
-    "file": "original_images/Bagel.jpg",
-    "width": 1200,
-    "height": 1038,
-    "created_at": "2019-02-23T07:48:34.296Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 104030
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 31,
-  "fields": {
-    "collection": 4,
-    "title": "Baguette",
-    "file": "original_images/Baguette_de_pain_WikiCheese_Lausanne.jpg",
-    "width": 1200,
-    "height": 583,
-    "created_at": "2019-02-23T07:48:34.417Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 41014
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 32,
-  "fields": {
-    "collection": 4,
-    "title": "Bammies",
-    "file": "original_images/Bammies.jpg",
-    "width": 1200,
-    "height": 1078,
-    "created_at": "2019-02-23T07:48:34.498Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 137317
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 33,
-  "fields": {
-    "collection": 4,
-    "title": "Bazin",
-    "file": "original_images/Bazin.jpg",
-    "width": 1200,
-    "height": 900,
-    "created_at": "2019-02-23T07:48:34.571Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 112991
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 34,
-  "fields": {
-    "collection": 4,
-    "title": "Bunanpankatori",
-    "file": "original_images/Bean-jam-bunanpankatori-cityjapan.JPG",
-    "width": 800,
-    "height": 640,
-    "created_at": "2019-02-23T07:48:34.650Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 60721
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 35,
-  "fields": {
-    "collection": 4,
-    "title": "Belgian Waffle",
-    "file": "original_images/Belgische_waffeln.jpg",
-    "width": 1200,
-    "height": 910,
-    "created_at": "2019-02-23T07:48:34.735Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 151259
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 36,
-  "fields": {
-    "collection": 4,
-    "title": "Afghan Bolani",
-    "file": "original_images/Bolani_Afghan_bread_01.jpg",
-    "width": 1280,
-    "height": 960,
-    "created_at": "2019-02-23T07:48:34.809Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 104969
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 37,
-  "fields": {
-    "collection": 4,
-    "title": "Misc Breads",
-    "file": "original_images/Breads_1.jpg",
-    "width": 1200,
-    "height": 796,
-    "created_at": "2019-02-23T07:48:34.909Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 167917
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 39,
-  "fields": {
-    "collection": 4,
-    "title": "Rye Bread",
-    "file": "original_images/Sourdough_rye_with_walnuts.jpg",
-    "width": 1200,
-    "height": 773,
-    "created_at": "2019-02-23T08:18:10.895Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 213288
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 40,
-  "fields": {
-    "collection": 4,
-    "title": "Bhakri",
-    "file": "original_images/Bhakri_1.jpg",
-    "width": 1200,
-    "height": 900,
-    "created_at": "2019-02-23T08:25:03.822Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 193665
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 41,
-  "fields": {
-    "collection": 3,
-    "title": "Sprint Crew",
-    "file": "original_images/sprint_crew.jpg",
-    "width": 1000,
-    "height": 750,
-    "created_at": "2019-02-24T08:01:50.590Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 121235
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 42,
-  "fields": {
-    "collection": 3,
-    "title": "Baking Soda",
-    "file": "original_images/bakingsoda.jpg",
-    "width": 1024,
-    "height": 678,
-    "created_at": "2019-03-22T06:13:09.773Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 87095
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 43,
-  "fields": {
-    "collection": 3,
-    "title": "Boston Cream Pie",
-    "file": "original_images/bostoncream.jpg",
-    "width": 1024,
-    "height": 683,
-    "created_at": "2019-03-22T06:29:18.751Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 117057
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 44,
-  "fields": {
-    "collection": 1,
-    "title": "Image by \u00c6var Gu\u00f0mundsson",
-    "file": "original_images/aevar-gudmundsson-selfoss.jpg",
-    "width": 1400,
-    "height": 932,
-    "created_at": "2019-03-29T17:27:55.769Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 167793
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 45,
-  "fields": {
-    "collection": 1,
-    "title": "Image by Sverrir Thorolfsson",
-    "file": "original_images/reykjavik-sverrir-thorolfsson.jpg",
-    "width": 992,
-    "height": 971,
-    "created_at": "2019-03-29T17:31:36.429Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 206071
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 46,
-  "fields": {
-    "collection": 1,
-    "title": "Glacier descending near Hof",
-    "file": "original_images/hof-cornell-university-filter.jpg",
-    "width": 1200,
-    "height": 948,
-    "created_at": "2019-03-29T17:46:14.914Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": 518,
-    "focal_point_y": 248,
-    "focal_point_width": 1031,
-    "focal_point_height": 496,
-    "file_size": 279068
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 47,
-  "fields": {
-    "collection": 1,
-    "title": "Old buildings above Vik",
-    "file": "original_images/vik.jpg",
-    "width": 1400,
-    "height": 981,
-    "created_at": "2019-03-29T18:00:33.977Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 207895
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 48,
-  "fields": {
-    "collection": 1,
-    "title": "Höfn from above",
-    "file": "original_images/Hofn.jpg",
-    "width": 1200,
-    "height": 800,
-    "created_at": "2019-03-29T18:04:27.068Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 369123
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 49,
-  "fields": {
-    "collection": 1,
-    "title": "Akranes",
-    "file": "original_images/Akranes.jpg",
-    "width": 1200,
-    "height": 800,
-    "created_at": "2019-03-29T18:08:27.770Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": 578,
-    "focal_point_y": 476,
-    "focal_point_width": 1031,
-    "focal_point_height": 537,
-    "file_size": 225856
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 51,
-  "fields": {
-    "collection": 3,
-    "title": "Muddy Waters",
-    "file": "original_images/muddy_waters_hUPkmSW.jpg",
-    "width": 611,
-    "height": 672,
-    "created_at": "2019-03-31T06:36:23.486Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 189650
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 52,
-  "fields": {
-    "collection": 3,
-    "title": "Olivia Ava",
-    "file": "original_images/olivia_ava.jpeg",
-    "width": 300,
-    "height": 294,
-    "created_at": "2019-04-01T07:30:10.713Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 46112
-  }
-},
-{
-  "model": "wagtailimages.image",
-  "pk": 53,
-  "fields": {
-    "collection": 3,
-    "title": "Lightnin' Hopkins",
-    "file": "original_images/lightnin_hopkins.jpg",
-    "width": 150,
-    "height": 162,
-    "created_at": "2019-04-01T07:31:21.251Z",
-    "uploaded_by_user": [
-      "admin"
-    ],
-    "focal_point_x": null,
-    "focal_point_y": null,
-    "focal_point_width": null,
-    "focal_point_height": null,
-    "file_size": 18521
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 64,
-  "fields": {
-    "introduction": "Pie gingerbread cake caramels chocolate cake tiramisu wafer. Gummi bears chupa chups chocolate. Topping chupa chups bonbon cake pie caramels. Pie gingerbread cake caramels chocolate cake tiramisu wafer.",
-    "image": 46,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Chocolate bar I love marzipan chupa chups souffl\\u00e9 chocolate bar. Biscuit caramels lollipop cookie. Macaroon I love tart pudding topping I love. Jujubes macaroon gummies pudding icing cake pastry. Candy canes candy chocolate cake I love chocolate carrot cake halvah. I love croissant I love donut. Chocolate sweet chocolate cake cotton candy souffl\\u00e9 caramels pie tiramisu I love. Lemon drops topping caramels. Pudding candy cotton candy gingerbread jelly beans jelly-o tiramisu cotton candy souffl\\u00e9. Cake bear claw cupcake pastry gummi bears cake.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"Never say no to more\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Muffin wafer chocolate cake bonbon icing chupa chups cupcake. Pudding drag\\u00e9e souffl\\u00e9 icing caramels chupa chups sweet muffin. Pastry fruitcake pastry dessert chupa chups. Sugar plum wafer chupa chups tootsie roll candy chocolate bar souffl\\u00e9 sesame snaps jelly-o. Dessert macaroon jelly fruitcake jujubes marshmallow cake. Gummies souffl\\u00e9 cotton candy candy pastry powder topping muffin cotton candy. I love jelly beans I love I love chocolate cake fruitcake oat cake drag\\u00e9e dessert.</p><p>Chupa chups marzipan pie caramels cotton candy jelly-o. Pie sweet cake souffl\\u00e9 apple pie cake. Chocolate cake chupa chups bear claw cotton candy. I love marshmallow chocolate sweet I love. Drag\\u00e9e donut cotton candy jujubes ice cream. Marshmallow gummies gingerbread marzipan. Caramels tootsie roll cake. Macaroon chocolate liquorice ice cream. Candy biscuit chupa chups chocolate cake cake danish. Sesame snaps I love macaroon cupcake bear claw chocolate cake I love candy canes.</p>\"}]",
-    "address": "Hof 2,\r\nL\u00e6kjarh\u00fas,\r\n785 \u00d6r\u00e6fi,\r\nIceland",
-    "lat_long": "63.9095213,-16.7093877"
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 65,
-  "fields": {
-    "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
-    "image": 45,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
-    "address": "Laugavegur 36,\r\n101 Reykjav\u00edk,\r\nIceland",
-    "lat_long": "64.144018, -21.950953"
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 66,
-  "fields": {
-    "introduction": "Chocolate bar tiramisu toffee. Topping pie powder candy canes jujubes liquorice. Apple pie muffin marshmallow tiramisu powder cotton candy topping. Apple pie tiramisu marshmallow sesame snaps.",
-    "image": 47,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Cupcake ipsum dolor sit. Amet cake bear claw cheesecake marshmallow donut topping. Bonbon tootsie roll tiramisu drag\\u00e9e. Sweet macaroon gummies tootsie roll toffee cupcake jujubes gingerbread. Chocolate bar cupcake danish muffin donut cookie souffl\\u00e9 carrot cake. Cake cake macaroon muffin sesame snaps marzipan apple pie cheesecake.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"Now with sugar\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Chocolate caramels cupcake jelly beans icing gummi bears fruitcake gingerbread. Cupcake drag\\u00e9e tootsie roll cheesecake chocolate. Jelly lemon drops lemon drops chocolate. Sesame snaps chocolate bar cheesecake tiramisu gummi bears sweet sesame snaps wafer. Pie cake macaroon sugar plum toffee icing. Bonbon sweet roll cupcake sesame snaps toffee candy fruitcake.</p><p>Cupcake cupcake souffl\\u00e9 jelly beans chocolate cake lemon drops. Dessert chocolate bar cotton candy. Pastry icing oat cake wafer. Marshmallow topping gummies cotton candy cake gingerbread. Donut macaroon carrot cake. Pie candy canes cupcake powder marzipan. Sweet oat cake jelly beans apple pie ice cream. Brownie caramels chupa chups marzipan. Biscuit biscuit croissant fruitcake pastry pastry.</p>\"}]",
-    "address": "Klettsvegi 1,\r\n870 V\u00edk,\r\nIceland",
-    "lat_long": "63.419061,-19.0064982"
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 67,
-  "fields": {
-    "introduction": "Gummies dessert cake pastry jujubes cotton candy apple pie chocolate bar muffin. Bonbon souffl\u00e9 icing brownie cheesecake candy canes. Sesame snaps chocolate pudding souffl\u00e9 powder pastry pastry jelly beans. Chocolate cake caramels gingerbread bear claw gingerbread jelly-o.",
-    "image": 44,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Jelly-o marzipan fruitcake. Candy marshmallow candy canes macaroon marshmallow marshmallow sesame snaps. Cookie croissant wafer jelly beans. Bonbon sesame snaps danish chocolate bar. Pudding marzipan tootsie roll lollipop sesame snaps souffl\\u00e9 fruitcake. Tootsie roll jujubes cookie chocolate topping cupcake. Pudding cake gummies chupa chups jelly beans gingerbread sesame snaps gummi bears gummies. Chocolate chupa chups jelly candy canes carrot cake croissant ice cream. Bonbon sugar plum jelly beans cake tiramisu. Carrot cake gummies carrot cake macaroon wafer cake cupcake.</p><p>Jelly-o candy canes macaroon chocolate cake cheesecake cake lollipop cookie. Halvah candy topping sugar plum topping sesame snaps cotton candy topping. Sesame snaps brownie chocolate cake. Lemon drops sweet roll cookie drag\\u00e9e chocolate bar sugar plum jelly-o. Liquorice toffee jujubes chocolate cake cheesecake biscuit. Marshmallow chocolate bar oat cake wafer souffl\\u00e9 brownie fruitcake. Oat cake icing cheesecake liquorice caramels.</p>\"}, {\"type\": \"heading_block\", \"value\": {\"heading_text\": \"An awesome heading\", \"size\": \"h3\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Brownie marzipan marshmallow tart pudding carrot cake. Cheesecake jelly beans gingerbread lollipop. Marshmallow tiramisu jelly beans apple pie gingerbread candy bonbon carrot cake. Pastry candy gummies danish pudding topping. Tart jelly-o chocolate wafer pastry brownie chocolate bar oat cake. Cookie sugar plum liquorice jelly beans. Sweet jujubes candy canes sweet chocolate chocolate cookie chocolate cookie. Cookie pudding toffee tart.</p>\"}]",
-    "address": "Eyravegur,\r\n800 Selfoss,\r\nIceland",
-    "lat_long": "63.9375899, -21.0419085"
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 78,
-  "fields": {
-    "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
-    "image": 48,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
-    "address": "Hafnarbraut,\r\n780 H\u00f6fn \u00ed Hornafir\u00f0i,\r\nIceland",
-    "lat_long": "64.2518583,-15.2037097"
-  }
-},
-{
-  "model": "locations.locationpage",
-  "pk": 79,
-  "fields": {
-    "introduction": "Ice cream pie tiramisu carrot cake pie macaroon brownie wafer. Cupcake cookie cotton candy jelly-o macaroon tootsie roll ice cream. Biscuit caramels apple pie. Marshmallow lollipop gingerbread chocolate powder ice cream tootsie roll.",
-    "image": 49,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><br/></p><p>Gingerbread jujubes pudding lollipop cake sweet pudding biscuit. Dessert sweet roll gummies. Pudding jujubes powder macaroon. Lollipop sweet roll jelly-o tiramisu chupa chups marzipan tart cookie. Macaroon tootsie roll lemon drops. Fruitcake macaroon liquorice bonbon chocolate bar caramels donut pastry. Wafer candy canes jujubes powder gummi bears candy canes biscuit pastry oat cake. Halvah pastry lemon drops gummi bears lemon drops powder. Tart lollipop bonbon apple pie sugar plum gummies cake.</p><p>Souffl\\u00e9 sweet roll caramels toffee. Ice cream cotton candy jelly-o sweet roll sugar plum dessert chupa chups. Drag\\u00e9e ice cream chocolate cake candy canes sugar plum pudding cheesecake. Tart jelly beans liquorice ice cream gummi bears lollipop tiramisu. Ice cream pie sweet roll liquorice. Tiramisu jujubes lollipop chocolate tiramisu. Cotton candy jelly cake lemon drops lollipop. Tootsie roll chocolate bar jelly-o cookie wafer cookie toffee pastry. Sugar plum chocolate bar jelly beans gummies jujubes sweet chocolate cake.</p><p></p>\"}]",
-    "address": "Skagabraut 43,\r\n300 Akranes,\r\nIceland",
-    "lat_long": "64.3214253,-22.0674947"
-  }
-},
-{
-  "model": "locations.locationsindexpage",
-  "pk": 63,
-  "fields": {
-    "introduction": "You can find our fine bakeries in friendly cities all over the world.",
-    "image": 10
-  }
-},
-{
-  "model": "breads.breadsindexpage",
-  "pk": 3,
-  "fields": {
-    "introduction": "We feature outlandishly delicious breads sourced from every continent (except Antarctica)",
-    "image": 9
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 34,
-  "fields": {
-    "introduction": "It is not readily agreed exactly when or where the bread originated, except it existed before 1850 in Rockport, Massachusetts. It is thought to have come from the local fishing community, but it may have come through the Finnish community of local stonecutters.",
-    "image": 26,
-    "body": "[]",
-    "origin": 3,
-    "bread_type": 4,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 35,
-  "fields": {
-    "introduction": "Anpan was first made in 1875, during the Meiji period, by a man called Yasubei Kimura, a samurai who lost his job with the rise of the conscript Imperial Army and the dissolution of the samurai as a social class.",
-    "image": 34,
-    "body": "[]",
-    "origin": 4,
-    "bread_type": 5,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 36,
-  "fields": {
-    "introduction": "Appam is a type of pancake made with fermented rice batter and coconut milk. It is a common food in Kerala, Tamil Nadu and Sri Lanka. It is eaten most frequently for breakfast or dinner.",
-    "image": 28,
-    "body": "[]",
-    "origin": 5,
-    "bread_type": 6,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 37,
-  "fields": {
-    "introduction": "Arepa  is a type of food made of ground maize dough or cooked flour prominent in the cuisine of Colombia and Venezuela.",
-    "image": 29,
-    "body": "[]",
-    "origin": 6,
-    "bread_type": 7,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 39,
-  "fields": {
-    "introduction": "Though the origins of bagels are somewhat obscure, it is known that they were widely consumed in eastern European Jewish communities from the 17th century.",
-    "image": 30,
-    "body": "[]",
-    "origin": 8,
-    "bread_type": 4,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 40,
-  "fields": {
-    "introduction": "A baguette has a diameter of about 5 or 6 centimetres  and a usual length of about 65 centimetres (26 in), although a baguette can be up to a metre (39 in) long.",
-    "image": 31,
-    "body": "[]",
-    "origin": 9,
-    "bread_type": 4,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 42,
-  "fields": {
-    "introduction": "Bammies, like wheat bread and tortillas, are served at any meal or consumed as a snack.",
-    "image": 32,
-    "body": "[]",
-    "origin": 11,
-    "bread_type": 2,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 49,
-  "fields": {
-    "introduction": "When consumed, bazin may be \"crumpled and eaten with the fingers.\"",
-    "image": 33,
-    "body": "[]",
-    "origin": 18,
-    "bread_type": 11,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 53,
-  "fields": {
-    "introduction": "Bhakri  is a round flat unleavened bread often used in the cuisine of the state of mainly Maharashtra, but also in Gujarat.",
-    "image": 40,
-    "body": "[]",
-    "origin": 21,
-    "bread_type": 14,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 57,
-  "fields": {
-    "introduction": "Rye bread is a type of bread made with various proportions of flour from rye grain",
-    "image": 39,
-    "body": "[]",
-    "origin": 12,
-    "bread_type": 16,
-    "ingredients": []
-  }
-},
-{
-  "model": "breads.breadpage",
-  "pk": 59,
-  "fields": {
-    "introduction": "Perakai is made for special occasions like birthday parties, engagement parties or holidays.",
-    "image": 36,
-    "body": "[]",
-    "origin": 24,
-    "bread_type": 2,
-    "ingredients": []
-  }
-},
-{
-  "model": "blog.blogindexpage",
-  "pk": 61,
-  "fields": {
-    "introduction": "Welcome to our blog",
-    "image": 11
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 62,
-  "fields": {
-    "introduction": "Yeasts, with their single-celled growth habit, can be contrasted with molds, which grow hyphae. Fungal species that can take both forms (depending on temperature or other conditions) are called dimorphic fungi (\"dimorphic\" means \"having two forms\").",
-    "image": 21,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Yeasts are eukaryotic, single-celled microorganisms classified as members of the fungus kingdom. The yeast lineage[which?] originated hundreds of millions of years ago, and 1,500 species are currently identified.[1][2][3] They are estimated to constitute 1% of all described fungal species.[4] Yeasts are unicellular organisms which evolved from multicellular ancestors,[5] with some species having the ability to develop multicellular characteristics by forming strings of connected budding cells known as pseudohyphae or false hyphae.[6] Yeast sizes vary greatly, depending on species and environment, typically measuring 3\\u20134 \\u00b5m in diameter, although some yeasts can grow to 40 \\u00b5m in size.[7] Most yeasts reproduce asexually by mitosis, and many do so by the asymmetric division process known as budding.</p><h3>Contrast with Molds</h3><p>Yeasts, with their single-celled growth habit, can be contrasted with molds, which grow hyphae. Fungal species that can take both forms (depending on temperature or other conditions) are called dimorphic fungi (\\\"dimorphic\\\" means \\\"having two forms\\\").<br/></p><p>By fermentation, the yeast species Saccharomyces cerevisiae converts carbohydrates to carbon dioxide and alcohols \\u2013 for thousands of years the carbon dioxide has been used in baking and the alcohol in alcoholic beverages.[8] It is also a centrally important model organism in modern cell biology research, and is one of the most thoroughly researched eukaryotic microorganisms. Researchers have used it to gather information about the biology of the eukaryotic cell and ultimately human biology.[9] Other species of yeasts, such as Candida albicans, are opportunistic pathogens and can cause infections in humans. Yeasts have recently been used to generate electricity in microbial fuel cells,[10] and produce ethanol for the biofuel industry.<br/></p><p>Yeasts do not form a single taxonomic or phylogenetic grouping. The term \\\"yeast\\\" is often taken as a synonym for Saccharomyces cerevisiae,[11] but the phylogenetic diversity of yeasts is shown by their placement in two separate phyla: the Ascomycota and the Basidiomycota. The budding yeasts (\\\"true yeasts\\\") are classified in the order Saccharomycetales,[12] within the phylum Ascomycota.<br/></p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 39, \"attribution\": \"Creative Commons\", \"caption\": \"Raised Yummy\"}}]",
-    "subtitle": "The art of cultivating yeast",
-    "date_published": "2019-01-12"
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 68,
-  "fields": {
-    "introduction": "Baking is a method of cooking food that uses prolonged dry heat, normally in an oven, but also in hot ashes, or on hot stones. The most common baked item is bread but many other types of foods are baked.",
-    "image": 22,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Heat is <b>gradually</b> transferred \\\"from the surface of cakes, cookies, and breads to their centre. As heat travels through it transforms batters and doughs into baked goods with a firm dry crust and a softer centre\\\".[2] Baking can be combined with grilling to produce a hybrid barbecue variant by using both methods simultaneously, or one after the other. Baking is related to barbecuing because the concept of the masonry oven is similar to that of a smoke pit.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 24, \"attribution\": \"Creative Commons\", \"caption\": \"Soda Bread\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Because of historical social and familial roles,\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Baking\\\">baking</a>\\u00a0has traditionally been performed at home by women for domestic consumption and by men in bakeries and restaurants for local consumption. When production was industrialized, baking was automated by machines in large factories. The art of baking remains a fundamental skill and is important for nutrition, as baked goods, especially breads, are a common but important food, both from an economic and cultural point of view. A person who prepares baked goods as a profession is called a baker.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 12, \"attribution\": \"\", \"caption\": \"\"}}]",
-    "subtitle": "The art of baking",
-    "date_published": "2019-02-14"
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 72,
-  "fields": {
-    "introduction": "Nordic bread culture has existed in Denmark, Finland, Norway, and Sweden from prehistoric time through to the present.",
-    "image": 23,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Four grain types dominated in the Nordic countries: barley and rye are the oldest; wheat and oats are more recent. During the Iron Age (500 AD \\u2013 1050 AD), rye became the most commonly used grain, followed by barley and oats. Rye was also the most commonly used grain for bread up until the beginning of the 20th century. Today, older grain types such as emmer and spelt are once again being cultivated and new bread types are being developed from these grains.</p><p>Archaeological finds in Denmark indicate use of the two triticum (wheat) species, emmer and einkorn, during the Mesolithic Period (8900 BC \\u2013 3900 BC). There is no direct evidence of bread-making, but cereals have been crushed, cooked and served as porridge since at least 4,200 BC. During the Neolithic Period (3900 BC \\u2013 1800 BC), when agriculture was introduced, barley seems to have taken over to some extent, and ceramic plates apparently used for baking are found. Moulded cereals, with water added to make a dough and baked or fried in the shape of bread, are known as burial gifts in Iron Age graves (200 AD onwards) in the M\\u00e4lardalen area of central Sweden. However, it is not certain that this bread was eaten; it could just have been a burial gift. During the Bronze Age (1800 BC \\u2013 500 AD), oats and the triticum species spelt seem to have been the most commonly used grains, and we see the first real ovens, probably used for baking small loaves and perhaps the first bread (probably around 400 AD).</p><p><br/></p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 42, \"attribution\": \"Creative Commons\", \"caption\": \"Baking Soda\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Scandinavian soldiers in Roman times apparently learned baking techniques when working as mercenaries in the Roman army (200\\u2013400 AD). They subsequently took the technique home with them to show that they had been employed in high status work on the continent[citation needed]. Early Christian traditions promoted an interest in bread. Culturally, German traditions have influenced most of the bread types in the Nordic countries. In the eastern part of Finland, there is a cultural link to Russia and Slavic bread traditions.</p><p>In the Nordic countries, bread was the main part of a meal until the late 18th century. Four different bread regions can be found in the Nordic area in the late 19th century. In the south, soft rye bread dominated. Further north came crisp bread, usually baked with rye, then thin and crispy barley bread. In the far north, soft barley loaves dominated. During the 19th century, potatoes began to become the centrepiece of meals and bread was put aside as an extra source of carbohydrates in a meal. Bread still retained its key function for breakfast, as the open sandwich is a starter for most Nordic people today and potatoes are used as a centrepiece in lunches and dinners.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 14, \"attribution\": \"Creative Commons\", \"caption\": \"Fresh baked\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>A history of Nordic bread from around 1000 AD and some contemporary types and bread innovations is presented below. Countries are presented in alphabetic order (Denmark, Finland, Iceland, Norway and Sweden). The names of the bread types are mostly given in both the contemporary national language and in English.</p>\"}]",
-    "subtitle": "Viking bakeries and Norse donuts",
-    "date_published": "2019-03-21"
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 73,
-  "fields": {
-    "introduction": "During the early years of European settlement of the Americas, settlers and some groups of Indigenous peoples of the Americas used soda or pearl ash, more commonly known as potash (pot ash) or potassium carbonate, as a leavening agent (the forerunner to baking soda) in quick breads.",
-    "image": 42,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Since it has long been known and is widely used, the salt has many related names such as baking soda, bread soda, cooking soda, and bicarbonate of soda. In colloquial usage, the names sodium bicarbonate and bicarbonate of soda are often truncated. Forms such as sodium bicarb, bicarb soda, bicarbonate, bicarb, or even bica are common. The word saleratus, from Latin <i>sal \\u00e6ratus</i> meaning \\\"aerated salt\\\", was widely used in the 19th century for both sodium bicarbonate and potassium bicarbonate.</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 15, \"attribution\": \"Creative Commons\", \"caption\": \"Fresh baked\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>The prefix, bi, in bicarbonate comes from an outdated naming system and is based on the observation that there is twice as much carbonate (CO3) per sodium in\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Sodium_bicarbonate\\\">sodium bicarbonate</a>\\u00a0(NaHCO3) as there is carbonate per sodium in sodium carbonate (Na2CO3) and other carbonates. The modern way of analyzing the situation based on the exact chemical composition (which was unknown when the name sodium bicarbonate was coined) says this the other way around: there is half as much sodium in NaHCO3 as in Na2CO3 (Na versus Na2).</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 37, \"attribution\": \"Creative Commons\", \"caption\": \"Cornucopia of Breads\"}}]",
-    "subtitle": "The ingredients of traditional soda bread are flour, bread soda, salt, and buttermilk.",
-    "date_published": "2019-02-08"
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 74,
-  "fields": {
-    "introduction": "Sandwich bread (also referred to as sandwich loaf)  is bread that is prepared specifically to be used for the preparation of sandwiches.",
-    "image": 25,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Sandwich breads are produced in many varieties, such as white, whole wheat, sourdough, rye, multigrain and others. Sandwich bread may be formulated to slice easily,[8] cleanly or uniformly, and may have a fine crumb (the soft, inner part of bread) and a light texture.[4] Sandwich bread may be designed to have a balanced proportion of crumb and crust, whereby the bread holds and supports fillings in place and reduces drips and messiness. <a href=\\\"https://en.wikipedia.org/wiki/Sandwich_bread\\\">Some may be designed</a> to not become crumbly, hardened, dried or have too squishy a texture.</p>\"}, {\"type\": \"block_quote\", \"value\": {\"attribute_name\": \"Jim Davis\", \"text\": \"Vegetables are a must on a diet. I suggest carrot cake, zucchini bread, and pumpkin pie.\"}}, {\"type\": \"image_block\", \"value\": {\"image\": 35, \"attribution\": \"Creative Commons\", \"caption\": \"Belgian Waffle\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>Sandwich bread can refer to cross-sectionally square, sliced white and wheat bread, which has been described as \\\"perfectly designed for holding square luncheon meat\\\".[10] The bread used for preparing finger sandwiches is sometimes referred to as sandwich bread.[10] Pan de molde is a sandwich loaf.[11][12] Some sandwich breads are designed for use in the creation of specific types of sandwiches, such as the submarine sandwich.[13] For barbecuing, use of a high-quality white sandwich bread has been described as suitable for toasting over a fire.[14] Gluten-free sandwich bread may be prepared using gluten-free flour, teff flour.[15][16] and other ingredients.<br/></p><p>In the 1930s in the United States, the term sandwich loaf referred to sliced bread.[10] In contemporary times, U.S. consumers sometimes refer to white bread such as Wonder Bread as sandwich bread and sandwich loaf.[1] Wonder Bread produced and marketed a bread called Wonder Round sandwich bread, which was designed to be used with round-shaped cold cuts and other fillings such as eggs and hamburgers, but it was discontinued due to low consumer demand.[17] American sandwich breads have historically included some fat derived from the use of milk or oil to enrich the bread.</p>\"}]",
-    "subtitle": "Innovation in the brick oven",
-    "date_published": "2019-02-02"
-  }
-},
-{
-  "model": "blog.blogpage",
-  "pk": 77,
-  "fields": {
-    "introduction": "A Boston cream pie is a yellow butter cake that is filled with custard or cream and topped with chocolate glaze.",
-    "image": 43,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>Despite its name, it is in fact a cake, and not a pie.[2] The dessert acquired its name when cakes and pies were cooked in the same pans, and the words were used interchangeably.[3] In the latter part of the 19th century, this type of cake was variously called a \\\"cream pie\\\", a \\\"chocolate cream pie\\\", or a \\\"custard cake\\\".[3]</p><p>Owners of the Parker House Hotel in Boston claim that the Boston cream pie was first created at the hotel by Armenian-French chef M. Sanzian in 1856.[4] Called a \\\"Chocolate Cream Pie\\\", this cake consisted of two layers of French butter sponge cake filled with cr\\u00e8me p\\u00e2tissi\\u00e8re and brushed with a rum syrup, its side coated with cr\\u00e8me p\\u00e2tissi\\u00e8re overlain with toasted sliced almonds, and the top coated with chocolate fondant.[5] However, historians dispute this claim to primacy; while this cake may have been served then, there is no specific contemporaneous evidence of it, and custard-filled cake was already popular at that time.[3]</p>\"}, {\"type\": \"image_block\", \"value\": {\"image\": 15, \"attribution\": \"Creative Commons\", \"caption\": \"Central Bakery\"}}, {\"type\": \"paragraph_block\", \"value\": \"<p>The cake is likely derived from the Washington pie, a two-layer yellow cake filled with jam and topped with confectioner's sugar, for which pastry cream of custard eventually replaced the jam, and a chocolate glaze replaced the confectioner's sugar.[2] Today, the cake is topped with a chocolate glaze (such as ganache) and sometimes powdered sugar or a cherry.</p><p>The name first appeared in the 1872 Methodist Almanac.[3] Another early printed use of the term \\\"Boston cream pie\\\" occurred in the Granite Iron Ware Cook Book, printed in 1878.[2] The earliest known recipe of the modern variant was printed in Miss Parloa's Kitchen Companion in 1887 as \\\"Chocolate Cream Pie\\\".[2]</p>\"}]",
-    "subtitle": "Banana toffee chocolate pie?",
-    "date_published": "2019-02-24"
-  }
-},
-{
-  "model": "base.formpage",
-  "pk": 69,
-  "fields": {
-    "to_address": "us@example.com",
-    "from_address": "you@example.com",
-    "subject": "Contact message from Wagtail Demo site",
-    "image": null,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p>We'd love to hear from you! Drop us a line to let us know what you liked or didn't like about your recent store visit, or if you have comments or questions about this site.\\u00a0</p><p>This form is for demo purposes only - email goes nowhere. Developers: \\u00a0Edit the \\\"To Address\\\" field in the Form object in the Wagtail admin, and see the Email notes in the project readme to make your instance send live email.</p>\"}]",
-    "thank_you_text": "<p>Thanks!</p><p>We've received your message and will get back to you shortly.</p>"
-  }
-},
-{
-  "model": "base.gallerypage",
-  "pk": 70,
-  "fields": {
-    "introduction": "Some of our best-baked images, from around the world.",
-    "image": 23,
-    "body": "[]",
-    "collection": 2
-  }
-},
-{
-  "model": "base.homepage",
-  "pk": 60,
-  "fields": {
-    "image": 9,
-    "hero_text": "A sample site designed to demonstrate the capabilities of the Wagtail Content Management System.",
-    "hero_cta": "Learn more about Wagtail",
-    "hero_cta_link": 76,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<p><b>Bread</b>\\u00a0is a\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Staple_food\\\">staple food</a>\\u00a0prepared from a\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Dough\\\">dough</a>\\u00a0of\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Flour\\\">flour</a>\\u00a0and\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Water\\\">water</a>, usually by\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Baking\\\">baking</a>. Throughout recorded history it has been popular around the world and is one of the oldest artificial foods, having been of importance since the dawn of\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Agriculture#History\\\">agriculture</a>.</p><p>Proportions of types of flour and other ingredients vary widely, as do modes of preparation. As a result, types, shapes, sizes, and textures of breads differ around the world. Bread may be\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Leaven\\\">leavened</a>\\u00a0by processes such as reliance on naturally occurring\\u00a0<a href=\\\"https://en.wikipedia.org/wiki/Sourdough\\\">sourdough</a>\\u00a0microbes, chemicals, industrially produced yeast, or high-pressure aeration. Some bread is cooked before it can leaven, including for traditional or religious reasons. Non-cereal ingredients such as fruits, nuts and fats may be included. Commercial bread commonly contains additives to improve flavor, texture, color, shelf life, and ease of manufacturing.</p>\"}]",
-    "promo_image": 37,
-    "promo_title": "Our most excellent bread",
-    "promo_text": "<p>There's a lot that we can say about our bread but frankly we think you need to taste it to believe it. Crafted from lines of Python, Django and the old staples of HTML, CSS and JS we think you'll love what we're baking. With our demonstrations across our fair Island you're never far from a treat. Come visit us whenever you're nearby.</p>",
-    "featured_section_1_title": "Breads",
-    "featured_section_1": 3,
-    "featured_section_2_title": "Locations",
-    "featured_section_2": 63,
-    "featured_section_3_title": "Blog",
-    "featured_section_3": 61
-  }
-},
-{
-  "model": "base.standardpage",
-  "pk": 76,
-  "fields": {
-    "introduction": "Things to know about this demo site",
-    "image": 41,
-    "body": "[{\"type\": \"paragraph_block\", \"value\": \"<h2>Welcome to the Wagtail Demo Site!</h2><p>If you've gotten this far, congratulations - you're running an instance of a killer content management system written for and on top of Django, <i>the framework for perfectionists with deadlines.</i></p><p>What does Wagtail get you that Django alone does not?\\u00a0</p><p></p><ul><li>Focus on content creators/managers, rather than developers (but developer-friendly!)</li><li>\\\"Page-centric\\\" content modeling</li><li>Beautiful, modern, intuitive user interface optimized for content people</li><li>Super-powerful hierarchical content management (\\\"content trees\\\")</li><li>User- and group-based permissions system attached to content hierarchies</li><li>Flexible image resizing with a ton of image display helpers</li><li>Innovative \\\"<a href=\\\"https://torchbox.com/blog/rich-text-fields-and-faster-horses/\\\">StreamFields</a>\\\" as an alternative to traditional \\\"anything goes\\\" rich text fields</li><li>Intuitive choosers for embedded Pages, Images, Documents and other content</li><li>Native integration with ElasticSearch to help you build powerful search features</li><li>Template tags to help create image renditions, smart links, and to navigate content trees</li></ul><p>If you're new to Wagtail, there are two primary paths to learning:</p><p></p><ul><li>The source code that powers this demo site</li><li>The official <a href=\\\"https://docs.wagtail.org/en/stable/getting_started/index.html\\\">tutorial</a></li></ul><p></p><p></p>\"}]"
-  }
-}
 ]

--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -18,27 +18,29 @@ class Command(BaseCommand):
         """
         directories, file_names = local_storage.listdir(path)
         for directory in directories:
-            self._copy_files(local_storage, path + directory + '/')
+            self._copy_files(local_storage, path + directory + "/")
         for file_name in file_names:
             with local_storage.open(path + file_name) as file_:
                 default_storage.save(path + file_name, file_)
 
     def handle(self, **options):
-        fixtures_dir = os.path.join(settings.PROJECT_DIR, 'base', 'fixtures')
-        fixture_file = os.path.join(fixtures_dir, 'bakerydemo.json')
+        fixtures_dir = os.path.join(settings.PROJECT_DIR, "base", "fixtures")
+        fixture_file = os.path.join(fixtures_dir, "bakerydemo.json")
 
         print("Copying media files to configured storage...")
-        local_storage = FileSystemStorage(os.path.join(fixtures_dir, 'media'))
-        self._copy_files(local_storage, '')  # file storage paths are relative
+        local_storage = FileSystemStorage(os.path.join(fixtures_dir, "media"))
+        self._copy_files(local_storage, "")  # file storage paths are relative
 
         # Wagtail creates default Site and Page instances during install, but we already have
         # them in the data load. Remove the auto-generated ones.
-        if Site.objects.filter(hostname='localhost').exists():
-            Site.objects.get(hostname='localhost').delete()
-        if Page.objects.filter(title='Welcome to your new Wagtail site!').exists():
-            Page.objects.get(title='Welcome to your new Wagtail site!').delete()
+        if Site.objects.filter(hostname="localhost").exists():
+            Site.objects.get(hostname="localhost").delete()
+        if Page.objects.filter(title="Welcome to your new Wagtail site!").exists():
+            Page.objects.get(title="Welcome to your new Wagtail site!").delete()
 
-        call_command('loaddata', fixture_file, verbosity=0)
-        call_command('update_index', verbosity=0)
+        call_command("loaddata", fixture_file, verbosity=0)
+        call_command("update_index", verbosity=0)
 
-        print("Awesome. Your data is loaded! The bakery's doors are almost ready to open...")
+        print(
+            "Awesome. Your data is loaded! The bakery's doors are almost ready to open..."
+        )

--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -1,11 +1,10 @@
 import os
 
 from django.conf import settings
-from django.core.files.storage import default_storage, FileSystemStorage
-from django.core.management.base import BaseCommand
+from django.core.files.storage import FileSystemStorage, default_storage
 from django.core.management import call_command
-
-from wagtail.models import Site, Page
+from django.core.management.base import BaseCommand
+from wagtail.models import Page, Site
 
 
 class Command(BaseCommand):

--- a/bakerydemo/base/migrations/0001_initial.py
+++ b/bakerydemo/base/migrations/0001_initial.py
@@ -16,146 +16,783 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailimages', '0018_remove_rendition_filter'),
-        ('wagtailcore', '0032_add_bulk_delete_page_permission'),
+        ("wagtailimages", "0018_remove_rendition_filter"),
+        ("wagtailcore", "0032_add_bulk_delete_page_permission"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='FooterText',
+            name="FooterText",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('body', wagtail.fields.RichTextField()),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("body", wagtail.fields.RichTextField()),
             ],
             options={
-                'verbose_name_plural': 'Footer Text',
+                "verbose_name_plural": "Footer Text",
             },
         ),
         migrations.CreateModel(
-            name='FormField',
+            name="FormField",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('sort_order', models.IntegerField(blank=True, editable=False, null=True)),
-                ('label', models.CharField(help_text='The label of the form field', max_length=255, verbose_name='label')),
-                ('field_type', models.CharField(choices=[('singleline', 'Single line text'), ('multiline', 'Multi-line text'), ('email', 'Email'), ('number', 'Number'), ('url', 'URL'), ('checkbox', 'Checkbox'), ('checkboxes', 'Checkboxes'), ('dropdown', 'Drop down'), ('radio', 'Radio buttons'), ('date', 'Date'), ('datetime', 'Date/time')], max_length=16, verbose_name='field type')),
-                ('required', models.BooleanField(default=True, verbose_name='required')),
-                ('choices', models.TextField(blank=True, help_text='Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.', verbose_name='choices')),
-                ('default_value', models.CharField(blank=True, help_text='Default value. Comma separated values supported for checkboxes.', max_length=255, verbose_name='default value')),
-                ('help_text', models.CharField(blank=True, max_length=255, verbose_name='help text')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "sort_order",
+                    models.IntegerField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "label",
+                    models.CharField(
+                        help_text="The label of the form field",
+                        max_length=255,
+                        verbose_name="label",
+                    ),
+                ),
+                (
+                    "field_type",
+                    models.CharField(
+                        choices=[
+                            ("singleline", "Single line text"),
+                            ("multiline", "Multi-line text"),
+                            ("email", "Email"),
+                            ("number", "Number"),
+                            ("url", "URL"),
+                            ("checkbox", "Checkbox"),
+                            ("checkboxes", "Checkboxes"),
+                            ("dropdown", "Drop down"),
+                            ("radio", "Radio buttons"),
+                            ("date", "Date"),
+                            ("datetime", "Date/time"),
+                        ],
+                        max_length=16,
+                        verbose_name="field type",
+                    ),
+                ),
+                (
+                    "required",
+                    models.BooleanField(default=True, verbose_name="required"),
+                ),
+                (
+                    "choices",
+                    models.TextField(
+                        blank=True,
+                        help_text="Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.",
+                        verbose_name="choices",
+                    ),
+                ),
+                (
+                    "default_value",
+                    models.CharField(
+                        blank=True,
+                        help_text="Default value. Comma separated values supported for checkboxes.",
+                        max_length=255,
+                        verbose_name="default value",
+                    ),
+                ),
+                (
+                    "help_text",
+                    models.CharField(
+                        blank=True, max_length=255, verbose_name="help text"
+                    ),
+                ),
             ],
             options={
-                'ordering': ['sort_order'],
-                'abstract': False,
+                "ordering": ["sort_order"],
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='FormPage',
+            name="FormPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('to_address', models.CharField(blank=True, help_text='Optional - form submissions will be emailed to these addresses. Separate multiple addresses by comma.', max_length=255, verbose_name='to address')),
-                ('from_address', models.CharField(blank=True, max_length=255, verbose_name='from address')),
-                ('subject', models.CharField(blank=True, max_length=255, verbose_name='subject')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))))),
-                ('thank_you_text', wagtail.fields.RichTextField(blank=True)),
-                ('image', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "to_address",
+                    models.CharField(
+                        blank=True,
+                        help_text="Optional - form submissions will be emailed to these addresses. Separate multiple addresses by comma.",
+                        max_length=255,
+                        verbose_name="to address",
+                    ),
+                ),
+                (
+                    "from_address",
+                    models.CharField(
+                        blank=True, max_length=255, verbose_name="from address"
+                    ),
+                ),
+                (
+                    "subject",
+                    models.CharField(
+                        blank=True, max_length=255, verbose_name="subject"
+                    ),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        )
+                    ),
+                ),
+                ("thank_you_text", wagtail.fields.RichTextField(blank=True)),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page',),
+            bases=("wagtailcore.page",),
         ),
         migrations.CreateModel(
-            name='GalleryPage',
+            name="GalleryPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('collection', models.ForeignKey(blank=True, help_text='Select the image collection for this gallery.', null=True, on_delete=django.db.models.deletion.SET_NULL, to='wagtailcore.Collection')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                (
+                    "collection",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Select the image collection for this gallery.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="wagtailcore.Collection",
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.CreateModel(
-            name='HomePage',
+            name="HomePage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('hero_text', models.CharField(help_text='Write an introduction for the bakery', max_length=255)),
-                ('hero_cta', models.CharField(help_text='Text to display on Call to Action', max_length=255, verbose_name='Hero CTA')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Home content block')),
-                ('promo_title', models.CharField(blank=True, help_text='Title to display above the promo copy', max_length=255, null=True)),
-                ('promo_text', wagtail.fields.RichTextField(blank=True, help_text='Write some promotional copy', null=True)),
-                ('featured_section_1_title', models.CharField(blank=True, help_text='Title to display above the promo copy', max_length=255, null=True)),
-                ('featured_section_2_title', models.CharField(blank=True, help_text='Title to display above the promo copy', max_length=255, null=True)),
-                ('featured_section_3_title', models.CharField(blank=True, help_text='Title to display above the promo copy', max_length=255, null=True)),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "hero_text",
+                    models.CharField(
+                        help_text="Write an introduction for the bakery", max_length=255
+                    ),
+                ),
+                (
+                    "hero_cta",
+                    models.CharField(
+                        help_text="Text to display on Call to Action",
+                        max_length=255,
+                        verbose_name="Hero CTA",
+                    ),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Home content block",
+                    ),
+                ),
+                (
+                    "promo_title",
+                    models.CharField(
+                        blank=True,
+                        help_text="Title to display above the promo copy",
+                        max_length=255,
+                        null=True,
+                    ),
+                ),
+                (
+                    "promo_text",
+                    wagtail.fields.RichTextField(
+                        blank=True, help_text="Write some promotional copy", null=True
+                    ),
+                ),
+                (
+                    "featured_section_1_title",
+                    models.CharField(
+                        blank=True,
+                        help_text="Title to display above the promo copy",
+                        max_length=255,
+                        null=True,
+                    ),
+                ),
+                (
+                    "featured_section_2_title",
+                    models.CharField(
+                        blank=True,
+                        help_text="Title to display above the promo copy",
+                        max_length=255,
+                        null=True,
+                    ),
+                ),
+                (
+                    "featured_section_3_title",
+                    models.CharField(
+                        blank=True,
+                        help_text="Title to display above the promo copy",
+                        max_length=255,
+                        null=True,
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page',),
+            bases=("wagtailcore.page",),
         ),
         migrations.CreateModel(
-            name='People',
+            name="People",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('first_name', models.CharField(max_length=254, verbose_name='First name')),
-                ('last_name', models.CharField(max_length=254, verbose_name='Last name')),
-                ('job_title', models.CharField(max_length=254, verbose_name='Job title')),
-                ('image', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "first_name",
+                    models.CharField(max_length=254, verbose_name="First name"),
+                ),
+                (
+                    "last_name",
+                    models.CharField(max_length=254, verbose_name="Last name"),
+                ),
+                (
+                    "job_title",
+                    models.CharField(max_length=254, verbose_name="Job title"),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'verbose_name_plural': 'People',
-                'verbose_name': 'Person',
+                "verbose_name_plural": "People",
+                "verbose_name": "Person",
             },
         ),
         migrations.CreateModel(
-            name='StandardPage',
+            name="StandardPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='featured_section_1',
-            field=models.ForeignKey(blank=True, help_text='First featured section for the homepage. Will display up to three child items.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page', verbose_name='Featured section 1'),
+            model_name="homepage",
+            name="featured_section_1",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="First featured section for the homepage. Will display up to three child items.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailcore.Page",
+                verbose_name="Featured section 1",
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='featured_section_2',
-            field=models.ForeignKey(blank=True, help_text='Second featured section for the homepage. Will display up to three child items.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page', verbose_name='Featured section 2'),
+            model_name="homepage",
+            name="featured_section_2",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Second featured section for the homepage. Will display up to three child items.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailcore.Page",
+                verbose_name="Featured section 2",
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='featured_section_3',
-            field=models.ForeignKey(blank=True, help_text='Third featured section for the homepage. Will display up to six child items.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page', verbose_name='Featured section 3'),
+            model_name="homepage",
+            name="featured_section_3",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Third featured section for the homepage. Will display up to six child items.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailcore.Page",
+                verbose_name="Featured section 3",
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='hero_cta_link',
-            field=models.ForeignKey(blank=True, help_text='Choose a page to link to for the Call to Action', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page', verbose_name='Hero CTA link'),
+            model_name="homepage",
+            name="hero_cta_link",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Choose a page to link to for the Call to Action",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailcore.Page",
+                verbose_name="Hero CTA link",
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='image',
-            field=models.ForeignKey(blank=True, help_text='Homepage image', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image'),
+            model_name="homepage",
+            name="image",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Homepage image",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.Image",
+            ),
         ),
         migrations.AddField(
-            model_name='homepage',
-            name='promo_image',
-            field=models.ForeignKey(blank=True, help_text='Promo image', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image'),
+            model_name="homepage",
+            name="promo_image",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Promo image",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.Image",
+            ),
         ),
         migrations.AddField(
-            model_name='formfield',
-            name='page',
-            field=modelcluster.fields.ParentalKey(on_delete=django.db.models.deletion.CASCADE, related_name='form_fields', to='base.FormPage'),
+            model_name="formfield",
+            name="page",
+            field=modelcluster.fields.ParentalKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="form_fields",
+                to="base.FormPage",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0002_auto_20170329_0055.py
+++ b/bakerydemo/base/migrations/0002_auto_20170329_0055.py
@@ -12,28 +12,342 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0001_initial'),
+        ("base", "0001_initial"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='formpage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html')))),
+            model_name="formpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                )
+            ),
         ),
         migrations.AlterField(
-            model_name='gallerypage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body'),
+            model_name="gallerypage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Page body",
+            ),
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Home content block'),
+            model_name="homepage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Home content block",
+            ),
         ),
         migrations.AlterField(
-            model_name='standardpage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body'),
+            model_name="standardpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0003_auto_20170823_1127.py
+++ b/bakerydemo/base/migrations/0003_auto_20170823_1127.py
@@ -8,13 +8,30 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0002_auto_20170329_0055'),
+        ("base", "0002_auto_20170329_0055"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='formfield',
-            name='field_type',
-            field=models.CharField(choices=[('singleline', 'Single line text'), ('multiline', 'Multi-line text'), ('email', 'Email'), ('number', 'Number'), ('url', 'URL'), ('checkbox', 'Checkbox'), ('checkboxes', 'Checkboxes'), ('dropdown', 'Drop down'), ('multiselect', 'Multiple select'), ('radio', 'Radio buttons'), ('date', 'Date'), ('datetime', 'Date/time')], max_length=16, verbose_name='field type'),
+            model_name="formfield",
+            name="field_type",
+            field=models.CharField(
+                choices=[
+                    ("singleline", "Single line text"),
+                    ("multiline", "Multi-line text"),
+                    ("email", "Email"),
+                    ("number", "Number"),
+                    ("url", "URL"),
+                    ("checkbox", "Checkbox"),
+                    ("checkboxes", "Checkboxes"),
+                    ("dropdown", "Drop down"),
+                    ("multiselect", "Multiple select"),
+                    ("radio", "Radio buttons"),
+                    ("date", "Date"),
+                    ("datetime", "Date/time"),
+                ],
+                max_length=16,
+                verbose_name="field type",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0004_auto_20180522_1856.py
+++ b/bakerydemo/base/migrations/0004_auto_20180522_1856.py
@@ -7,18 +7,43 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0003_auto_20170823_1127'),
+        ("base", "0003_auto_20170823_1127"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='formfield',
-            name='field_type',
-            field=models.CharField(choices=[('singleline', 'Single line text'), ('multiline', 'Multi-line text'), ('email', 'Email'), ('number', 'Number'), ('url', 'URL'), ('checkbox', 'Checkbox'), ('checkboxes', 'Checkboxes'), ('dropdown', 'Drop down'), ('multiselect', 'Multiple select'), ('radio', 'Radio buttons'), ('date', 'Date'), ('datetime', 'Date/time'), ('hidden', 'Hidden field')], max_length=16, verbose_name='field type'),
+            model_name="formfield",
+            name="field_type",
+            field=models.CharField(
+                choices=[
+                    ("singleline", "Single line text"),
+                    ("multiline", "Multi-line text"),
+                    ("email", "Email"),
+                    ("number", "Number"),
+                    ("url", "URL"),
+                    ("checkbox", "Checkbox"),
+                    ("checkboxes", "Checkboxes"),
+                    ("dropdown", "Drop down"),
+                    ("multiselect", "Multiple select"),
+                    ("radio", "Radio buttons"),
+                    ("date", "Date"),
+                    ("datetime", "Date/time"),
+                    ("hidden", "Hidden field"),
+                ],
+                max_length=16,
+                verbose_name="field type",
+            ),
         ),
         migrations.AlterField(
-            model_name='gallerypage',
-            name='collection',
-            field=models.ForeignKey(blank=True, help_text='Select the image collection for this gallery.', limit_choices_to=models.Q(_negated=True, name__in=['Root']), null=True, on_delete=django.db.models.deletion.SET_NULL, to='wagtailcore.Collection'),
+            model_name="gallerypage",
+            name="collection",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Select the image collection for this gallery.",
+                limit_choices_to=models.Q(_negated=True, name__in=["Root"]),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to="wagtailcore.Collection",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0005_formfield_clean_name.py
+++ b/bakerydemo/base/migrations/0005_formfield_clean_name.py
@@ -6,13 +6,19 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0004_auto_20180522_1856'),
+        ("base", "0004_auto_20180522_1856"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='formfield',
-            name='clean_name',
-            field=models.CharField(blank=True, default='', help_text='Safe name of the form field, the label converted to ascii_snake_case', max_length=255, verbose_name='name'),
+            model_name="formfield",
+            name="clean_name",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Safe name of the form field, the label converted to ascii_snake_case",
+                max_length=255,
+                verbose_name="name",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0006_char_field_remove_null.py
+++ b/bakerydemo/base/migrations/0006_char_field_remove_null.py
@@ -6,32 +6,52 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0005_formfield_clean_name'),
+        ("base", "0005_formfield_clean_name"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='homepage',
-            name='featured_section_1_title',
-            field=models.CharField(blank=True, default='', help_text='Title to display above the promo copy', max_length=255),
+            model_name="homepage",
+            name="featured_section_1_title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Title to display above the promo copy",
+                max_length=255,
+            ),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='featured_section_2_title',
-            field=models.CharField(blank=True, default='', help_text='Title to display above the promo copy', max_length=255),
+            model_name="homepage",
+            name="featured_section_2_title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Title to display above the promo copy",
+                max_length=255,
+            ),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='featured_section_3_title',
-            field=models.CharField(blank=True, default='', help_text='Title to display above the promo copy', max_length=255),
+            model_name="homepage",
+            name="featured_section_3_title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Title to display above the promo copy",
+                max_length=255,
+            ),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='promo_title',
-            field=models.CharField(blank=True, default='', help_text='Title to display above the promo copy', max_length=255),
+            model_name="homepage",
+            name="promo_title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Title to display above the promo copy",
+                max_length=255,
+            ),
             preserve_default=False,
         ),
     ]

--- a/bakerydemo/base/migrations/0007_alter_formfield_choices_and_more.py
+++ b/bakerydemo/base/migrations/0007_alter_formfield_choices_and_more.py
@@ -7,28 +7,44 @@ import wagtail.contrib.forms.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0006_char_field_remove_null'),
+        ("base", "0006_char_field_remove_null"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='formfield',
-            name='choices',
-            field=models.TextField(blank=True, help_text='Comma or new line separated list of choices. Only applicable in checkboxes, radio and dropdown.', verbose_name='choices'),
+            model_name="formfield",
+            name="choices",
+            field=models.TextField(
+                blank=True,
+                help_text="Comma or new line separated list of choices. Only applicable in checkboxes, radio and dropdown.",
+                verbose_name="choices",
+            ),
         ),
         migrations.AlterField(
-            model_name='formfield',
-            name='default_value',
-            field=models.TextField(blank=True, help_text='Default value. Comma or new line separated values supported for checkboxes.', verbose_name='default value'),
+            model_name="formfield",
+            name="default_value",
+            field=models.TextField(
+                blank=True,
+                help_text="Default value. Comma or new line separated values supported for checkboxes.",
+                verbose_name="default value",
+            ),
         ),
         migrations.AlterField(
-            model_name='formpage',
-            name='from_address',
-            field=models.EmailField(blank=True, max_length=255, verbose_name='from address'),
+            model_name="formpage",
+            name="from_address",
+            field=models.EmailField(
+                blank=True, max_length=255, verbose_name="from address"
+            ),
         ),
         migrations.AlterField(
-            model_name='formpage',
-            name='to_address',
-            field=models.CharField(blank=True, help_text='Optional - form submissions will be emailed to these addresses. Separate multiple addresses by comma.', max_length=255, validators=[wagtail.contrib.forms.models.validate_to_address], verbose_name='to address'),
+            model_name="formpage",
+            name="to_address",
+            field=models.CharField(
+                blank=True,
+                help_text="Optional - form submissions will be emailed to these addresses. Separate multiple addresses by comma.",
+                max_length=255,
+                validators=[wagtail.contrib.forms.models.validate_to_address],
+                verbose_name="to address",
+            ),
         ),
     ]

--- a/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
@@ -10,28 +10,346 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('base', '0007_alter_formfield_choices_and_more'),
+        ("base", "0007_alter_formfield_choices_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='formpage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], use_json_field=True),
+            model_name="formpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                use_json_field=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='gallerypage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Page body'),
+            model_name="gallerypage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Page body",
+            ),
         ),
         migrations.AlterField(
-            model_name='homepage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Home content block'),
+            model_name="homepage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Home content block",
+            ),
         ),
         migrations.AlterField(
-            model_name='standardpage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Page body'),
+            model_name="standardpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -34,32 +34,38 @@ class People(index.Indexed, ClusterableModel):
     to the database.
     https://github.com/wagtail/django-modelcluster
     """
+
     first_name = models.CharField("First name", max_length=254)
     last_name = models.CharField("Last name", max_length=254)
     job_title = models.CharField("Job title", max_length=254)
 
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+'
+        related_name="+",
     )
 
     panels = [
-        MultiFieldPanel([
-            FieldRowPanel([
-                FieldPanel('first_name', classname="col6"),
-                FieldPanel('last_name', classname="col6"),
-            ])
-        ], "Name"),
-        FieldPanel('job_title'),
-        FieldPanel('image')
+        MultiFieldPanel(
+            [
+                FieldRowPanel(
+                    [
+                        FieldPanel("first_name", classname="col6"),
+                        FieldPanel("last_name", classname="col6"),
+                    ]
+                )
+            ],
+            "Name",
+        ),
+        FieldPanel("job_title"),
+        FieldPanel("image"),
     ]
 
     search_fields = [
-        index.SearchField('first_name'),
-        index.SearchField('last_name'),
+        index.SearchField("first_name"),
+        index.SearchField("last_name"),
     ]
 
     @property
@@ -67,16 +73,16 @@ class People(index.Indexed, ClusterableModel):
         # Returns an empty string if there is no profile pic or the rendition
         # file can't be found.
         try:
-            return self.image.get_rendition('fill-50x50').img_tag()
+            return self.image.get_rendition("fill-50x50").img_tag()
         except:  # noqa: E722 FIXME: remove bare 'except:'
-            return ''
+            return ""
 
     def __str__(self):
-        return '{} {}'.format(self.first_name, self.last_name)
+        return "{} {}".format(self.first_name, self.last_name)
 
     class Meta:
-        verbose_name = 'Person'
-        verbose_name_plural = 'People'
+        verbose_name = "Person"
+        verbose_name_plural = "People"
 
 
 @register_snippet
@@ -87,17 +93,18 @@ class FooterText(models.Model):
     accessible on the template via a template tag defined in base/templatetags/
     navigation_tags.py
     """
+
     body = RichTextField()
 
     panels = [
-        FieldPanel('body'),
+        FieldPanel("body"),
     ]
 
     def __str__(self):
         return "Footer text"
 
     class Meta:
-        verbose_name_plural = 'Footer Text'
+        verbose_name_plural = "Footer Text"
 
 
 class StandardPage(Page):
@@ -107,24 +114,22 @@ class StandardPage(Page):
     image, introduction and body field
     """
 
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
     body = StreamField(
         BaseStreamBlock(), verbose_name="Page body", blank=True, use_json_field=True
     )
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('body'),
-        FieldPanel('image'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("body"),
+        FieldPanel("image"),
     ]
 
 
@@ -141,55 +146,53 @@ class HomePage(Page):
 
     # Hero section of HomePage
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Homepage image'
+        related_name="+",
+        help_text="Homepage image",
     )
     hero_text = models.CharField(
-        max_length=255,
-        help_text='Write an introduction for the bakery'
+        max_length=255, help_text="Write an introduction for the bakery"
     )
     hero_cta = models.CharField(
-        verbose_name='Hero CTA',
+        verbose_name="Hero CTA",
         max_length=255,
-        help_text='Text to display on Call to Action'
+        help_text="Text to display on Call to Action",
     )
     hero_cta_link = models.ForeignKey(
-        'wagtailcore.Page',
+        "wagtailcore.Page",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        verbose_name='Hero CTA link',
-        help_text='Choose a page to link to for the Call to Action'
+        related_name="+",
+        verbose_name="Hero CTA link",
+        help_text="Choose a page to link to for the Call to Action",
     )
 
     # Body section of the HomePage
     body = StreamField(
-        BaseStreamBlock(), verbose_name="Home content block", blank=True, use_json_field=True
+        BaseStreamBlock(),
+        verbose_name="Home content block",
+        blank=True,
+        use_json_field=True,
     )
 
     # Promo section of the HomePage
     promo_image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Promo image'
+        related_name="+",
+        help_text="Promo image",
     )
     promo_title = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='Title to display above the promo copy'
+        blank=True, max_length=255, help_text="Title to display above the promo copy"
     )
     promo_text = RichTextField(
-        null=True,
-        blank=True,
-        help_text='Write some promotional copy'
+        null=True, blank=True, help_text="Write some promotional copy"
     )
 
     # Featured sections on the HomePage
@@ -198,82 +201,94 @@ class HomePage(Page):
     # Each list their children items that we access via the children function
     # that we define on the individual Page models e.g. BlogIndexPage
     featured_section_1_title = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='Title to display above the promo copy'
+        blank=True, max_length=255, help_text="Title to display above the promo copy"
     )
     featured_section_1 = models.ForeignKey(
-        'wagtailcore.Page',
+        "wagtailcore.Page",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='First featured section for the homepage. Will display up to '
-        'three child items.',
-        verbose_name='Featured section 1'
+        related_name="+",
+        help_text="First featured section for the homepage. Will display up to "
+        "three child items.",
+        verbose_name="Featured section 1",
     )
 
     featured_section_2_title = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='Title to display above the promo copy'
+        blank=True, max_length=255, help_text="Title to display above the promo copy"
     )
     featured_section_2 = models.ForeignKey(
-        'wagtailcore.Page',
+        "wagtailcore.Page",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Second featured section for the homepage. Will display up to '
-        'three child items.',
-        verbose_name='Featured section 2'
+        related_name="+",
+        help_text="Second featured section for the homepage. Will display up to "
+        "three child items.",
+        verbose_name="Featured section 2",
     )
 
     featured_section_3_title = models.CharField(
-        blank=True,
-        max_length=255,
-        help_text='Title to display above the promo copy'
+        blank=True, max_length=255, help_text="Title to display above the promo copy"
     )
     featured_section_3 = models.ForeignKey(
-        'wagtailcore.Page',
+        "wagtailcore.Page",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Third featured section for the homepage. Will display up to '
-        'six child items.',
-        verbose_name='Featured section 3'
+        related_name="+",
+        help_text="Third featured section for the homepage. Will display up to "
+        "six child items.",
+        verbose_name="Featured section 3",
     )
 
     content_panels = Page.content_panels + [
-        MultiFieldPanel([
-            FieldPanel('image'),
-            FieldPanel('hero_text', classname="full"),
-            MultiFieldPanel([
-                FieldPanel('hero_cta'),
-                FieldPanel('hero_cta_link'),
-            ]),
-        ], heading="Hero section"),
-        MultiFieldPanel([
-            FieldPanel('promo_image'),
-            FieldPanel('promo_title'),
-            FieldPanel('promo_text'),
-        ], heading="Promo section"),
-        FieldPanel('body'),
-        MultiFieldPanel([
-            MultiFieldPanel([
-                FieldPanel('featured_section_1_title'),
-                FieldPanel('featured_section_1'),
-            ]),
-            MultiFieldPanel([
-                FieldPanel('featured_section_2_title'),
-                FieldPanel('featured_section_2'),
-            ]),
-            MultiFieldPanel([
-                FieldPanel('featured_section_3_title'),
-                FieldPanel('featured_section_3'),
-            ]),
-        ], heading="Featured homepage sections", classname="collapsible")
+        MultiFieldPanel(
+            [
+                FieldPanel("image"),
+                FieldPanel("hero_text", classname="full"),
+                MultiFieldPanel(
+                    [
+                        FieldPanel("hero_cta"),
+                        FieldPanel("hero_cta_link"),
+                    ]
+                ),
+            ],
+            heading="Hero section",
+        ),
+        MultiFieldPanel(
+            [
+                FieldPanel("promo_image"),
+                FieldPanel("promo_title"),
+                FieldPanel("promo_text"),
+            ],
+            heading="Promo section",
+        ),
+        FieldPanel("body"),
+        MultiFieldPanel(
+            [
+                MultiFieldPanel(
+                    [
+                        FieldPanel("featured_section_1_title"),
+                        FieldPanel("featured_section_1"),
+                    ]
+                ),
+                MultiFieldPanel(
+                    [
+                        FieldPanel("featured_section_2_title"),
+                        FieldPanel("featured_section_2"),
+                    ]
+                ),
+                MultiFieldPanel(
+                    [
+                        FieldPanel("featured_section_3_title"),
+                        FieldPanel("featured_section_3"),
+                    ]
+                ),
+            ],
+            heading="Featured homepage sections",
+            classname="collapsible",
+        ),
     ]
 
     def __str__(self):
@@ -288,35 +303,32 @@ class GalleryPage(Page):
     and is intended to show the extensibility of this aspect of Wagtail
     """
 
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and '
-        '3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and " "3000px.",
     )
     body = StreamField(
         BaseStreamBlock(), verbose_name="Page body", blank=True, use_json_field=True
     )
     collection = models.ForeignKey(
         Collection,
-        limit_choices_to=~models.Q(name__in=['Root']),
+        limit_choices_to=~models.Q(name__in=["Root"]),
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text='Select the image collection for this gallery.'
+        help_text="Select the image collection for this gallery.",
     )
 
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('body'),
-        FieldPanel('image'),
-        FieldPanel('collection'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("body"),
+        FieldPanel("image"),
+        FieldPanel("collection"),
     ]
 
     # Defining what content type can sit under the parent. Since it's a blank
@@ -333,16 +345,17 @@ class FormField(AbstractFormField):
     can read more about Wagtail forms at:
     https://docs.wagtail.org/en/stable/reference/contrib/forms/index.html
     """
-    page = ParentalKey('FormPage', related_name='form_fields', on_delete=models.CASCADE)
+
+    page = ParentalKey("FormPage", related_name="form_fields", on_delete=models.CASCADE)
 
 
 class FormPage(AbstractEmailForm):
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+'
+        related_name="+",
     )
     body = StreamField(BaseStreamBlock(), use_json_field=True)
     thank_you_text = RichTextField(blank=True)
@@ -350,15 +363,20 @@ class FormPage(AbstractEmailForm):
     # Note how we include the FormField object via an InlinePanel using the
     # related_name value
     content_panels = AbstractEmailForm.content_panels + [
-        FieldPanel('image'),
-        FieldPanel('body'),
-        InlinePanel('form_fields', label="Form fields"),
-        FieldPanel('thank_you_text', classname="full"),
-        MultiFieldPanel([
-            FieldRowPanel([
-                FieldPanel('from_address', classname="col6"),
-                FieldPanel('to_address', classname="col6"),
-            ]),
-            FieldPanel('subject'),
-        ], "Email"),
+        FieldPanel("image"),
+        FieldPanel("body"),
+        InlinePanel("form_fields", label="Form fields"),
+        FieldPanel("thank_you_text", classname="full"),
+        MultiFieldPanel(
+            [
+                FieldRowPanel(
+                    [
+                        FieldPanel("from_address", classname="col6"),
+                        FieldPanel("to_address", classname="col6"),
+                    ]
+                ),
+                FieldPanel("subject"),
+            ],
+            "Email",
+        ),
     ]

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -1,19 +1,12 @@
 from __future__ import unicode_literals
 
 from django.db import models
-
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
-
-from wagtail.admin.panels import (
-    FieldPanel,
-    FieldRowPanel,
-    InlinePanel,
-    MultiFieldPanel,
-)
+from wagtail.admin.panels import FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel
+from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Collection, Page
-from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 

--- a/bakerydemo/base/templatetags/gallery_tags.py
+++ b/bakerydemo/base/templatetags/gallery_tags.py
@@ -6,11 +6,11 @@ register = template.Library()
 
 
 # Retrieves a single gallery item and returns a gallery of images
-@register.inclusion_tag('tags/gallery.html', takes_context=True)
+@register.inclusion_tag("tags/gallery.html", takes_context=True)
 def gallery(context, gallery):
     images = Image.objects.filter(collection=gallery)
 
     return {
-        'images': images,
-        'request': context['request'],
+        "images": images,
+        "request": context["request"],
     }

--- a/bakerydemo/base/templatetags/gallery_tags.py
+++ b/bakerydemo/base/templatetags/gallery_tags.py
@@ -1,5 +1,4 @@
 from django import template
-
 from wagtail.images.models import Image
 
 register = template.Library()

--- a/bakerydemo/base/templatetags/navigation_tags.py
+++ b/bakerydemo/base/templatetags/navigation_tags.py
@@ -14,7 +14,7 @@ def get_site_root(context):
     # This returns a core.Page. The main menu needs to have the site.root_page
     # defined else will return an object attribute error ('str' object has no
     # attribute 'get_children')
-    return Site.find_for_request(context['request']).root_page
+    return Site.find_for_request(context["request"]).root_page
 
 
 def has_menu_children(page):
@@ -31,13 +31,13 @@ def has_children(page):
 
 def is_active(page, current_page):
     # To give us active state on main navigation
-    return (current_page.url_path.startswith(page.url_path) if current_page else False)
+    return current_page.url_path.startswith(page.url_path) if current_page else False
 
 
 # Retrieves the top menu items - the immediate children of the parent page
 # The has_menu_children method is necessary because the Foundation menu requires
 # a dropdown class to be applied to a parent
-@register.inclusion_tag('tags/top_menu.html', takes_context=True)
+@register.inclusion_tag("tags/top_menu.html", takes_context=True)
 def top_menu(context, parent, calling_page=None):
     menuitems = parent.get_children().live().in_menu()
     for menuitem in menuitems:
@@ -45,18 +45,21 @@ def top_menu(context, parent, calling_page=None):
         # We don't directly check if calling_page is None since the template
         # engine can pass an empty string to calling_page
         # if the variable passed as calling_page does not exist.
-        menuitem.active = (calling_page.url_path.startswith(menuitem.url_path)
-                           if calling_page else False)
+        menuitem.active = (
+            calling_page.url_path.startswith(menuitem.url_path)
+            if calling_page
+            else False
+        )
     return {
-        'calling_page': calling_page,
-        'menuitems': menuitems,
+        "calling_page": calling_page,
+        "menuitems": menuitems,
         # required by the pageurl tag that we want to use within this template
-        'request': context['request'],
+        "request": context["request"],
     }
 
 
 # Retrieves the children of the top menu items for the drop downs
-@register.inclusion_tag('tags/top_menu_children.html', takes_context=True)
+@register.inclusion_tag("tags/top_menu_children.html", takes_context=True)
 def top_menu_children(context, parent, calling_page=None):
     menuitems_children = parent.get_children()
     menuitems_children = menuitems_children.live().in_menu()
@@ -65,38 +68,40 @@ def top_menu_children(context, parent, calling_page=None):
         # We don't directly check if calling_page is None since the template
         # engine can pass an empty string to calling_page
         # if the variable passed as calling_page does not exist.
-        menuitem.active = (calling_page.url_path.startswith(menuitem.url_path)
-                           if calling_page else False)
+        menuitem.active = (
+            calling_page.url_path.startswith(menuitem.url_path)
+            if calling_page
+            else False
+        )
         menuitem.children = menuitem.get_children().live().in_menu()
     return {
-        'parent': parent,
-        'menuitems_children': menuitems_children,
+        "parent": parent,
+        "menuitems_children": menuitems_children,
         # required by the pageurl tag that we want to use within this template
-        'request': context['request'],
+        "request": context["request"],
     }
 
 
-@register.inclusion_tag('tags/breadcrumbs.html', takes_context=True)
+@register.inclusion_tag("tags/breadcrumbs.html", takes_context=True)
 def breadcrumbs(context):
-    self = context.get('self')
+    self = context.get("self")
     if self is None or self.depth <= 2:
         # When on the home page, displaying breadcrumbs is irrelevant.
         ancestors = ()
     else:
-        ancestors = Page.objects.ancestor_of(
-            self, inclusive=True).filter(depth__gt=1)
+        ancestors = Page.objects.ancestor_of(self, inclusive=True).filter(depth__gt=1)
     return {
-        'ancestors': ancestors,
-        'request': context['request'],
+        "ancestors": ancestors,
+        "request": context["request"],
     }
 
 
-@register.inclusion_tag('base/include/footer_text.html', takes_context=True)
+@register.inclusion_tag("base/include/footer_text.html", takes_context=True)
 def get_footer_text(context):
     footer_text = ""
     if FooterText.objects.first() is not None:
         footer_text = FooterText.objects.first().body
 
     return {
-        'footer_text': footer_text,
+        "footer_text": footer_text,
     }

--- a/bakerydemo/base/templatetags/navigation_tags.py
+++ b/bakerydemo/base/templatetags/navigation_tags.py
@@ -1,9 +1,7 @@
 from django import template
-
 from wagtail.models import Page, Site
 
 from bakerydemo.base.models import FooterText
-
 
 register = template.Library()
 # https://docs.djangoproject.com/en/3.2/howto/custom-template-tags/

--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -4,8 +4,8 @@ from wagtail.contrib.modeladmin.options import (
     modeladmin_register,
 )
 
-from bakerydemo.breads.models import Country, BreadIngredient, BreadType
-from bakerydemo.base.models import People, FooterText
+from bakerydemo.base.models import FooterText, People
+from bakerydemo.breads.models import BreadIngredient, BreadType, Country
 
 """
 N.B. To see what icons are available for use in Wagtail menus and StreamField block types,

--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -1,10 +1,13 @@
 from wagtail.contrib.modeladmin.options import (
-    ModelAdmin, ModelAdminGroup, modeladmin_register)
+    ModelAdmin,
+    ModelAdminGroup,
+    modeladmin_register,
+)
 
 from bakerydemo.breads.models import Country, BreadIngredient, BreadType
 from bakerydemo.base.models import People, FooterText
 
-'''
+"""
 N.B. To see what icons are available for use in Wagtail menus and StreamField block types,
 enable the styleguide in settings:
 
@@ -18,51 +21,51 @@ or see https://thegrouchy.dev/general/2015/12/06/wagtail-streamfield-icons.html
 
 This demo project includes the full font-awesome set via CDN in base.html, so the entire
 font-awesome icon set is available to you. Options are at https://fontawesome.com/icons .
-'''
+"""
 
 
 class BreadIngredientAdmin(ModelAdmin):
     # These stub classes allow us to put various models into the custom "Wagtail Bakery" menu item
     # rather than under the default Snippets section.
     model = BreadIngredient
-    search_fields = ('name', )
+    search_fields = ("name",)
 
 
 class BreadTypeAdmin(ModelAdmin):
     model = BreadType
-    search_fields = ('title', )
+    search_fields = ("title",)
 
 
 class BreadCountryAdmin(ModelAdmin):
     model = Country
-    search_fields = ('title', )
+    search_fields = ("title",)
 
 
 class BreadModelAdminGroup(ModelAdminGroup):
-    menu_label = 'Bread Categories'
-    menu_icon = 'fa-suitcase'  # change as required
+    menu_label = "Bread Categories"
+    menu_icon = "fa-suitcase"  # change as required
     menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
     items = (BreadIngredientAdmin, BreadTypeAdmin, BreadCountryAdmin)
 
 
 class PeopleModelAdmin(ModelAdmin):
     model = People
-    menu_label = 'People'  # ditch this to use verbose_name_plural from model
-    menu_icon = 'fa-users'  # change as required
-    list_display = ('first_name', 'last_name', 'job_title', 'thumb_image')
-    list_filter = ('job_title', )
-    search_fields = ('first_name', 'last_name', 'job_title')
+    menu_label = "People"  # ditch this to use verbose_name_plural from model
+    menu_icon = "fa-users"  # change as required
+    list_display = ("first_name", "last_name", "job_title", "thumb_image")
+    list_filter = ("job_title",)
+    search_fields = ("first_name", "last_name", "job_title")
     inspect_view_enabled = True
 
 
 class FooterTextAdmin(ModelAdmin):
     model = FooterText
-    search_fields = ('body',)
+    search_fields = ("body",)
 
 
 class BakeryModelAdminGroup(ModelAdminGroup):
-    menu_label = 'Bakery Misc'
-    menu_icon = 'fa-cutlery'  # change as required
+    menu_label = "Bakery Misc"
+    menu_icon = "fa-cutlery"  # change as required
     menu_order = 300  # will put in 4th place (000 being 1st, 100 2nd)
     items = (PeopleModelAdmin, FooterTextAdmin)
 

--- a/bakerydemo/blog/migrations/0001_initial.py
+++ b/bakerydemo/blog/migrations/0001_initial.py
@@ -18,68 +18,348 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('taggit', '0002_auto_20150616_2121'),
-        ('wagtailcore', '0032_add_bulk_delete_page_permission'),
-        ('base', '0001_initial'),
-        ('wagtailimages', '0018_remove_rendition_filter'),
+        ("taggit", "0002_auto_20150616_2121"),
+        ("wagtailcore", "0032_add_bulk_delete_page_permission"),
+        ("base", "0001_initial"),
+        ("wagtailimages", "0018_remove_rendition_filter"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='BlogIndexPage',
+            name="BlogIndexPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=(wagtail.contrib.routable_page.models.RoutablePageMixin, 'wagtailcore.page', models.Model),
+            bases=(
+                wagtail.contrib.routable_page.models.RoutablePageMixin,
+                "wagtailcore.page",
+                models.Model,
+            ),
         ),
         migrations.CreateModel(
-            name='BlogPage',
+            name="BlogPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('subtitle', models.CharField(blank=True, max_length=255)),
-                ('date_published', models.DateField(blank=True, null=True, verbose_name='Date article published')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                ("subtitle", models.CharField(blank=True, max_length=255)),
+                (
+                    "date_published",
+                    models.DateField(
+                        blank=True, null=True, verbose_name="Date article published"
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.CreateModel(
-            name='BlogPageTag',
+            name="BlogPageTag",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('content_object', modelcluster.fields.ParentalKey(on_delete=django.db.models.deletion.CASCADE, related_name='tagged_items', to='blog.BlogPage')),
-                ('tag', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='blog_blogpagetag_items', to='taggit.Tag')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "content_object",
+                    modelcluster.fields.ParentalKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tagged_items",
+                        to="blog.BlogPage",
+                    ),
+                ),
+                (
+                    "tag",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="blog_blogpagetag_items",
+                        to="taggit.Tag",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='BlogPeopleRelationship',
+            name="BlogPeopleRelationship",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('sort_order', models.IntegerField(blank=True, editable=False, null=True)),
-                ('page', modelcluster.fields.ParentalKey(on_delete=django.db.models.deletion.CASCADE, related_name='blog_person_relationship', to='blog.BlogPage')),
-                ('people', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='person_blog_relationship', to='base.People')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "sort_order",
+                    models.IntegerField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "page",
+                    modelcluster.fields.ParentalKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="blog_person_relationship",
+                        to="blog.BlogPage",
+                    ),
+                ),
+                (
+                    "people",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="person_blog_relationship",
+                        to="base.People",
+                    ),
+                ),
             ],
             options={
-                'ordering': ['sort_order'],
-                'abstract': False,
+                "ordering": ["sort_order"],
+                "abstract": False,
             },
         ),
         migrations.AddField(
-            model_name='blogpage',
-            name='tags',
-            field=modelcluster.contrib.taggit.ClusterTaggableManager(blank=True, help_text='A comma-separated list of tags.', through='blog.BlogPageTag', to='taggit.Tag', verbose_name='Tags'),
+            model_name="blogpage",
+            name="tags",
+            field=modelcluster.contrib.taggit.ClusterTaggableManager(
+                blank=True,
+                help_text="A comma-separated list of tags.",
+                through="blog.BlogPageTag",
+                to="taggit.Tag",
+                verbose_name="Tags",
+            ),
         ),
     ]

--- a/bakerydemo/blog/migrations/0002_remove_blogindexpage_body.py
+++ b/bakerydemo/blog/migrations/0002_remove_blogindexpage_body.py
@@ -8,12 +8,12 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blog', '0001_initial'),
+        ("blog", "0001_initial"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='blogindexpage',
-            name='body',
+            model_name="blogindexpage",
+            name="body",
         ),
     ]

--- a/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
@@ -12,13 +12,92 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blog', '0002_remove_blogindexpage_body'),
+        ("blog", "0002_remove_blogindexpage_body"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='blogpage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body'),
+            model_name="blogpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/blog/migrations/0004_alter_blogpagetag_tag.py
+++ b/bakerydemo/blog/migrations/0004_alter_blogpagetag_tag.py
@@ -7,14 +7,18 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('taggit', '0004_alter_taggeditem_content_type_alter_taggeditem_tag'),
-        ('blog', '0003_auto_20170329_0055'),
+        ("taggit", "0004_alter_taggeditem_content_type_alter_taggeditem_tag"),
+        ("blog", "0003_auto_20170329_0055"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='blogpagetag',
-            name='tag',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s_items', to='taggit.tag'),
+            model_name="blogpagetag",
+            name="tag",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="%(app_label)s_%(class)s_items",
+                to="taggit.tag",
+            ),
         ),
     ]

--- a/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
@@ -10,13 +10,93 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blog', '0004_alter_blogpagetag_tag'),
+        ("blog", "0004_alter_blogpagetag_tag"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='blogpage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Page body'),
+            model_name="blogpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -3,16 +3,13 @@ from __future__ import unicode_literals
 from django.contrib import messages
 from django.db import models
 from django.shortcuts import redirect, render
-
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
-
 from taggit.models import Tag, TaggedItemBase
-
-from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.admin.panels import FieldPanel, InlinePanel
+from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.fields import StreamField
-from wagtail.models import Page, Orderable
+from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock

--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -26,15 +26,14 @@ class BlogPeopleRelationship(Orderable, models.Model):
     We have created a two way relationship between BlogPage and People using
     the ParentalKey and ForeignKey
     """
+
     page = ParentalKey(
-        'BlogPage', related_name='blog_person_relationship', on_delete=models.CASCADE
+        "BlogPage", related_name="blog_person_relationship", on_delete=models.CASCADE
     )
     people = models.ForeignKey(
-        'base.People', related_name='person_blog_relationship', on_delete=models.CASCADE
+        "base.People", related_name="person_blog_relationship", on_delete=models.CASCADE
     )
-    panels = [
-        FieldPanel('people')
-    ]
+    panels = [FieldPanel("people")]
 
 
 class BlogPageTag(TaggedItemBase):
@@ -43,7 +42,10 @@ class BlogPageTag(TaggedItemBase):
     the BlogPage object and tags. There's a longer guide on using it at
     https://docs.wagtail.org/en/stable/reference/pages/model_recipes.html#tagging
     """
-    content_object = ParentalKey('BlogPage', related_name='tagged_items', on_delete=models.CASCADE)
+
+    content_object = ParentalKey(
+        "BlogPage", related_name="tagged_items", on_delete=models.CASCADE
+    )
 
 
 class BlogPage(Page):
@@ -54,40 +56,37 @@ class BlogPage(Page):
     ParentalKey's related_name in BlogPeopleRelationship. More docs:
     https://docs.wagtail.org/en/stable/topics/pages.html#inline-models
     """
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
     body = StreamField(
         BaseStreamBlock(), verbose_name="Page body", blank=True, use_json_field=True
     )
     subtitle = models.CharField(blank=True, max_length=255)
     tags = ClusterTaggableManager(through=BlogPageTag, blank=True)
-    date_published = models.DateField(
-        "Date article published", blank=True, null=True
-    )
+    date_published = models.DateField("Date article published", blank=True, null=True)
 
     content_panels = Page.content_panels + [
-        FieldPanel('subtitle', classname="full"),
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
-        FieldPanel('body'),
-        FieldPanel('date_published'),
+        FieldPanel("subtitle", classname="full"),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
+        FieldPanel("body"),
+        FieldPanel("date_published"),
         InlinePanel(
-            'blog_person_relationship', label="Author(s)",
-            panels=None, min_num=1),
-        FieldPanel('tags'),
+            "blog_person_relationship", label="Author(s)", panels=None, min_num=1
+        ),
+        FieldPanel("tags"),
     ]
 
     search_fields = Page.search_fields + [
-        index.SearchField('body'),
+        index.SearchField("body"),
     ]
 
     def authors(self):
@@ -98,9 +97,7 @@ class BlogPage(Page):
         with a loop on the template. If we tried to access the blog_person_
         relationship directly we'd print `blog.BlogPeopleRelationship.None`
         """
-        authors = [
-            n.people for n in self.blog_person_relationship.all()
-        ]
+        authors = [n.people for n in self.blog_person_relationship.all()]
 
         return authors
 
@@ -113,15 +110,13 @@ class BlogPage(Page):
         """
         tags = self.tags.all()
         for tag in tags:
-            tag.url = '/' + '/'.join(s.strip('/') for s in [
-                self.get_parent().url,
-                'tags',
-                tag.slug
-            ])
+            tag.url = "/" + "/".join(
+                s.strip("/") for s in [self.get_parent().url, "tags", tag.slug]
+            )
         return tags
 
     # Specifies parent to BlogPage as being BlogIndexPages
-    parent_page_types = ['BlogIndexPage']
+    parent_page_types = ["BlogIndexPage"]
 
     # Specifies what content types can exist as children of BlogPage.
     # Empty list means that no child content types are allowed.
@@ -137,25 +132,24 @@ class BlogIndexPage(RoutablePageMixin, Page):
     RoutablePageMixin is used to allow for a custom sub-URL for the tag views
     defined above.
     """
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
 
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
     ]
 
     # Speficies that only BlogPage objects can live under this index page
-    subpage_types = ['BlogPage']
+    subpage_types = ["BlogPage"]
 
     # Defines a method to access the children of the page (e.g. BlogPage
     # objects). On the demo site we use this on the HomePage
@@ -167,17 +161,17 @@ class BlogIndexPage(RoutablePageMixin, Page):
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
         context = super(BlogIndexPage, self).get_context(request)
-        context['posts'] = BlogPage.objects.descendant_of(
-            self).live().order_by(
-            '-date_published')
+        context["posts"] = (
+            BlogPage.objects.descendant_of(self).live().order_by("-date_published")
+        )
         return context
 
     # This defines a Custom view that utilizes Tags. This view will return all
     # related BlogPages for a given Tag or redirect back to the BlogIndexPage.
     # More information on RoutablePages is at
     # https://docs.wagtail.org/en/stable/reference/contrib/routablepage.html
-    @route(r'^tags/$', name='tag_archive')
-    @route(r'^tags/([\w-]+)/$', name='tag_archive')
+    @route(r"^tags/$", name="tag_archive")
+    @route(r"^tags/([\w-]+)/$", name="tag_archive")
     def tag_archive(self, request, tag=None):
 
         try:
@@ -189,11 +183,8 @@ class BlogIndexPage(RoutablePageMixin, Page):
             return redirect(self.url)
 
         posts = self.get_posts(tag=tag)
-        context = {
-            'tag': tag,
-            'posts': posts
-        }
-        return render(request, 'blog/blog_index_page.html', context)
+        context = {"tag": tag, "posts": posts}
+        return render(request, "blog/blog_index_page.html", context)
 
     def serve_preview(self, request, mode_name):
         # Needed for previews to work

--- a/bakerydemo/breads/migrations/0001_initial.py
+++ b/bakerydemo/breads/migrations/0001_initial.py
@@ -16,84 +16,336 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0032_add_bulk_delete_page_permission'),
-        ('wagtailimages', '0018_remove_rendition_filter'),
+        ("wagtailcore", "0032_add_bulk_delete_page_permission"),
+        ("wagtailimages", "0018_remove_rendition_filter"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='BreadIngredient',
+            name="BreadIngredient",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
             ],
             options={
-                'verbose_name_plural': 'Bread ingredients',
+                "verbose_name_plural": "Bread ingredients",
             },
         ),
         migrations.CreateModel(
-            name='BreadPage',
+            name="BreadPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.CreateModel(
-            name='BreadsIndexPage',
+            name="BreadsIndexPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.CreateModel(
-            name='BreadType',
+            name="BreadType",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('title', models.CharField(max_length=255)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=255)),
             ],
             options={
-                'verbose_name_plural': 'Bread types',
+                "verbose_name_plural": "Bread types",
             },
         ),
         migrations.CreateModel(
-            name='Country',
+            name="Country",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('title', models.CharField(max_length=100)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=100)),
             ],
             options={
-                'verbose_name_plural': 'Countries of Origin',
+                "verbose_name_plural": "Countries of Origin",
             },
         ),
         migrations.AddField(
-            model_name='breadpage',
-            name='bread_type',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='breads.BreadType'),
+            model_name="breadpage",
+            name="bread_type",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="breads.BreadType",
+            ),
         ),
         migrations.AddField(
-            model_name='breadpage',
-            name='image',
-            field=models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image'),
+            model_name="breadpage",
+            name="image",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.Image",
+            ),
         ),
         migrations.AddField(
-            model_name='breadpage',
-            name='ingredients',
-            field=modelcluster.fields.ParentalManyToManyField(blank=True, to='breads.BreadIngredient'),
+            model_name="breadpage",
+            name="ingredients",
+            field=modelcluster.fields.ParentalManyToManyField(
+                blank=True, to="breads.BreadIngredient"
+            ),
         ),
         migrations.AddField(
-            model_name='breadpage',
-            name='origin',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='breads.Country'),
+            model_name="breadpage",
+            name="origin",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to="breads.Country",
+            ),
         ),
     ]

--- a/bakerydemo/breads/migrations/0002_remove_breadsindexpage_body.py
+++ b/bakerydemo/breads/migrations/0002_remove_breadsindexpage_body.py
@@ -8,12 +8,12 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('breads', '0001_initial'),
+        ("breads", "0001_initial"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='breadsindexpage',
-            name='body',
+            model_name="breadsindexpage",
+            name="body",
         ),
     ]

--- a/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
@@ -12,13 +12,92 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('breads', '0002_remove_breadsindexpage_body'),
+        ("breads", "0002_remove_breadsindexpage_body"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='breadpage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body'),
+            model_name="breadpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
@@ -10,13 +10,93 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('breads', '0003_auto_20170329_0055'),
+        ("breads", "0003_auto_20170329_0055"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='breadpage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Page body'),
+            model_name="breadpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -1,9 +1,7 @@
 from django import forms
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-
 from modelcluster.fields import ParentalManyToManyField
-
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import Page

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -4,9 +4,7 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from modelcluster.fields import ParentalManyToManyField
 
-from wagtail.admin.panels import (
-    FieldPanel, MultiFieldPanel
-)
+from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import Page
 from wagtail.search import index
@@ -45,17 +43,18 @@ class BreadIngredient(models.Model):
     model to display this. The Wagtail Docs give a slightly more detailed example
     https://docs.wagtail.org/en/stable/getting_started/tutorial.html#categories
     """
+
     name = models.CharField(max_length=255)
 
     panels = [
-        FieldPanel('name'),
+        FieldPanel("name"),
     ]
 
     def __str__(self):
         return self.name
 
     class Meta:
-        verbose_name_plural = 'Bread ingredients'
+        verbose_name_plural = "Bread ingredients"
 
 
 @register_snippet
@@ -72,7 +71,7 @@ class BreadType(models.Model):
     title = models.CharField(max_length=255)
 
     panels = [
-        FieldPanel('title'),
+        FieldPanel("title"),
     ]
 
     def __str__(self):
@@ -86,16 +85,15 @@ class BreadPage(Page):
     """
     Detail view for a specific bread
     """
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
     body = StreamField(
         BaseStreamBlock(), verbose_name="Page body", blank=True, use_json_field=True
@@ -113,37 +111,37 @@ class BreadPage(Page):
     # relationship called `foopage_objects` that will throw a valueError on
     # collision.
     bread_type = models.ForeignKey(
-        'breads.BreadType',
+        "breads.BreadType",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+'
+        related_name="+",
     )
-    ingredients = ParentalManyToManyField('BreadIngredient', blank=True)
+    ingredients = ParentalManyToManyField("BreadIngredient", blank=True)
 
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
-        FieldPanel('body'),
-        FieldPanel('origin'),
-        FieldPanel('bread_type'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
+        FieldPanel("body"),
+        FieldPanel("origin"),
+        FieldPanel("bread_type"),
         MultiFieldPanel(
             [
                 FieldPanel(
-                    'ingredients',
+                    "ingredients",
                     widget=forms.CheckboxSelectMultiple,
                 ),
             ],
             heading="Additional Metadata",
-            classname="collapsible collapsed"
+            classname="collapsible collapsed",
         ),
     ]
 
     search_fields = Page.search_fields + [
-        index.SearchField('body'),
+        index.SearchField("body"),
     ]
 
-    parent_page_types = ['BreadsIndexPage']
+    parent_page_types = ["BreadsIndexPage"]
 
 
 class BreadsIndexPage(Page):
@@ -155,32 +153,30 @@ class BreadsIndexPage(Page):
     to be discrete functions to make it easier to follow
     """
 
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and '
-        '3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and " "3000px.",
     )
 
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
     ]
 
     # Can only have BreadPage children
-    subpage_types = ['BreadPage']
+    subpage_types = ["BreadPage"]
 
     # Returns a queryset of BreadPage objects that are live, that are direct
     # descendants of this index page with most recent first
     def get_breads(self):
-        return BreadPage.objects.live().descendant_of(
-            self).order_by('-first_published_at')
+        return (
+            BreadPage.objects.live().descendant_of(self).order_by("-first_published_at")
+        )
 
     # Allows child objects (e.g. BreadPage objects) to be accessible via the
     # template. We use this on the HomePage to display child items of featured
@@ -192,7 +188,7 @@ class BreadsIndexPage(Page):
     # standard Django app would, but the difference here being we have it as a
     # method on the model rather than within a view function
     def paginate(self, request, *args):
-        page = request.GET.get('page')
+        page = request.GET.get("page")
         paginator = Paginator(self.get_breads(), 12)
         try:
             pages = paginator.page(page)
@@ -210,6 +206,6 @@ class BreadsIndexPage(Page):
         # BreadPage objects (get_breads) are passed through pagination
         breads = self.paginate(request, self.get_breads())
 
-        context['breads'] = breads
+        context["breads"] = breads
 
         return context

--- a/bakerydemo/locations/choices.py
+++ b/bakerydemo/locations/choices.py
@@ -1,10 +1,9 @@
-
 DAY_CHOICES = (
-    ('MON', 'Monday'),
-    ('TUES', 'Tuesday'),
-    ('WED', 'Wednesday'),
-    ('THUR', 'Thursday'),
-    ('FRI', 'Friday'),
-    ('SAT', 'Saturday'),
-    ('SUN', 'Sunday'),
+    ("MON", "Monday"),
+    ("TUES", "Tuesday"),
+    ("WED", "Wednesday"),
+    ("THUR", "Thursday"),
+    ("FRI", "Friday"),
+    ("SAT", "Saturday"),
+    ("SUN", "Sunday"),
 )

--- a/bakerydemo/locations/migrations/0001_initial.py
+++ b/bakerydemo/locations/migrations/0001_initial.py
@@ -17,57 +17,324 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0032_add_bulk_delete_page_permission'),
-        ('wagtailimages', '0018_remove_rendition_filter'),
+        ("wagtailcore", "0032_add_bulk_delete_page_permission"),
+        ("wagtailimages", "0018_remove_rendition_filter"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='LocationOperatingHours',
+            name="LocationOperatingHours",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('sort_order', models.IntegerField(blank=True, editable=False, null=True)),
-                ('day', models.CharField(choices=[('MON', 'Monday'), ('TUES', 'Tuesday'), ('WED', 'Wednesday'), ('THUR', 'Thursday'), ('FRI', 'Friday'), ('SAT', 'Saturday'), ('SUN', 'Sunday')], default='MON', max_length=4)),
-                ('opening_time', models.TimeField(blank=True, null=True)),
-                ('closing_time', models.TimeField(blank=True, null=True)),
-                ('closed', models.BooleanField(help_text='Tick if location is closed on this day', verbose_name='Closed?')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "sort_order",
+                    models.IntegerField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "day",
+                    models.CharField(
+                        choices=[
+                            ("MON", "Monday"),
+                            ("TUES", "Tuesday"),
+                            ("WED", "Wednesday"),
+                            ("THUR", "Thursday"),
+                            ("FRI", "Friday"),
+                            ("SAT", "Saturday"),
+                            ("SUN", "Sunday"),
+                        ],
+                        default="MON",
+                        max_length=4,
+                    ),
+                ),
+                ("opening_time", models.TimeField(blank=True, null=True)),
+                ("closing_time", models.TimeField(blank=True, null=True)),
+                (
+                    "closed",
+                    models.BooleanField(
+                        help_text="Tick if location is closed on this day",
+                        verbose_name="Closed?",
+                    ),
+                ),
             ],
             options={
-                'ordering': ['sort_order'],
-                'abstract': False,
+                "ordering": ["sort_order"],
+                "abstract": False,
             },
         ),
         migrations.CreateModel(
-            name='LocationPage',
+            name="LocationPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('address', models.TextField()),
-                ('lat_long', models.CharField(help_text="Comma separated lat/long. (Ex. 64.144367, -21.939182)                    Right click Google Maps and select 'What's Here'", max_length=36, validators=[django.core.validators.RegexValidator(code='invalid_lat_long', message='Lat Long must be a comma-separated numeric lat and long', regex='^(\\-?\\d+(\\.\\d+)?),\\s*(\\-?\\d+(\\.\\d+)?)$')])),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                ("address", models.TextField()),
+                (
+                    "lat_long",
+                    models.CharField(
+                        help_text="Comma separated lat/long. (Ex. 64.144367, -21.939182)                    Right click Google Maps and select 'What's Here'",
+                        max_length=36,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                code="invalid_lat_long",
+                                message="Lat Long must be a comma-separated numeric lat and long",
+                                regex="^(\\-?\\d+(\\.\\d+)?),\\s*(\\-?\\d+(\\.\\d+)?)$",
+                            )
+                        ],
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.CreateModel(
-            name='LocationsIndexPage',
+            name="LocationsIndexPage",
             fields=[
-                ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('introduction', models.TextField(blank=True, help_text='Text to describe the page')),
-                ('body', wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Guy Picciotto', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body')),
-                ('image', models.ForeignKey(blank=True, help_text='Landscape mode only; horizontal width between 1000px and 3000px.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailimages.Image')),
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.Page",
+                    ),
+                ),
+                (
+                    "introduction",
+                    models.TextField(blank=True, help_text="Text to describe the page"),
+                ),
+                (
+                    "body",
+                    wagtail.fields.StreamField(
+                        (
+                            (
+                                "heading_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "heading_text",
+                                            wagtail.blocks.CharBlock(
+                                                classname="title", required=True
+                                            ),
+                                        ),
+                                        (
+                                            "size",
+                                            wagtail.blocks.ChoiceBlock(
+                                                blank=True,
+                                                choices=[
+                                                    ("", "Select a header size"),
+                                                    ("h2", "H2"),
+                                                    ("h3", "H3"),
+                                                    ("h4", "H4"),
+                                                ],
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "paragraph_block",
+                                wagtail.blocks.RichTextBlock(
+                                    icon="fa-paragraph",
+                                    template="blocks/paragraph_block.html",
+                                ),
+                            ),
+                            (
+                                "image_block",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        (
+                                            "image",
+                                            wagtail.images.blocks.ImageChooserBlock(
+                                                required=True
+                                            ),
+                                        ),
+                                        (
+                                            "caption",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                        (
+                                            "attribution",
+                                            wagtail.blocks.CharBlock(required=False),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "block_quote",
+                                wagtail.blocks.StructBlock(
+                                    (
+                                        ("text", wagtail.blocks.TextBlock()),
+                                        (
+                                            "attribute_name",
+                                            wagtail.blocks.CharBlock(
+                                                blank=True,
+                                                label="e.g. Guy Picciotto",
+                                                required=False,
+                                            ),
+                                        ),
+                                    )
+                                ),
+                            ),
+                            (
+                                "embed_block",
+                                wagtail.embeds.blocks.EmbedBlock(
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    icon="fa-s15",
+                                    template="blocks/embed_block.html",
+                                ),
+                            ),
+                        ),
+                        blank=True,
+                        verbose_name="Page body",
+                    ),
+                ),
+                (
+                    "image",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.Image",
+                    ),
+                ),
             ],
             options={
-                'abstract': False,
+                "abstract": False,
             },
-            bases=('wagtailcore.page', models.Model),
+            bases=("wagtailcore.page", models.Model),
         ),
         migrations.AddField(
-            model_name='locationoperatinghours',
-            name='location',
-            field=modelcluster.fields.ParentalKey(on_delete=django.db.models.deletion.CASCADE, related_name='hours_of_operation', to='locations.LocationPage'),
+            model_name="locationoperatinghours",
+            name="location",
+            field=modelcluster.fields.ParentalKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="hours_of_operation",
+                to="locations.LocationPage",
+            ),
         ),
     ]

--- a/bakerydemo/locations/migrations/0002_remove_locationsindexpage_body.py
+++ b/bakerydemo/locations/migrations/0002_remove_locationsindexpage_body.py
@@ -8,12 +8,12 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('locations', '0001_initial'),
+        ("locations", "0001_initial"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='locationsindexpage',
-            name='body',
+            model_name="locationsindexpage",
+            name="body",
         ),
     ]

--- a/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
@@ -12,13 +12,92 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('locations', '0002_remove_locationsindexpage_body'),
+        ("locations", "0002_remove_locationsindexpage_body"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='locationpage',
-            name='body',
-            field=wagtail.fields.StreamField((('heading_block', wagtail.blocks.StructBlock((('heading_text', wagtail.blocks.CharBlock(classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))))), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock((('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))))), ('block_quote', wagtail.blocks.StructBlock((('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))))), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))), blank=True, verbose_name='Page body'),
+            model_name="locationpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                (
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            (
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            (
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ),
+                blank=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/locations/migrations/0004_auto_20190912_1149.py
+++ b/bakerydemo/locations/migrations/0004_auto_20190912_1149.py
@@ -6,13 +6,17 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('locations', '0003_auto_20170329_0055'),
+        ("locations", "0003_auto_20170329_0055"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='locationoperatinghours',
-            name='closed',
-            field=models.BooleanField(blank=True, help_text='Tick if location is closed on this day', verbose_name='Closed?'),
+            model_name="locationoperatinghours",
+            name="closed",
+            field=models.BooleanField(
+                blank=True,
+                help_text="Tick if location is closed on this day",
+                verbose_name="Closed?",
+            ),
         ),
     ]

--- a/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
@@ -10,13 +10,93 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('locations', '0004_auto_20190912_1149'),
+        ("locations", "0004_auto_20190912_1149"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='locationpage',
-            name='body',
-            field=wagtail.fields.StreamField([('heading_block', wagtail.blocks.StructBlock([('heading_text', wagtail.blocks.CharBlock(form_classname='title', required=True)), ('size', wagtail.blocks.ChoiceBlock(blank=True, choices=[('', 'Select a header size'), ('h2', 'H2'), ('h3', 'H3'), ('h4', 'H4')], required=False))])), ('paragraph_block', wagtail.blocks.RichTextBlock(icon='fa-paragraph', template='blocks/paragraph_block.html')), ('image_block', wagtail.blocks.StructBlock([('image', wagtail.images.blocks.ImageChooserBlock(required=True)), ('caption', wagtail.blocks.CharBlock(required=False)), ('attribution', wagtail.blocks.CharBlock(required=False))])), ('block_quote', wagtail.blocks.StructBlock([('text', wagtail.blocks.TextBlock()), ('attribute_name', wagtail.blocks.CharBlock(blank=True, label='e.g. Mary Berry', required=False))])), ('embed_block', wagtail.embeds.blocks.EmbedBlock(help_text='Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks', icon='fa-s15', template='blocks/embed_block.html'))], blank=True, use_json_field=True, verbose_name='Page body'),
+            model_name="locationpage",
+            name="body",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "heading_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "heading_text",
+                                    wagtail.blocks.CharBlock(
+                                        form_classname="title", required=True
+                                    ),
+                                ),
+                                (
+                                    "size",
+                                    wagtail.blocks.ChoiceBlock(
+                                        blank=True,
+                                        choices=[
+                                            ("", "Select a header size"),
+                                            ("h2", "H2"),
+                                            ("h3", "H3"),
+                                            ("h4", "H4"),
+                                        ],
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "paragraph_block",
+                        wagtail.blocks.RichTextBlock(
+                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                        ),
+                    ),
+                    (
+                        "image_block",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        required=True
+                                    ),
+                                ),
+                                ("caption", wagtail.blocks.CharBlock(required=False)),
+                                (
+                                    "attribution",
+                                    wagtail.blocks.CharBlock(required=False),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "block_quote",
+                        wagtail.blocks.StructBlock(
+                            [
+                                ("text", wagtail.blocks.TextBlock()),
+                                (
+                                    "attribute_name",
+                                    wagtail.blocks.CharBlock(
+                                        blank=True,
+                                        label="e.g. Mary Berry",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    (
+                        "embed_block",
+                        wagtail.embeds.blocks.EmbedBlock(
+                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            icon="fa-s15",
+                            template="blocks/embed_block.html",
+                        ),
+                    ),
+                ],
+                blank=True,
+                use_json_field=True,
+                verbose_name="Page body",
+            ),
         ),
     ]

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -20,30 +20,18 @@ class OperatingHours(models.Model):
     A Django model to capture operating hours for a Location
     """
 
-    day = models.CharField(
-        max_length=4,
-        choices=DAY_CHOICES,
-        default='MON'
-    )
-    opening_time = models.TimeField(
-        blank=True,
-        null=True
-    )
-    closing_time = models.TimeField(
-        blank=True,
-        null=True
-    )
+    day = models.CharField(max_length=4, choices=DAY_CHOICES, default="MON")
+    opening_time = models.TimeField(blank=True, null=True)
+    closing_time = models.TimeField(blank=True, null=True)
     closed = models.BooleanField(
-        "Closed?",
-        blank=True,
-        help_text='Tick if location is closed on this day'
+        "Closed?", blank=True, help_text="Tick if location is closed on this day"
     )
 
     panels = [
-        FieldPanel('day'),
-        FieldPanel('opening_time'),
-        FieldPanel('closing_time'),
-        FieldPanel('closed'),
+        FieldPanel("day"),
+        FieldPanel("opening_time"),
+        FieldPanel("closing_time"),
+        FieldPanel("closed"),
     ]
 
     class Meta:
@@ -51,19 +39,14 @@ class OperatingHours(models.Model):
 
     def __str__(self):
         if self.opening_time:
-            opening = self.opening_time.strftime('%H:%M')
+            opening = self.opening_time.strftime("%H:%M")
         else:
-            opening = '--'
+            opening = "--"
         if self.closing_time:
-            closed = self.closing_time.strftime('%H:%M')
+            closed = self.closing_time.strftime("%H:%M")
         else:
-            closed = '--'
-        return '{}: {} - {} {}'.format(
-            self.day,
-            opening,
-            closed,
-            settings.TIME_ZONE
-        )
+            closed = "--"
+        return "{}: {} - {} {}".format(self.day, opening, closed, settings.TIME_ZONE)
 
 
 class LocationOperatingHours(Orderable, OperatingHours):
@@ -75,10 +58,9 @@ class LocationOperatingHours(Orderable, OperatingHours):
     relate the two objects to one another. We use the ParentalKey's related_
     name to access it from the LocationPage admin
     """
+
     location = ParentalKey(
-        'LocationPage',
-        related_name='hours_of_operation',
-        on_delete=models.CASCADE
+        "LocationPage", related_name="hours_of_operation", on_delete=models.CASCADE
     )
 
 
@@ -86,20 +68,19 @@ class LocationsIndexPage(Page):
     """
     A Page model that creates an index page (a listview)
     """
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
 
     # Only LocationPage objects can be added underneath this index page
-    subpage_types = ['LocationPage']
+    subpage_types = ["LocationPage"]
 
     # Allows children of this indexpage to be accessible via the indexpage
     # object on templates. We use this on the homepage to show featured
@@ -112,14 +93,14 @@ class LocationsIndexPage(Page):
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
         context = super(LocationsIndexPage, self).get_context(request)
-        context['locations'] = LocationPage.objects.descendant_of(
-            self).live().order_by(
-            'title')
+        context["locations"] = (
+            LocationPage.objects.descendant_of(self).live().order_by("title")
+        )
         return context
 
     content_panels = Page.content_panels + [
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
     ]
 
 
@@ -127,16 +108,15 @@ class LocationPage(Page):
     """
     Detail for a specific bakery location.
     """
-    introduction = models.TextField(
-        help_text='Text to describe the page',
-        blank=True)
+
+    introduction = models.TextField(help_text="Text to describe the page", blank=True)
     image = models.ForeignKey(
-        'wagtailimages.Image',
+        "wagtailimages.Image",
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
-        help_text='Landscape mode only; horizontal width between 1000px and 3000px.'
+        related_name="+",
+        help_text="Landscape mode only; horizontal width between 1000px and 3000px.",
     )
     body = StreamField(
         BaseStreamBlock(), verbose_name="Page body", blank=True, use_json_field=True
@@ -145,31 +125,31 @@ class LocationPage(Page):
     lat_long = models.CharField(
         max_length=36,
         help_text="Comma separated lat/long. (Ex. 64.144367, -21.939182) \
-                   Right click Google Maps and select 'What\'s Here'",
+                   Right click Google Maps and select 'What's Here'",
         validators=[
             RegexValidator(
-                regex=r'^(\-?\d+(\.\d+)?),\s*(\-?\d+(\.\d+)?)$',
-                message='Lat Long must be a comma-separated numeric lat and long',
-                code='invalid_lat_long'
+                regex=r"^(\-?\d+(\.\d+)?),\s*(\-?\d+(\.\d+)?)$",
+                message="Lat Long must be a comma-separated numeric lat and long",
+                code="invalid_lat_long",
             ),
-        ]
+        ],
     )
 
     # Search index configuration
     search_fields = Page.search_fields + [
-        index.SearchField('address'),
-        index.SearchField('body'),
+        index.SearchField("address"),
+        index.SearchField("body"),
     ]
 
     # Fields to show to the editor in the admin view
     content_panels = [
-        FieldPanel('title', classname="full"),
-        FieldPanel('introduction', classname="full"),
-        FieldPanel('image'),
-        FieldPanel('body'),
-        FieldPanel('address', classname="full"),
-        FieldPanel('lat_long'),
-        InlinePanel('hours_of_operation', label="Hours of Operation"),
+        FieldPanel("title", classname="full"),
+        FieldPanel("introduction", classname="full"),
+        FieldPanel("image"),
+        FieldPanel("body"),
+        FieldPanel("address", classname="full"),
+        FieldPanel("lat_long"),
+        InlinePanel("hours_of_operation", label="Hours of Operation"),
     ]
 
     def __str__(self):
@@ -184,12 +164,12 @@ class LocationPage(Page):
     def is_open(self):
         now = datetime.now()
         current_time = now.time()
-        current_day = now.strftime('%a').upper()
+        current_day = now.strftime("%a").upper()
         try:
             self.operating_hours.get(
                 day=current_day,
                 opening_time__lte=current_time,
-                closing_time__gte=current_time
+                closing_time__gte=current_time,
             )
             return True
         except LocationOperatingHours.DoesNotExist:
@@ -199,10 +179,10 @@ class LocationPage(Page):
     # the latitude, longitude and map API key to render the map
     def get_context(self, request):
         context = super(LocationPage, self).get_context(request)
-        context['lat'] = self.lat_long.split(",")[0]
-        context['long'] = self.lat_long.split(",")[1]
-        context['google_map_api_key'] = settings.GOOGLE_MAP_API_KEY
+        context["lat"] = self.lat_long.split(",")[0]
+        context["long"] = self.lat_long.split(",")[1]
+        context["google_map_api_key"] = settings.GOOGLE_MAP_API_KEY
         return context
 
     # Can only be placed under a LocationsIndexPage object
-    parent_page_types = ['LocationsIndexPage']
+    parent_page_types = ["LocationsIndexPage"]

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -3,11 +3,9 @@ from datetime import datetime
 from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
-
 from modelcluster.fields import ParentalKey
-
-from wagtail.fields import StreamField
 from wagtail.admin.panels import FieldPanel, InlinePanel
+from wagtail.fields import StreamField
 from wagtail.models import Orderable, Page
 from wagtail.search import index
 

--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -12,9 +12,9 @@ from bakerydemo.locations.models import LocationPage
 
 def search(request):
     # Search
-    search_query = request.GET.get('q', None)
+    search_query = request.GET.get("q", None)
     if search_query:
-        if 'elasticsearch' in settings.WAGTAILSEARCH_BACKENDS['default']['BACKEND']:
+        if "elasticsearch" in settings.WAGTAILSEARCH_BACKENDS["default"]["BACKEND"]:
             # In production, use ElasticSearch and a simplified search query, per
             # https://docs.wagtail.org/en/stable/topics/search/backends.html
             # like this:
@@ -44,7 +44,7 @@ def search(request):
         search_results = Page.objects.none()
 
     # Pagination
-    page = request.GET.get('page', 1)
+    page = request.GET.get("page", 1)
     paginator = Paginator(search_results, 10)
     try:
         search_results = paginator.page(page)
@@ -53,7 +53,11 @@ def search(request):
     except EmptyPage:
         search_results = paginator.page(paginator.num_pages)
 
-    return render(request, 'search/search_results.html', {
-        'search_query': search_query,
-        'search_results': search_results,
-    })
+    return render(
+        request,
+        "search/search_results.html",
+        {
+            "search_query": search_query,
+            "search_results": search_results,
+        },
+    )

--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
-
 from wagtail.models import Page
 from wagtail.search.models import Query
 

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'c6u0-9c!7nilj_ysatsda0(f@e_2mws2f!6m0n^o*4#*q#kzp)'
+SECRET_KEY = "c6u0-9c!7nilj_ysatsda0(f@e_2mws2f!6m0n^o*4#*q#kzp)"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -35,89 +35,86 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'bakerydemo.base',
-    'bakerydemo.blog',
-    'bakerydemo.breads',
-    'bakerydemo.locations',
-    'bakerydemo.search',
-
-    'wagtail.contrib.search_promotions',
-    'wagtail.contrib.forms',
-    'wagtail.contrib.redirects',
-    'wagtail.embeds',
-    'wagtail.sites',
-    'wagtail.users',
-    'wagtail.snippets',
-    'wagtail.documents',
-    'wagtail.images',
-    'wagtail.search',
-    'wagtail.admin',
-    'wagtail.api.v2',
-    'wagtail.locales',
-    'wagtail.contrib.modeladmin',
-    'wagtail.contrib.routable_page',
-    'wagtail.contrib.simple_translation',
-    'wagtail.contrib.styleguide',
-    'wagtail',
-
-    'rest_framework',
-    'modelcluster',
-    'taggit',
-    'wagtailfontawesome',
-    'debug_toolbar',
-
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.sitemaps',
+    "bakerydemo.base",
+    "bakerydemo.blog",
+    "bakerydemo.breads",
+    "bakerydemo.locations",
+    "bakerydemo.search",
+    "wagtail.contrib.search_promotions",
+    "wagtail.contrib.forms",
+    "wagtail.contrib.redirects",
+    "wagtail.embeds",
+    "wagtail.sites",
+    "wagtail.users",
+    "wagtail.snippets",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.search",
+    "wagtail.admin",
+    "wagtail.api.v2",
+    "wagtail.locales",
+    "wagtail.contrib.modeladmin",
+    "wagtail.contrib.routable_page",
+    "wagtail.contrib.simple_translation",
+    "wagtail.contrib.styleguide",
+    "wagtail",
+    "rest_framework",
+    "modelcluster",
+    "taggit",
+    "wagtailfontawesome",
+    "debug_toolbar",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
 ]
 
 MIDDLEWARE = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
-
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
-ROOT_URLCONF = 'bakerydemo.urls'
+ROOT_URLCONF = "bakerydemo.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['bakerydemo/templates', ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            "bakerydemo/templates",
+        ],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'bakerydemo.wsgi.application'
+WSGI_APPLICATION = "bakerydemo.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'bakerydemodb')
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "bakerydemodb"),
     }
 }
 
@@ -127,16 +124,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -144,9 +141,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -159,28 +156,28 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATICFILES_FINDERS = [
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
 STATICFILES_DIRS = [
-    os.path.join(PROJECT_DIR, 'static'),
+    os.path.join(PROJECT_DIR, "static"),
 ]
 
-STATIC_ROOT = os.path.join(PROJECT_DIR, 'collect_static')
-STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(PROJECT_DIR, "collect_static")
+STATIC_URL = "/static/"
 
-MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
-MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(PROJECT_DIR, "media")
+MEDIA_URL = "/media/"
 
 # Override in local settings or replace with your own key. Please don't use our demo key in production!
-GOOGLE_MAP_API_KEY = 'AIzaSyD31CT9P9KxvNUJOwDq2kcFEIG8ADgaFgw'
+GOOGLE_MAP_API_KEY = "AIzaSyD31CT9P9KxvNUJOwDq2kcFEIG8ADgaFgw"
 
 # Use Elasticsearch as the search backend for extra performance and better search results
 WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.database',
-        'INDEX': 'bakerydemo',
+    "default": {
+        "BACKEND": "wagtail.search.backends.database",
+        "INDEX": "bakerydemo",
     },
 }
 

--- a/bakerydemo/settings/dev.py
+++ b/bakerydemo/settings/dev.py
@@ -2,9 +2,9 @@ from .base import *  # noqa: F403, F401
 
 DEBUG = True
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # WAGTAILADMIN_BASE_URL required for notification emails
-WAGTAILADMIN_BASE_URL = 'http://localhost:8000'
+WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -7,120 +7,132 @@ import django_cache_url
 
 from .base import *  # noqa: F403
 
-DEBUG = os.getenv('DJANGO_DEBUG', 'off') == 'on'
+DEBUG = os.getenv("DJANGO_DEBUG", "off") == "on"
 
 # DJANGO_SECRET_KEY *should* be specified in the environment. If it's not, generate an ephemeral key.
-if 'DJANGO_SECRET_KEY' in os.environ:
-    SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+if "DJANGO_SECRET_KEY" in os.environ:
+    SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 else:
     # Use if/else rather than a default value to avoid calculating this if we don't need it
-    print("WARNING: DJANGO_SECRET_KEY not found in os.environ. Generating ephemeral SECRET_KEY.")
-    SECRET_KEY = ''.join([random.SystemRandom().choice(string.printable) for i in range(50)])
+    print(
+        "WARNING: DJANGO_SECRET_KEY not found in os.environ. Generating ephemeral SECRET_KEY."
+    )
+    SECRET_KEY = "".join(
+        [random.SystemRandom().choice(string.printable) for i in range(50)]
+    )
 
 # Make sure Django can detect a secure connection properly on Heroku:
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Redirect all requests to HTTPS
-SECURE_SSL_REDIRECT = os.getenv('DJANGO_SECURE_SSL_REDIRECT', 'off') == 'on'
+SECURE_SSL_REDIRECT = os.getenv("DJANGO_SECURE_SSL_REDIRECT", "off") == "on"
 
 # Accept all hostnames, since we don't know in advance which hostname will be used for any given Heroku instance.
 # IMPORTANT: Set this to a real hostname when using this in production!
 # See https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '*').split(';')
+ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "*").split(";")
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # WAGTAILADMIN_BASE_URL required for notification emails
-WAGTAILADMIN_BASE_URL = 'http://localhost:8000'
+WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
 db_from_env = dj_database_url.config(conn_max_age=500)
-DATABASES['default'].update(db_from_env)
+DATABASES["default"].update(db_from_env)
 
 # AWS creds may be used for S3 and/or Elasticsearch
-AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', '')
-AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', '')
-AWS_REGION = os.getenv('AWS_REGION', '')
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+AWS_REGION = os.getenv("AWS_REGION", "")
 
 # configure CACHES from CACHE_URL environment variable (defaults to locmem if no CACHE_URL is set)
-CACHES = {'default': django_cache_url.config()}
+CACHES = {"default": django_cache_url.config()}
 
 # Configure Elasticsearch, if present in os.environ
-ELASTICSEARCH_ENDPOINT = os.getenv('ELASTICSEARCH_ENDPOINT', '')
+ELASTICSEARCH_ENDPOINT = os.getenv("ELASTICSEARCH_ENDPOINT", "")
 
 if ELASTICSEARCH_ENDPOINT:
     from elasticsearch import RequestsHttpConnection
+
     WAGTAILSEARCH_BACKENDS = {
-        'default': {
-            'BACKEND': 'wagtail.search.backends.elasticsearch5',
-            'HOSTS': [{
-                'host': ELASTICSEARCH_ENDPOINT,
-                'port': int(os.getenv('ELASTICSEARCH_PORT', '9200')),
-                'use_ssl': os.getenv('ELASTICSEARCH_USE_SSL', 'off') == 'on',
-                'verify_certs': os.getenv('ELASTICSEARCH_VERIFY_CERTS', 'off') == 'on',
-            }],
-            'OPTIONS': {
-                'connection_class': RequestsHttpConnection,
+        "default": {
+            "BACKEND": "wagtail.search.backends.elasticsearch5",
+            "HOSTS": [
+                {
+                    "host": ELASTICSEARCH_ENDPOINT,
+                    "port": int(os.getenv("ELASTICSEARCH_PORT", "9200")),
+                    "use_ssl": os.getenv("ELASTICSEARCH_USE_SSL", "off") == "on",
+                    "verify_certs": os.getenv("ELASTICSEARCH_VERIFY_CERTS", "off")
+                    == "on",
+                }
+            ],
+            "OPTIONS": {
+                "connection_class": RequestsHttpConnection,
             },
         }
     }
 
     if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
         from aws_requests_auth.aws_auth import AWSRequestsAuth
-        WAGTAILSEARCH_BACKENDS['default']['HOSTS'][0]['http_auth'] = AWSRequestsAuth(
+
+        WAGTAILSEARCH_BACKENDS["default"]["HOSTS"][0]["http_auth"] = AWSRequestsAuth(
             aws_access_key=AWS_ACCESS_KEY_ID,
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-            aws_token=os.getenv('AWS_SESSION_TOKEN', ''),
+            aws_token=os.getenv("AWS_SESSION_TOKEN", ""),
             aws_host=ELASTICSEARCH_ENDPOINT,
             aws_region=AWS_REGION,
-            aws_service='es',
+            aws_service="es",
         )
     elif AWS_REGION:
         # No API keys in the environ, so attempt to discover them with Boto instead, per:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
         # This may be useful if your credentials are obtained via EC2 instance meta data.
         from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
-        WAGTAILSEARCH_BACKENDS['default']['HOSTS'][0]['http_auth'] = BotoAWSRequestsAuth(
+
+        WAGTAILSEARCH_BACKENDS["default"]["HOSTS"][0][
+            "http_auth"
+        ] = BotoAWSRequestsAuth(
             aws_host=ELASTICSEARCH_ENDPOINT,
             aws_region=AWS_REGION,
-            aws_service='es',
+            aws_service="es",
         )
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 
-MIDDLEWARE.append('whitenoise.middleware.WhiteNoiseMiddleware')
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-if 'AWS_STORAGE_BUCKET_NAME' in os.environ:
-    AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
-    AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
+if "AWS_STORAGE_BUCKET_NAME" in os.environ:
+    AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")
+    AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
     AWS_AUTO_CREATE_BUCKET = True
 
-    INSTALLED_APPS.append('storages')
+    INSTALLED_APPS.append("storages")
     MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 
-if 'GS_BUCKET_NAME' in os.environ:
-    GS_BUCKET_NAME = os.getenv('GS_BUCKET_NAME')
-    GS_PROJECT_ID = os.getenv('GS_PROJECT_ID')
-    GS_DEFAULT_ACL = 'publicRead'
+if "GS_BUCKET_NAME" in os.environ:
+    GS_BUCKET_NAME = os.getenv("GS_BUCKET_NAME")
+    GS_PROJECT_ID = os.getenv("GS_PROJECT_ID")
+    GS_DEFAULT_ACL = "publicRead"
     GS_AUTO_CREATE_BUCKET = True
 
-    INSTALLED_APPS.append('storages')
-    DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+    INSTALLED_APPS.append("storages")
+    DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
         },
     },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
         },
     },
 }

--- a/bakerydemo/static/css/font-marcellus.css
+++ b/bakerydemo/static/css/font-marcellus.css
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: 'Marcellus';
+  font-family: Marcellus;
   font-style: normal;
   font-weight: 400;
   font-display: swap;

--- a/bakerydemo/static/css/font-open-sans.css
+++ b/bakerydemo/static/css/font-open-sans.css
@@ -1,10 +1,11 @@
 /* open-sans-300 - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
 @font-face {
-    font-family: 'Open Sans';
-    font-style: normal;
-    font-display: swap;
-    font-weight: 300;
-    src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-300.woff2') format('woff2');
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-300.woff2')
+    format('woff2');
 }
 
 /* open-sans-300italic - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -13,7 +14,8 @@
   font-style: italic;
   font-display: swap;
   font-weight: 300;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-300italic.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-300italic.woff2')
+    format('woff2');
 }
 
 /* open-sans-regular - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -22,7 +24,8 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-regular.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-regular.woff2')
+    format('woff2');
 }
 
 /* open-sans-italic - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -31,7 +34,8 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-italic.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-italic.woff2')
+    format('woff2');
 }
 
 /* open-sans-600 - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -40,7 +44,8 @@
   font-style: normal;
   font-display: swap;
   font-weight: 600;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-600.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-600.woff2')
+    format('woff2');
 }
 
 /* open-sans-600italic - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -49,7 +54,8 @@
   font-style: italic;
   font-display: swap;
   font-weight: 600;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-600italic.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-600italic.woff2')
+    format('woff2');
 }
 
 /* open-sans-700 - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -58,7 +64,8 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-700.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-700.woff2')
+    format('woff2');
 }
 
 /* open-sans-700italic - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -67,7 +74,8 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-700italic.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-700italic.woff2')
+    format('woff2');
 }
 
 /* open-sans-800 - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -76,7 +84,8 @@
   font-style: normal;
   font-display: swap;
   font-weight: 800;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-800.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-800.woff2')
+    format('woff2');
 }
 
 /* open-sans-800italic - vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext */
@@ -85,5 +94,6 @@
   font-style: italic;
   font-display: swap;
   font-weight: 800;
-  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-800italic.woff2') format('woff2');
+  src: url('../fonts/open-sans-v17-vietnamese_greek_cyrillic-ext_cyrillic_latin_greek-ext_latin-ext-800italic.woff2')
+    format('woff2');
 }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -365,7 +365,7 @@ blockquote .text {
   line-height: 1.15;
 }
 
-blockquote .attribute_name {
+blockquote .attribute-name {
   color: var(--dark);
   font-size: var(--font-md);
   line-height: 1.56;
@@ -387,10 +387,12 @@ blockquote .attribute_name {
 }
 
 /* Richtext Styles */
+/* stylelint-disable-next-line selector-class-pattern */
 .block-paragraph_block p {
   color: var(--dark);
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .block-paragraph_block a {
   text-decoration: underline;
 }
@@ -503,6 +505,7 @@ blockquote .attribute_name {
 .navigation__mobile-toggle {
   background-color: transparent;
   border: none;
+  margin: 0 0 0 auto;
 }
 
 .navigation__mobile-toggle[aria-expanded='true'] {
@@ -636,10 +639,6 @@ blockquote .attribute_name {
 .navigation__items > li > a:focus,
 .navigation__items > li > a:hover {
   text-decoration: underline;
-}
-
-.navigation__mobile-toggle {
-  margin: 0 0 0 auto;
 }
 
 /* Required as bootstrap nav automatically hides this otherwise */
@@ -1283,11 +1282,7 @@ input[type='radio'] {
 }
 
 .form-page .required {
-  color: red;
-}
-
-.form-page .fieldWrapper {
-  margin-bottom: 30px;
+  color: var(--orange);
 }
 
 .form-page .help {
@@ -1296,10 +1291,6 @@ input[type='radio'] {
   font-size: var(--font-sm);
   margin-top: 10px;
   max-width: 350px;
-}
-
-.form-page .required {
-  color: var(--orange);
 }
 
 .form-page__field {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -18,7 +18,7 @@
 :root {
   --dark: #333333;
   --grey: #6e6e6e;
-  --border-grey: #E1DCD3;
+  --border-grey: #e1dcd3;
   --transparent-border: rgba(135, 116, 79, 0.25);
   --white: #ffffff;
   --cream: #f5f3e9;
@@ -27,8 +27,8 @@
   --dark-brown: #553801;
   --orange: #c55302;
   --dark-orange: #833701;
-  --font--primary: "Marcellus", serif;
-  --font--secondary: "Open Sans", sans-serif;
+  --font--primary: 'Marcellus', serif;
+  --font--secondary: 'Open Sans', sans-serif;
   --font-sm: 1rem;
   --font-md: 1.125rem;
 }
@@ -500,7 +500,7 @@ blockquote .attribute_name {
   border: none;
 }
 
-.navigation__mobile-toggle[aria-expanded="true"] {
+.navigation__mobile-toggle[aria-expanded='true'] {
   position: absolute;
   z-index: 15;
   top: 30px;
@@ -513,16 +513,18 @@ blockquote .attribute_name {
   }
 }
 
-.navigation__mobile-toggle[aria-expanded="true"] .navigation__toggle-icon-bar {
+.navigation__mobile-toggle[aria-expanded='true'] .navigation__toggle-icon-bar {
   opacity: 0;
 }
 
-.navigation__mobile-toggle[aria-expanded="true"] .navigation__toggle-icon-bar:first-of-type {
+.navigation__mobile-toggle[aria-expanded='true']
+  .navigation__toggle-icon-bar:first-of-type {
   transform: translateY(10px) rotate(45deg);
   opacity: 1;
 }
 
-.navigation__mobile-toggle[aria-expanded="true"] .navigation__toggle-icon-bar:last-child {
+.navigation__mobile-toggle[aria-expanded='true']
+  .navigation__toggle-icon-bar:last-child {
   transform: translateY(-10px) rotate(-45deg);
   opacity: 1;
 }
@@ -584,11 +586,11 @@ blockquote .attribute_name {
   }
 }
 
-.navigation__items>li {
+.navigation__items > li {
   padding: 10px 0;
 }
 
-.navigation__items>li>a {
+.navigation__items > li > a {
   color: var(--dark);
   font-family: var(--font--secondary);
   font-size: var(--font-md);
@@ -596,40 +598,38 @@ blockquote .attribute_name {
   padding: 10px 0;
 }
 
-
-
 @media (min-width: 1150px) {
   .navigation__items {
     display: block;
   }
 
-  .navigation__items>li {
+  .navigation__items > li {
     padding: 0 0 0 20px;
   }
 
-  .navigation__items>li>a {
+  .navigation__items > li > a {
     padding: 10px;
   }
 
-  .navigation__items>li:first-child {
+  .navigation__items > li:first-child {
     padding: 0 0 0 20px;
   }
 }
 
 /* N.B. We're overriding Bootstrap's default nav styles here,
    these rules set what the currently active nav tab looks like. */
-.navigation__items>li.active>a,
-.navigation__items>li.active>a:focus,
-.navigation__items>li.active>a:hover {
+.navigation__items > li.active > a,
+.navigation__items > li.active > a:focus,
+.navigation__items > li.active > a:hover {
   color: var(--dark);
   border-radius: 0;
   border: none;
   background-color: transparent;
 }
 
-.navigation__items>li:hover,
-.navigation__items>li>a:focus,
-.navigation__items>li>a:hover {
+.navigation__items > li:hover,
+.navigation__items > li > a:focus,
+.navigation__items > li > a:hover {
   text-decoration: underline;
 }
 
@@ -709,15 +709,14 @@ blockquote .attribute_name {
   border: transparent;
 }
 
-
-.dropdown-menu>li>a {
+.dropdown-menu > li > a {
   border-bottom: 1px solid var(--border-grey);
   color: var(--dark);
   font-family: var(--font--secondary);
   padding: 10px 20px;
 }
 
-.dropdown-menu>li>a:hover {
+.dropdown-menu > li > a:hover {
   text-decoration: underline;
 }
 
@@ -733,12 +732,12 @@ li.has-submenu a.allow-toggle {
 }
 
 .caret-custom:after {
-  content: "▼" !important;
+  content: '▼' !important;
 }
 
 /* Mobile menu styling */
 @media (max-width: 1150px) {
-  .nav-pills>.presentation {
+  .nav-pills > .presentation {
     float: none;
     width: 100%;
   }
@@ -801,7 +800,7 @@ footer {
   }
 }
 
-.container-narrow>hr {
+.container-narrow > hr {
   margin: 30px 0;
 }
 
@@ -823,7 +822,7 @@ footer {
   background-color: transparent;
 }
 
-.breadcrumb>li+li:before {
+.breadcrumb > li + li:before {
   display: none;
 }
 
@@ -973,7 +972,7 @@ footer {
   color: var(--white);
 }
 
-.blog-tags__pill:hover.blog-tags__pill--selected{
+.blog-tags__pill:hover.blog-tags__pill--selected {
   background-color: var(--dark-orange);
 }
 
@@ -1024,10 +1023,12 @@ footer {
 }
 
 .blog-list-item .text {
-  background: linear-gradient(to bottom,
-      rgba(0, 0, 0, 0) 0%,
-      rgba(0, 0, 0, 0.6) 23%,
-      rgba(0, 0, 0, 1) 50%);
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0.6) 23%,
+    rgba(0, 0, 0, 1) 50%
+  );
   margin-top: -150px;
   padding: 20px;
   position: relative;
@@ -1105,7 +1106,6 @@ footer {
   .blog__tag-introduction {
     margin-top: 100px;
   }
-
 }
 
 /* ---- Gallery Page ---- */
@@ -1248,7 +1248,7 @@ select {
   border: 1px solid var(--dark);
 }
 
-.form-page input[type="submit"]{
+.form-page input[type='submit'] {
   border: none;
   color: var(--white);
   background-color: var(--orange);
@@ -1260,12 +1260,12 @@ select {
   width: max-content;
 }
 
-.form-page input[type="submit"]:hover {
+.form-page input[type='submit']:hover {
   background-color: var(--dark);
 }
 
-.form-page li input[type="checkbox"],
-input[type="radio"] {
+.form-page li input[type='checkbox'],
+input[type='radio'] {
   display: inline-block;
   margin-right: 10px;
 }
@@ -1314,7 +1314,7 @@ input[type="radio"] {
   margin: -10px 0 10px 0;
 }
 
-@media (min-width: 766px){
+@media (min-width: 766px) {
   .form-page input,
   textarea,
   select {
@@ -1326,7 +1326,7 @@ input[type="radio"] {
   }
 
   .form-page__field {
-      margin-bottom: 50px;
+    margin-bottom: 50px;
   }
 }
 
@@ -1678,8 +1678,8 @@ input[type="radio"] {
   }
 }
 
-.row.no-gutters>[class^="col-"],
-.row.no-gutters>[class*=" col-"] {
+.row.no-gutters > [class^='col-'],
+.row.no-gutters > [class*=' col-'] {
   padding-right: 0;
   padding-left: 0;
 }
@@ -1749,7 +1749,7 @@ input[type="radio"] {
 }
 
 .picture-card__image:before {
-  content: "";
+  content: '';
   position: absolute;
   height: 200px;
   left: 0px;
@@ -1871,7 +1871,6 @@ input[type="radio"] {
     font-size: var(--font-sm);
     line-height: 1.5;
   }
-
 }
 
 /* #endregion */

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -1,26 +1,31 @@
-/* The bakery demo avoids using tooling so doesn't use SASS. This is a static */
-/* CSS file that extends Bootstrap. It's deliberately verbose to aid          */
-/* readability with global themes, themes for each list view and themes for   */
-/* each detail view                                                           */
-/* 1. Global styles --------------------------------------------------------- */
-/* 2. Page header ----------------------------------------------------------- */
-/* 3. Main menu ------------------------------------------------------------- */
-/* 4. Breadcrumb ------------------------------------------------------------ */
-/* 5. Location styles ------------------------------------------------------- */
-/* 6. Blog styles ----------------------------------------------------------- */
-/* 7. Bread styles ---------------------------------------------------------- */
-/* 8. Form styles ----------------------------------------------------------- */
-/* 9. Homepage styles ------------------------------------------------------- */
-/* 9. Miscellaneous/ Helper styles ------------------------------------------ */
+/*
+
+The bakery demo avoids using tooling so doesn't use SASS. This is a static
+CSS file that extends Bootstrap. It's deliberately verbose to aid
+readability with global themes, themes for each list view and themes for
+each detail view
+1. Global styles ---------------------------------------------------------
+2. Page header -----------------------------------------------------------
+3. Main menu -------------------------------------------------------------
+4. Breadcrumb ------------------------------------------------------------
+5. Location styles -------------------------------------------------------
+6. Blog styles -----------------------------------------------------------
+7. Bread styles ----------------------------------------------------------
+8. Form styles -----------------------------------------------------------
+9. Homepage styles -------------------------------------------------------
+9. Miscellaneous/ Helper styles ------------------------------------------
+
+*/
 
 /* Global styles */
+
 /* CSS Variables */
 :root {
-  --dark: #333333;
+  --dark: #333;
   --grey: #6e6e6e;
   --border-grey: #e1dcd3;
-  --transparent-border: rgba(135, 116, 79, 0.25);
-  --white: #ffffff;
+  --transparent-border: rgb(135 116 79 / 25%);
+  --white: #fff;
   --cream: #f5f3e9;
   --light-brown: #87744f;
   --mid-brown: #825600;
@@ -252,12 +257,12 @@ figure img {
 }
 
 .alert {
-  margin: 40px auto 0 auto;
+  margin: 40px auto 0;
   max-width: 1400px;
   border-radius: 0;
   background-color: var(--orange);
   color: var(--white);
-  padding: 40px 40px;
+  padding: 40px;
 }
 
 .alert > .alert__title {
@@ -277,19 +282,19 @@ figure img {
 .hero {
   background-size: cover;
   background-position: center;
-  padding: 300px 0 0 0;
+  padding: 300px 0 0;
   position: relative;
   margin: 0 0 10px;
 }
 
 @media screen and (min-width: 768px) {
   .hero {
-    padding: 250px 0 0 0;
+    padding: 250px 0 0;
     margin: 0;
   }
 
   .hero.hero--blog {
-    padding: 400px 0 0 0;
+    padding: 400px 0 0;
   }
 }
 
@@ -298,18 +303,18 @@ figure img {
   width: 100%;
   height: 100%;
   bottom: 0;
-  background: linear-gradient(0deg, #000000 11.33%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(0deg, #000 11.33%, rgb(0 0 0 / 0%) 100%);
 }
 
 @media (min-width: 768px) {
   .hero-gradient-mask {
-    background: linear-gradient(90deg, #000000 11.33%, rgba(0, 0, 0, 0) 100%);
+    background: linear-gradient(90deg, #000 11.33%, rgb(0 0 0 / 0%) 100%);
   }
 }
 
 .hero__container {
   width: 100%;
-  padding: 30px 20px 100px 20px;
+  padding: 30px 20px 100px;
   background-color: var(--orange);
   margin: 0 auto;
 }
@@ -348,13 +353,13 @@ figure img {
 
 blockquote {
   border-left: 3px solid var(--orange);
-  margin: 40px 0 30px 0;
+  margin: 40px 0 30px;
   padding: 0 0 0 20px;
 }
 
 blockquote .text {
   color: var(--orange);
-  margin: 0 0 30px 0;
+  margin: 0 0 30px;
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;
@@ -536,7 +541,7 @@ blockquote .attribute_name {
 
 .navigation__search {
   display: none;
-  margin: 15px 0 0 0;
+  margin: 15px 0 0;
   position: relative;
 }
 
@@ -564,7 +569,7 @@ blockquote .attribute_name {
 .navigation__items {
   list-style: none;
   margin: 0;
-  padding: 20px 0 0 0;
+  padding: 20px 0 0;
 }
 
 .navigation__desktop {
@@ -686,7 +691,7 @@ blockquote .attribute_name {
   font-weight: 400;
   font-size: 1.5rem;
   line-height: 1.25;
-  margin: 0 0 0;
+  margin: 0;
   position: relative;
 }
 
@@ -731,7 +736,7 @@ li.has-submenu a.allow-toggle {
   padding: 10px 10px 15px 5px !important;
 }
 
-.caret-custom:after {
+.caret-custom::after {
   content: '▼' !important;
 }
 
@@ -751,7 +756,7 @@ hr {
 }
 
 footer {
-  padding: 55px 0 30px 0;
+  padding: 55px 0 30px;
   background-color: var(--white);
 }
 
@@ -816,13 +821,13 @@ footer {
   font-family: var(--font--secondary);
   font-size: var(--font-sm);
   line-height: 1.5;
-  margin-bottom: 0px;
-  padding-left: 0px;
+  margin-bottom: 0;
+  padding-left: 0;
   text-decoration: underline;
   background-color: transparent;
 }
 
-.breadcrumb > li + li:before {
+.breadcrumb > li + li::before {
   display: none;
 }
 
@@ -849,7 +854,7 @@ footer {
 /* Pagination navigation */
 .pagination {
   display: block;
-  margin: 0 auto 40px auto;
+  margin: 0 auto 40px;
 }
 
 .pagination__list {
@@ -905,7 +910,7 @@ footer {
 
 /* Location list page */
 .location-list-page {
-  padding: 0 0 70px 0;
+  padding: 0 0 70px;
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
@@ -913,7 +918,7 @@ footer {
 
 @media (min-width: 768px) {
   .location-list-page {
-    padding: 50px 0 110px 0;
+    padding: 50px 0 110px;
     grid-template-columns: 1fr 1fr;
     gap: 30px;
   }
@@ -1025,9 +1030,9 @@ footer {
 .blog-list-item .text {
   background: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.6) 23%,
-    rgba(0, 0, 0, 1) 50%
+    rgb(0 0 0 / 0%) 0%,
+    rgb(0 0 0 / 60%) 23%,
+    rgb(0 0 0 / 100%) 50%
   );
   margin-top: -150px;
   padding: 20px;
@@ -1120,7 +1125,7 @@ footer {
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;
-  margin: 0 0 60px 0;
+  margin: 0 0 60px;
 }
 
 .gallery__grid {
@@ -1138,7 +1143,7 @@ footer {
   .gallery__introduction {
     font-size: 2rem;
     line-height: 1.31;
-    margin: 0 0 85px 0;
+    margin: 0 0 85px;
   }
 
   .gallery__grid {
@@ -1187,7 +1192,7 @@ footer {
 }
 
 .bread-detail figure {
-  margin: 35px auto 20px auto;
+  margin: 35px auto 20px;
   overflow: hidden;
 }
 
@@ -1215,20 +1220,20 @@ footer {
   font-weight: 700;
   font-size: var(--font-md);
   line-height: 1.55;
-  margin: 0 0 5px 0;
+  margin: 0 0 5px;
 }
 
 .bread-detail__meta-content {
   font-family: var(--font--secondary);
   font-size: var(--font-md);
   line-height: 1.55;
-  margin: 0 0 20px 0;
+  margin: 0 0 20px;
 }
 
 @media (min-width: 992px) {
   .bread-detail__meta {
     background-color: var(--cream);
-    padding: 240px 60px 60px 60px;
+    padding: 240px 60px 60px;
     margin-right: -40px;
     margin-bottom: 0;
   }
@@ -1311,7 +1316,7 @@ input[type='radio'] {
   font-family: var(--font--secondary);
   font-size: var(--font-md);
   line-height: 28px;
-  margin: -10px 0 10px 0;
+  margin: -10px 0 10px;
 }
 
 @media (min-width: 766px) {
@@ -1349,7 +1354,7 @@ input[type='radio'] {
 /* #region -- Hero -- */
 .homepage .hero {
   margin: 0;
-  padding: 200px 0 30px 0;
+  padding: 200px 0 30px;
 }
 
 .homepage .home-hero {
@@ -1455,7 +1460,7 @@ input[type='radio'] {
 
 /* #region -- Promo Section */
 .homepage .promo-row {
-  padding: 40px 0 80px 0;
+  padding: 40px 0 80px;
 }
 
 @media (min-width: 768px) {
@@ -1494,7 +1499,7 @@ input[type='radio'] {
 }
 
 .homepage .promo figure img {
-  margin: 40px 0 -200px 0;
+  margin: 40px 0 -200px;
   width: 100%;
   height: auto;
 }
@@ -1503,7 +1508,7 @@ input[type='radio'] {
   .homepage .promo {
     margin-top: -180px;
     margin-right: -120px;
-    padding: 180px 60px 40px 60px;
+    padding: 180px 60px 40px;
   }
 
   .homepage .promo figure img {
@@ -1601,12 +1606,13 @@ input[type='radio'] {
 @media (min-width: 768px) {
   .homepage .locations-section {
     text-align: left;
-    padding: 120px 0 160px 0;
+    padding: 120px 0 160px;
   }
 
   .homepage .locations-section__title {
     font-size: 3.75rem;
     line-height: 1.07;
+
     /* Aligns title with below cards */
     padding-left: 10px;
   }
@@ -1616,7 +1622,7 @@ input[type='radio'] {
 
 /* #region -- Blog Section -- */
 .homepage .blog-section {
-  padding: 80px 20px 100px 20px;
+  padding: 80px 20px 100px;
   text-align: center;
 }
 
@@ -1647,7 +1653,7 @@ input[type='radio'] {
 
 @media (min-width: 768px) {
   .homepage .blog-section {
-    padding: 90px 0 110px 0;
+    padding: 90px 0 110px;
   }
 }
 
@@ -1666,6 +1672,7 @@ input[type='radio'] {
 /* #endregion */
 
 /* Miscellaneous helper styles */
+
 /* No gutters */
 .row.no-gutters {
   margin-right: 0;
@@ -1686,9 +1693,9 @@ input[type='radio'] {
 
 /* Bootstrap Equal height rows */
 .row-eq-height {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
+  display: box;
+  display: flex;
+  display: flexbox;
   display: flex;
   flex-wrap: wrap;
 }
@@ -1748,14 +1755,14 @@ input[type='radio'] {
   transition: transform 0.2s ease;
 }
 
-.picture-card__image:before {
+.picture-card__image::before {
   content: '';
   position: absolute;
   height: 200px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 67.69%);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(180deg, rgb(0 0 0 / 0%) 0%, #000 67.69%);
   z-index: 2;
 }
 

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,23 +1,24 @@
 const navigation = document.querySelector('[data-navigation]');
 const mobileNavigation = navigation.querySelector('[data-mobile-navigation]');
 const body = document.querySelector('body');
-const mobileNavigationToggle = navigation.querySelector('[data-mobile-navigation-toggle]');
+const mobileNavigationToggle = navigation.querySelector(
+  '[data-mobile-navigation-toggle]',
+);
 
 function toggleMobileNavigation() {
-    if (mobileNavigation.hidden) {
-      body.classList.add('no-scroll');
-      mobileNavigation.hidden = false;
-      mobileNavigationToggle.setAttribute('aria-expanded', 'true');
-    } else {
-      body.classList.remove('no-scroll');
-      mobileNavigation.hidden = true;
-      mobileNavigationToggle.setAttribute('aria-expanded', 'false');
-    }
+  if (mobileNavigation.hidden) {
+    body.classList.add('no-scroll');
+    mobileNavigation.hidden = false;
+    mobileNavigationToggle.setAttribute('aria-expanded', 'true');
+  } else {
+    body.classList.remove('no-scroll');
+    mobileNavigation.hidden = true;
+    mobileNavigationToggle.setAttribute('aria-expanded', 'false');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   mobileNavigationToggle.addEventListener('click', () => {
     toggleMobileNavigation();
   });
-})
-
+});

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,55 +1,55 @@
 {% load navigation_tags static wagtailuserbar wagtailfontawesome %}
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<title>
-  {% block title %}
-    {% if page.seo_title %}
-      {{ page.seo_title }}
-    {% else %}
-      {{ page.title }}
-    {% endif %}
-  {% endblock %}
-  {% block title_suffix %}
-    | The Wagtail Bakery
-  {% endblock %}
-</title>
-<meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% endif %}">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+    <head>
+        <meta charset="utf-8">
+        <title>
+            {% block title %}
+                {% if page.seo_title %}
+                    {{ page.seo_title }}
+                {% else %}
+                    {{ page.title }}
+                {% endif %}
+            {% endblock %}
+            {% block title_suffix %}
+                | The Wagtail Bakery
+            {% endblock %}
+        </title>
+        <meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% endif %}">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
-{% fontawesome_css %}
-<link rel="stylesheet" href="{% static 'css/font-marcellus.css' %}">
-<link rel="stylesheet" href="{% static 'css/font-open-sans.css' %}">
-<link rel="stylesheet" href="{% static 'css/main.css' %}">
-</head>
+        <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
+        {% fontawesome_css %}
+        <link rel="stylesheet" href="{% static 'css/font-marcellus.css' %}">
+        <link rel="stylesheet" href="{% static 'css/font-open-sans.css' %}">
+        <link rel="stylesheet" href="{% static 'css/main.css' %}">
+    </head>
 
-<body class="{% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}">
-{% wagtailuserbar %}
+    <body class="{% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}">
+        {% wagtailuserbar %}
 
-{% block header %}
-    {% include "includes/header.html" with parent=site_root calling_page=self %}
-{% endblock header %}
+        {% block header %}
+            {% include "includes/header.html" with parent=site_root calling_page=self %}
+        {% endblock header %}
 
-{% block breadcrumbs %}
-    {# breadcrumbs is defined in base/templatetags/navigation_tags.py #}
-    {% breadcrumbs %}
-{% endblock breadcrumbs %}
+        {% block breadcrumbs %}
+            {# breadcrumbs is defined in base/templatetags/navigation_tags.py #}
+            {% breadcrumbs %}
+        {% endblock breadcrumbs %}
 
-{% block messages %}
-    {% include "includes/messages.html" %}
-{% endblock messages %}
+        {% block messages %}
+            {% include "includes/messages.html" %}
+        {% endblock messages %}
 
-<main>
-    {% block content %}
-    {% endblock content %}
-</main>
+        <main>
+            {% block content %}
+            {% endblock content %}
+        </main>
 
-<hr>
+        <hr>
 
-{% include "includes/footer.html" %}
+        {% include "includes/footer.html" %}
 
-<script type="module" src="{% static 'js/main.js' %}"></script>
-</body>
+        <script type="module" src="{% static 'js/main.js' %}"></script>
+    </body>
 </html>

--- a/bakerydemo/templates/base/form_page.html
+++ b/bakerydemo/templates/base/form_page.html
@@ -3,55 +3,55 @@
 
 {% block content %}
 
-<div class="container">
-    <div class="row">
-        <div class="col-md-12">
-            <h1 class="index-header__title">{{ page.title }}</h1>
-        </div>
-        <div class="col-md-8 index-header__body-introduction">
-            {% if page.intro %}
-                <p class="intro">{{ page.intro|richtext }}</p>
-            {% endif %}
-            {% if page.body %}
-                {{ page.body }}
-            {% endif %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <h1 class="index-header__title">{{ page.title }}</h1>
+            </div>
+            <div class="col-md-8 index-header__body-introduction">
+                {% if page.intro %}
+                    <p class="intro">{{ page.intro|richtext }}</p>
+                {% endif %}
+                {% if page.body %}
+                    {{ page.body }}
+                {% endif %}
+            </div>
         </div>
     </div>
-</div>
 
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 form-page">
-        {% comment %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 form-page">
+                {% comment %}
         You could render your form using a Django rendering shortcut such as `{{ form.as_p }}` but that will tend towards unsemantic code, and make it difficult to style. You can read more on Django form at:
         https://docs.djangoproject.com/en/3.2/topics/forms/#form-rendering-options
         {% endcomment %}
-            <form action="{% pageurl page %}" method="POST">
-                {% csrf_token %}
-                {% if form.subject.errors %}
-                    <ol>
-                    {% for error in form.subject.errors %}
-                        <li><strong>{{ error|escape }}</strong></li>
+                <form action="{% pageurl page %}" method="POST">
+                    {% csrf_token %}
+                    {% if form.subject.errors %}
+                        <ol>
+                            {% for error in form.subject.errors %}
+                                <li><strong>{{ error|escape }}</strong></li>
+                            {% endfor %}
+                        </ol>
+                    {% endif %}
+
+                    {% for field in form %}
+                        <div class="form-page__field" aria-required={% if field.field.required %}"true"{% else %}"false"{% endif %}>
+
+                            {{ field.label_tag }}{% if field.field.required %}<span class="required">*</span>{% endif %}
+
+                            {% if field.help_text %}
+                                <p class="help">{{ field.help_text }}</p>
+                            {% endif %}
+
+                            {{ field }}
+                        </div>
                     {% endfor %}
-                    </ol>
-                {% endif %}
 
-                {% for field in form %}
-                    <div class="form-page__field" aria-required={% if field.field.required %}"true"{% else %}"false"{% endif %}>
-
-                        {{ field.label_tag }}{% if field.field.required %}<span class="required">*</span>{% endif %}
-
-                        {% if field.help_text %}
-                            <p class="help">{{ field.help_text }}</p>
-                        {% endif %}
-
-                        {{ field }}
-                    </div>
-                {% endfor %}
-
-                <input type="submit">
-            </form>
+                    <input type="submit">
+                </form>
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/base/form_page_landing.html
+++ b/bakerydemo/templates/base/form_page_landing.html
@@ -3,14 +3,14 @@
 
 {% block content %}
 
-<div class="container form-page-thanks">
-    <div class="row">
-        <div class="col-md-12">
-            <h1 class="index-header__title">{{ page.title }}</h1>
-        </div>
-        <div class="col-md-7 index-header__body-introduction">
-            {{ page.thank_you_text|richtext }}
+    <div class="container form-page-thanks">
+        <div class="row">
+            <div class="col-md-12">
+                <h1 class="index-header__title">{{ page.title }}</h1>
+            </div>
+            <div class="col-md-7 index-header__body-introduction">
+                {{ page.thank_you_text|richtext }}
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/base/gallery_page.html
+++ b/bakerydemo/templates/base/gallery_page.html
@@ -2,19 +2,19 @@
 {% load wagtailimages_tags gallery_tags %}
 
 {% block content %}
-{% image self.image fill-1920x600 as hero_img %}
-{% include "base/include/header-hero.html" %}
+    {% image self.image fill-1920x600 as hero_img %}
+    {% include "base/include/header-hero.html" %}
 
-<div class="container gallery__container">
-    <div class="row">
-        <div class="col-md-8">
-            {% if page.introduction %}
-            <p class="gallery__introduction">{{ page.introduction }}</p>
-            {% endif %}
+    <div class="container gallery__container">
+        <div class="row">
+            <div class="col-md-8">
+                {% if page.introduction %}
+                    <p class="gallery__introduction">{{ page.introduction }}</p>
+                {% endif %}
+            </div>
+        </div>
+        <div class="gallery__grid">
+            {% gallery page.collection %}
         </div>
     </div>
-    <div class="gallery__grid">
-        {% gallery page.collection %}
-    </div>
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -2,103 +2,103 @@
 {% load wagtailimages_tags wagtailcore_tags %}
 
 {% block content %}
-<div class="homepage">
+    <div class="homepage">
 
-    {% image page.image fill-1920x600 as image %}
-    <div class="container-fluid hero" style="background-image:url('{{ image.url }}')">
-        <div class="hero-gradient-mask"></div>
-        <div class="container">
-            <div class="row">
-                <div class="col-md-6 col-md-offset-1 col-lg-5 home-hero">
-                    <h1>{{ page.title }}</h1>
-                    <p class="lead">{{ page.hero_text }}</p>
-                    {% if page.hero_cta_link %}
-                    <a href="{% pageurl page.hero_cta_link %}" class="hero-cta-link">
-                        {{ page.hero_cta }}
-                    </a>
-                    {% else %}
-                    {{ page.hero_cta }}
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="container">
-        <div class="row promo-row">
-            <div class="featured-cards col-sm-5 col-sm-offset-1">
-                {% if page.featured_section_1 %}
-                <h2 class="featured-cards__title">{{ page.featured_section_1_title }}</h2>
-                <ul class="featured-cards__list">
-                    {% for childpage in page.featured_section_1.specific.children|slice:"3" %}
-                    <li>
-                        {% include "includes/card/listing-card.html" with page=childpage %}
-                    </li>
-                    {% endfor %}
-                </ul>
-                <a class="featured-cards__link" href="/breads">
-                    <span>View more of our breads</span>
-                    {% include "includes/chevron-icon.html" with class="featured-cards__chevron-icon" %}
-                </a>
-                {% endif %}
-            </div>
-
-            <div class="col-sm-6 promo">
-                {% if page.promo_image or page.promo_title or page.promo_text %}
-                <div class="col-lg-10 promo-text">
-                    {% if page.promo_title %}
-                    <h2>{{ page.promo_title }}</h2>
-                    {% endif %}
-                    {% if page.promo_text %}
-                    {{ page.promo_text|richtext }}
-                    {% endif %}
-                </div>
-                {% endif %}
-                {% if page.promo_image %}
-                <figure>{% image page.promo_image fill-590x413-c100 %}</figure>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    {% if page.body %}
-    <div class="container-fluid streamfield">
-        <div class="row">
-            <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 streamfield-column">
-                {{ page.body }}
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12 locations-section">
-                {% if page.featured_section_2 %}
-                <h2 class="locations-section__title">{{ page.featured_section_2_title }}</h2>
-                {% for childpage in page.featured_section_2.specific.children|slice:"3" %}
-                {% include "includes/card/location-card.html" with page=childpage %}
-                {% endfor %}
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    {% if page.featured_section_3 %}
-    <div class="blog-section__background">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12 blog-section">
-                    <h2 class="blog-section__title">{{ page.featured_section_3_title }}</h2>
-                    <div class="blog-section__grid">
-                        {% for childpage in page.featured_section_3.specific.children|slice:"6" %}
-                        {% include "includes/card/picture-card.html" with page=childpage portrait=True %}
-                        {% endfor %}
+        {% image page.image fill-1920x600 as image %}
+        <div class="container-fluid hero" style="background-image:url('{{ image.url }}')">
+            <div class="hero-gradient-mask"></div>
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-6 col-md-offset-1 col-lg-5 home-hero">
+                        <h1>{{ page.title }}</h1>
+                        <p class="lead">{{ page.hero_text }}</p>
+                        {% if page.hero_cta_link %}
+                            <a href="{% pageurl page.hero_cta_link %}" class="hero-cta-link">
+                                {{ page.hero_cta }}
+                            </a>
+                        {% else %}
+                            {{ page.hero_cta }}
+                        {% endif %}
                     </div>
                 </div>
             </div>
         </div>
+
+        <div class="container">
+            <div class="row promo-row">
+                <div class="featured-cards col-sm-5 col-sm-offset-1">
+                    {% if page.featured_section_1 %}
+                        <h2 class="featured-cards__title">{{ page.featured_section_1_title }}</h2>
+                        <ul class="featured-cards__list">
+                            {% for childpage in page.featured_section_1.specific.children|slice:"3" %}
+                                <li>
+                                    {% include "includes/card/listing-card.html" with page=childpage %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                        <a class="featured-cards__link" href="/breads">
+                            <span>View more of our breads</span>
+                            {% include "includes/chevron-icon.html" with class="featured-cards__chevron-icon" %}
+                        </a>
+                    {% endif %}
+                </div>
+
+                <div class="col-sm-6 promo">
+                    {% if page.promo_image or page.promo_title or page.promo_text %}
+                        <div class="col-lg-10 promo-text">
+                            {% if page.promo_title %}
+                                <h2>{{ page.promo_title }}</h2>
+                            {% endif %}
+                            {% if page.promo_text %}
+                                {{ page.promo_text|richtext }}
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    {% if page.promo_image %}
+                        <figure>{% image page.promo_image fill-590x413-c100 %}</figure>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {% if page.body %}
+            <div class="container-fluid streamfield">
+                <div class="row">
+                    <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 streamfield-column">
+                        {{ page.body }}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="container">
+            <div class="row">
+                <div class="col-md-12 locations-section">
+                    {% if page.featured_section_2 %}
+                        <h2 class="locations-section__title">{{ page.featured_section_2_title }}</h2>
+                        {% for childpage in page.featured_section_2.specific.children|slice:"3" %}
+                            {% include "includes/card/location-card.html" with page=childpage %}
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {% if page.featured_section_3 %}
+            <div class="blog-section__background">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-md-12 blog-section">
+                            <h2 class="blog-section__title">{{ page.featured_section_3_title }}</h2>
+                            <div class="blog-section__grid">
+                                {% for childpage in page.featured_section_3.specific.children|slice:"6" %}
+                                    {% include "includes/card/picture-card.html" with page=childpage portrait=True %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     </div>
-    {% endif %}
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/base/include/header-blog.html
+++ b/bakerydemo/templates/base/include/header-blog.html
@@ -9,17 +9,17 @@
         <div class="col-sm-12 col-md-9">
             <h1 class="index-header__title index-header__title--blog">{{ page.title }}</h1>
             {% if page.subtitle %}
-              <p>{{ page.subtitle }}</p>
+                <p>{{ page.subtitle }}</p>
             {% endif %}
         </div>
         <div class="col-sm-12 col-md-7">
             {% if page.introduction %}
-            <p class="index-header__introduction index-header__introduction--blog">{{ page.introduction }}</p>
+                <p class="index-header__introduction index-header__introduction--blog">{{ page.introduction }}</p>
             {% endif %}
             {% if page.date_published %}
-            <div class="blog__published">
-                {{ page.date_published }}
-            </div>
+                <div class="blog__published">
+                    {{ page.date_published }}
+                </div>
             {% endif %}
         </div>
     </div>

--- a/bakerydemo/templates/blocks/blockquote.html
+++ b/bakerydemo/templates/blocks/blockquote.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
 
 <blockquote><p class="text">{{ self.text }}</p>
-<p class="attribute_name">{{ self.attribute_name}}</p>
+    <p class="attribute_name">{{ self.attribute_name}}</p>
 </blockquote>

--- a/bakerydemo/templates/blocks/blockquote.html
+++ b/bakerydemo/templates/blocks/blockquote.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
 
 <blockquote><p class="text">{{ self.text }}</p>
-    <p class="attribute_name">{{ self.attribute_name}}</p>
+    <p class="attribute-name">{{ self.attribute_name}}</p>
 </blockquote>

--- a/bakerydemo/templates/blocks/heading_block.html
+++ b/bakerydemo/templates/blocks/heading_block.html
@@ -4,12 +4,12 @@
 {% endcomment %}
 
 {% if self.size == 'h2' %}
-        <h2>{{ self.heading_text }}</h2>
+    <h2>{{ self.heading_text }}</h2>
 
-    {% elif self.size == 'h3' %}
-        <h3>{{ self.heading_text }}</h3>
+{% elif self.size == 'h3' %}
+    <h3>{{ self.heading_text }}</h3>
 
-    {% elif self.size == 'h4' %}
-        <h4>{{ self.heading_text }}</h4>
+{% elif self.size == 'h4' %}
+    <h4>{{ self.heading_text }}</h4>
 
 {% endif %}

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -2,9 +2,9 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% if tag %}
-  {% block title %}
-    Viewing all blog posts sorted by the tag {{ tag }}
-  {% endblock %}
+    {% block title %}
+        Viewing all blog posts sorted by the tag {{ tag }}
+    {% endblock %}
 {% endif %}
 
 {% block content %}

--- a/bakerydemo/templates/blog/blog_page.html
+++ b/bakerydemo/templates/blog/blog_page.html
@@ -3,35 +3,35 @@
 
 {% block content %}
 
-{% image self.image fill-1920x600 as hero_img %}
-{% include "base/include/header-blog.html" %}
+    {% image self.image fill-1920x600 as hero_img %}
+    {% include "base/include/header-blog.html" %}
 
-<div class="container">
-    <div class="row">
-        <div class="col-md-8">
-            <div class="blog__meta">
-                {% if page.authors %}
-                <div class="blog__avatars">
-                    {% for author in page.authors %}
-                    <div class="blog__author">{% image author.image fill-50x50-c100 class="blog__avatar" %}
-                        {{ author.first_name }} {{ author.last_name }}</div>
-                    {% endfor %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8">
+                <div class="blog__meta">
+                    {% if page.authors %}
+                        <div class="blog__avatars">
+                            {% for author in page.authors %}
+                                <div class="blog__author">{% image author.image fill-50x50-c100 class="blog__avatar" %}
+                                    {{ author.first_name }} {{ author.last_name }}</div>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                 </div>
+
+                {{ page.body }}
+
+                {% if page.get_tags %}
+                    <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
+                    <div class="blog-tags blog-tags--condensed">
+                        <span class="u-sr-only">Filter blog posts by tag</span>
+                        {% for tag in page.get_tags %}
+                            <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
+                        {% endfor %}
+                    </div>
                 {% endif %}
             </div>
-
-            {{ page.body }}
-
-            {% if page.get_tags %}
-            <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
-            <div class="blog-tags blog-tags--condensed">
-                <span class="u-sr-only">Filter blog posts by tag</span>
-                {% for tag in page.get_tags %}
-                <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/breads/bread_page.html
+++ b/bakerydemo/templates/breads/bread_page.html
@@ -51,7 +51,7 @@
 
                 <div class="col-md-7">
                     <div class="row hidden-md-up">
-                    {{ page.body }}
+                        {{ page.body }}
                     </div>
                 </div>
             </div>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -6,11 +6,11 @@
             <a href="/" class="navigation__logo">The Wagtail Bakery</a>
 
             <button
-              type="button"
-              class="navigation__mobile-toggle"
-              aria-label="Toggle mobile menu"
-              aria-expanded="false"
-              data-mobile-navigation-toggle
+                type="button"
+                class="navigation__mobile-toggle"
+                aria-label="Toggle mobile menu"
+                aria-expanded="false"
+                data-mobile-navigation-toggle
             >
                 <span class="navigation__toggle-icon-bar"></span>
                 <span class="navigation__toggle-icon-bar"></span>

--- a/bakerydemo/templates/includes/messages.html
+++ b/bakerydemo/templates/includes/messages.html
@@ -3,7 +3,7 @@
         <p class="alert__title">Error</p>
         <ul class="alert__messages">
             {% for message in messages %}
-            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
             {% endfor %}
         </ul>
     </div>

--- a/bakerydemo/templates/includes/pagination.html
+++ b/bakerydemo/templates/includes/pagination.html
@@ -6,7 +6,7 @@
             <li class="page-item">
                 <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">previous</a>
             </li>
-            {% else %}
+        {% else %}
             <li class="page-item disabled">
                 <a class="page-link">previous</a>
             </li>
@@ -14,17 +14,17 @@
 
         {% for i in subpages.paginator.page_range %}
             {% if subpages.number == i %}
-              <li class="page-item active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                <li class="page-item active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
             {% else %}
-              <li class="page-item"><a href="?page={{ query_string|urlencode }}&amp;page={{ i }}" class="page-link">{{ i }}</a></li>
+                <li class="page-item"><a href="?page={{ query_string|urlencode }}&amp;page={{ i }}" class="page-link">{{ i }}</a></li>
             {% endif %}
-          {% endfor %}
+        {% endfor %}
 
         {% if subpages.has_next %}
             <li class="page-item">
                 <a href="?page={{ subpages.next_page_number }}" class="page-link next arrows">next</a>
             </li>
-            {% else %}
+        {% else %}
             <li class="page-item disabled">
                 <a class="page-link">next</a>
             </li>

--- a/bakerydemo/templates/locations/location_page.html
+++ b/bakerydemo/templates/locations/location_page.html
@@ -2,68 +2,68 @@
 {% load wagtailimages_tags navigation_tags %}
 
 {% block content %}
-{% include "base/include/header-hero.html" %}
+    {% include "base/include/header-hero.html" %}
 
-<div class="container bread-detail">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="col-md-7">
-                <div class="row">
-                    {% if page.introduction %}
-                    <p class="bread-detail__introduction">
-                        {{ page.introduction }}
-                    </p>
-                    {% endif %}
+    <div class="container bread-detail">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="col-md-7">
+                    <div class="row">
+                        {% if page.introduction %}
+                            <p class="bread-detail__introduction">
+                                {{ page.introduction }}
+                            </p>
+                        {% endif %}
 
-                    <div class="hidden-md-down">
+                        <div class="hidden-md-down">
+                            {{ page.body }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-md-4 col-md-offset-1">
+                    <div class="row">
+                        <div class="bread-detail__meta">
+                            <p class="location__meta-title">Operating Status</p>
+                            {% if page.is_open %}
+                                This location is currently open.
+                            {% else %}
+                                Sorry, this location is currently closed.
+                            {% endif %}
+
+                            <p class="location__meta-title">Address</p>
+                            <address>{{ page.address|linebreaks }}</address>
+
+                            {% if page.operating_hours %}
+                                <p class="location__meta-title">Opening hours</p>
+                                {% for hours in page.operating_hours %}
+                                    <time itemprop="openingHours" datetime="{{ hours }}" class="location__time">
+                                        <span class="location__day">{{ hours.day }}</span>:
+                                        <span class="location__hours">
+                                            {% if hours.closed == True %}
+                                                Closed
+                                            {% else %}
+                                                {% if hours.opening_time %}
+                                                    {{ hours.opening_time }}
+                                                {% endif %} -
+                                                {% if hours.closing_time %}
+                                                    {{ hours.closing_time }}
+                                                {% endif %}
+                                            {% endif %}
+                                        </span></time>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-md-7">
+                    <div class="row hidden-md-up">
                         {{ page.body }}
                     </div>
                 </div>
             </div>
-
-            <div class="col-md-4 col-md-offset-1">
-                <div class="row">
-                    <div class="bread-detail__meta">
-                        <p class="location__meta-title">Operating Status</p>
-                        {% if page.is_open %}
-                        This location is currently open.
-                        {% else %}
-                        Sorry, this location is currently closed.
-                        {% endif %}
-
-                        <p class="location__meta-title">Address</p>
-                        <address>{{ page.address|linebreaks }}</address>
-
-                        {% if page.operating_hours %}
-                        <p class="location__meta-title">Opening hours</p>
-                        {% for hours in page.operating_hours %}
-                        <time itemprop="openingHours" datetime="{{ hours }}" class="location__time">
-                            <span class="location__day">{{ hours.day }}</span>:
-                            <span class="location__hours">
-                                {% if hours.closed == True %}
-                                Closed
-                                {% else %}
-                                {% if hours.opening_time %}
-                                {{ hours.opening_time }}
-                                {% endif %} -
-                                {% if hours.closing_time %}
-                                {{ hours.closing_time }}
-                                {% endif %}
-                                {% endif %}
-                            </span></time>
-                        {% endfor %}
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-7">
-                <div class="row hidden-md-up">
-                    {{ page.body }}
-                </div>
-            </div>
         </div>
     </div>
-</div>
 
 {% endblock content %}

--- a/bakerydemo/templates/locations/locations_index_page.html
+++ b/bakerydemo/templates/locations/locations_index_page.html
@@ -3,14 +3,14 @@
 
 {% block content %}
 
-{% include "base/include/header-index.html" %}
+    {% include "base/include/header-index.html" %}
 
-<div class="container">
-    <div class="location-list-page">
-        {% for location in locations %}
-            {% include "includes/card/picture-card.html" with page=location portrait=False %}
-        {% endfor %}
+    <div class="container">
+        <div class="location-list-page">
+            {% for location in locations %}
+                {% include "includes/card/picture-card.html" with page=location portrait=False %}
+            {% endfor %}
+        </div>
     </div>
-</div>
 {% endblock content %}
 

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -4,46 +4,46 @@
 {% block title %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="row">
-        <div class="col-md-8">
-            <h1>Search results</h1>
-            {% if search_results %}
-                <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} result{{ search_results|length|pluralize }} found.</p>
-                <ul class="search__results">
-                    {% for result in search_results %}
-                        <li class="listing-card">
-                            <a class="listing-card__link" href="{% pageurl result.specific %}">
-                                {% if result.specific.image %}
-                                    <figure class="listing-card__image">
-                                        {% image result.specific.image fill-180x180-c100 loading="lazy" %}
-                                    </figure>
-                                {% endif %}
-                                <div class="listing-card__contents">
-                                    <h3 class="listing-card__title">{{ result.specific }}</h3>
-                                    <p class="listing-card__content-type">
-                                        {% if result.specific.content_type.model == "blogpage" %}
-                                            Blog Post
-                                        {% elif result.specific.content_type.model == "locationpage" %}
-                                            Location
-                                        {% else %}
-                                            Bread
-                                        {% endif %}
-                                    </p>
-                                    <p class="listing-card__description">
-                                        {% if result.specific.search_description %}{{ result.specific.search_description|richtext }}{% endif %}
-                                    </p>
-                                </div>
-                            </a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% elif search_query %}
-                <p class="search__introduction">No results found for “{{ search_query }}”.</p>
-            {% else %}
-                <p class="search__introduction">You didn&apos;t search for anything!</p>
-            {% endif %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8">
+                <h1>Search results</h1>
+                {% if search_results %}
+                    <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} result{{ search_results|length|pluralize }} found.</p>
+                    <ul class="search__results">
+                        {% for result in search_results %}
+                            <li class="listing-card">
+                                <a class="listing-card__link" href="{% pageurl result.specific %}">
+                                    {% if result.specific.image %}
+                                        <figure class="listing-card__image">
+                                            {% image result.specific.image fill-180x180-c100 loading="lazy" %}
+                                        </figure>
+                                    {% endif %}
+                                    <div class="listing-card__contents">
+                                        <h3 class="listing-card__title">{{ result.specific }}</h3>
+                                        <p class="listing-card__content-type">
+                                            {% if result.specific.content_type.model == "blogpage" %}
+                                                Blog Post
+                                            {% elif result.specific.content_type.model == "locationpage" %}
+                                                Location
+                                            {% else %}
+                                                Bread
+                                            {% endif %}
+                                        </p>
+                                        <p class="listing-card__description">
+                                            {% if result.specific.search_description %}{{ result.specific.search_description|richtext }}{% endif %}
+                                        </p>
+                                    </div>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% elif search_query %}
+                    <p class="search__introduction">No results found for “{{ search_query }}”.</p>
+                {% else %}
+                    <p class="search__introduction">You didn&apos;t search for anything!</p>
+                {% endif %}
+            </div>
         </div>
     </div>
-</div>
 {% endblock content %}

--- a/bakerydemo/templates/tags/breadcrumbs.html
+++ b/bakerydemo/templates/tags/breadcrumbs.html
@@ -1,22 +1,22 @@
 {% load wagtailcore_tags %}
 
 {% if ancestors %}
-<nav class="breadcrumb-container" aria-label="Breadcrumb">
-  <div class="container">
-    <div class="row">
-      <div class="col-lg-12">
-        <ol class="breadcrumb">
-          {% for ancestor in ancestors %}
-          {% if forloop.last %}
-          <li aria-current="page">{{ ancestor }}</li>
-          {% else %}
-          <li><a href="{% pageurl ancestor %}">{% if forloop.first %}Home{% else %}{{ ancestor }}{% endif %}</a>
-            {% include "includes/chevron-icon.html" with class="breadcrumb__chevron-icon" %}</li>
-          {% endif %}
-          {% endfor %}
-        </ol>
-      </div>
-    </div>
-  </div>
-</nav>
+    <nav class="breadcrumb-container" aria-label="Breadcrumb">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                    <ol class="breadcrumb">
+                        {% for ancestor in ancestors %}
+                            {% if forloop.last %}
+                                <li aria-current="page">{{ ancestor }}</li>
+                            {% else %}
+                                <li><a href="{% pageurl ancestor %}">{% if forloop.first %}Home{% else %}{{ ancestor }}{% endif %}</a>
+                                    {% include "includes/chevron-icon.html" with class="breadcrumb__chevron-icon" %}</li>
+                            {% endif %}
+                        {% endfor %}
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </nav>
 {% endif %}

--- a/bakerydemo/templates/tags/gallery.html
+++ b/bakerydemo/templates/tags/gallery.html
@@ -1,13 +1,13 @@
 {% load wagtailimages_tags %}
 
 {% for img in images %}
-<div class="picture-card">
-    <figure class="picture-card__image">
-        {% image img fill-645x480-c100 loading="lazy" %}
-        <div class="picture-card__contents">
-            <p class="picture-card__title">{{ img.title }}</p>
-        </div>
-    </figure>
-</div>
-{{ image.title }}
+    <div class="picture-card">
+        <figure class="picture-card__image">
+            {% image img fill-645x480-c100 loading="lazy" %}
+            <div class="picture-card__contents">
+                <p class="picture-card__title">{{ img.title }}</p>
+            </div>
+        </figure>
+    </div>
+    {{ image.title }}
 {% endfor %}

--- a/bakerydemo/templates/tags/sidebar_menu.html
+++ b/bakerydemo/templates/tags/sidebar_menu.html
@@ -2,31 +2,31 @@
 {% get_site_root as site_root %}
 
 {% if calling_page|has_protocol_parent and calling_page.content_type.model == 'standardpage' %}
-  <div class="off-canvas position-left reveal-for-large bla" id="offCanvasLeft" data-off-canvas>
-    {% protocol_menu calling_page=calling_page %}
-  </div>
+    <div class="off-canvas position-left reveal-for-large bla" id="offCanvasLeft" data-off-canvas>
+        {% protocol_menu calling_page=calling_page %}
+    </div>
 {% elif ancestor.has_children %}
-  <div class="off-canvas position-left reveal-for-large" id="offCanvasLeft" data-off-canvas>
-    <nav class="sidebar-nav">
-      <h3>In this section</h3>
-      <ul class="vertical menu">
-        {% for menuitem in ancestor.children %}
-          <li class="{% if menuitem.is_active %}is-active{% endif %}">
-            <a href="{% pageurl menuitem %}">{{ menuitem.title }}</a>
+    <div class="off-canvas position-left reveal-for-large" id="offCanvasLeft" data-off-canvas>
+        <nav class="sidebar-nav">
+            <h3>In this section</h3>
+            <ul class="vertical menu">
+                {% for menuitem in ancestor.children %}
+                    <li class="{% if menuitem.is_active %}is-active{% endif %}">
+                        <a href="{% pageurl menuitem %}">{{ menuitem.title }}</a>
 
-            {% if menuitem.is_active and menuitem.has_children %}
-              <ul class="nested vertical menu is-active">
-                {% for child in menuitem.children %}
-                  <li>
-                    <a href="{% pageurl child %}">{{ child.title }}</a>
-                  </li>
+                        {% if menuitem.is_active and menuitem.has_children %}
+                            <ul class="nested vertical menu is-active">
+                                {% for child in menuitem.children %}
+                                    <li>
+                                        <a href="{% pageurl child %}">{{ child.title }}</a>
+                                    </li>
 
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </li>
                 {% endfor %}
-              </ul>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
+            </ul>
+        </nav>
+    </div>
 {% endif %}

--- a/bakerydemo/templates/tags/table_of_contents_menu.html
+++ b/bakerydemo/templates/tags/table_of_contents_menu.html
@@ -22,7 +22,7 @@
               {% if heading.children %}
                 <ul>
                   {% for subheading in heading.children %}
-                    <li><a href="#{{subheading|slugify}}">{{subheading}}</a>
+                    <li><a href="#{{subheading|slugify}}">{{subheading}}</a></li>
                   {% endfor %}
                 </ul>
               {% endif %}

--- a/bakerydemo/templates/tags/table_of_contents_menu.html
+++ b/bakerydemo/templates/tags/table_of_contents_menu.html
@@ -1,35 +1,35 @@
 {% if section_pages %}
-  <nav class="sidebar-nav section-nav">
-    <h3>In this section</h3>
-    <ul class="vertical menu">
-      {% for section_page in section_pages %}
-        <li class="{% if section_page.is_active %}is-active{% endif %}">
-          <a href="{{section_page.url}}">{{ section_page.title }}</a>
-        </li>
-      {% endfor %}
-    </ul>
-  </nav>
+    <nav class="sidebar-nav section-nav">
+        <h3>In this section</h3>
+        <ul class="vertical menu">
+            {% for section_page in section_pages %}
+                <li class="{% if section_page.is_active %}is-active{% endif %}">
+                    <a href="{{section_page.url}}">{{ section_page.title }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
 {% endif %}
 {% if article_headings %}
-  <div data-sticky-container>
-    <div class="sticky" data-sticky data-sticky-on="large" data-margin-top="3" data-top-anchor="on-this-page:top" data-btm-anchor="main-end:bottom">
-      <nav class="sidebar-nav article-nav">
-        <h3 id="on-this-page">On this page</h3>
-        <ul class="vertical menu" data-magellan data-bar-offset="60">
-          {% for heading in article_headings %}
-            <li>
-              <a href="#{{heading.value|slugify}}">{{heading.value}}</a>
-              {% if heading.children %}
-                <ul>
-                  {% for subheading in heading.children %}
-                    <li><a href="#{{subheading|slugify}}">{{subheading}}</a></li>
-                  {% endfor %}
+    <div data-sticky-container>
+        <div class="sticky" data-sticky data-sticky-on="large" data-margin-top="3" data-top-anchor="on-this-page:top" data-btm-anchor="main-end:bottom">
+            <nav class="sidebar-nav article-nav">
+                <h3 id="on-this-page">On this page</h3>
+                <ul class="vertical menu" data-magellan data-bar-offset="60">
+                    {% for heading in article_headings %}
+                        <li>
+                            <a href="#{{heading.value|slugify}}">{{heading.value}}</a>
+                            {% if heading.children %}
+                                <ul>
+                                    {% for subheading in heading.children %}
+                                        <li><a href="#{{subheading|slugify}}">{{subheading}}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
                 </ul>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
+            </nav>
+        </div>
     </div>
-  </div>
 {% endif %}

--- a/bakerydemo/templates/tags/top_menu.html
+++ b/bakerydemo/templates/tags/top_menu.html
@@ -2,13 +2,13 @@
 {% get_site_root as site_root %}
 
 {% for menuitem in menuitems %}
-  <li class="presentation {{ menuitem.title|lower|cut:" " }}{% if menuitem.active %} active{% endif %}{% if menuitem.show_dropdown %} has-submenu{% endif %}">
-      {% if menuitem.show_dropdown %}
-          <a href="{% pageurl menuitem %}" class="allow-toggle">{{ menuitem.title }} <span><a class="caret-custom dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"></a></span></a>
-              {% top_menu_children parent=menuitem %}
-              {# Used to display child menu items #}
-      {% else %}
-          <a href="{% pageurl menuitem %}">{{ menuitem.title }}</a>
-      {% endif %}
-  </li>
+    <li class="presentation {{ menuitem.title|lower|cut:" " }}{% if menuitem.active %} active{% endif %}{% if menuitem.show_dropdown %} has-submenu{% endif %}">
+        {% if menuitem.show_dropdown %}
+            <a href="{% pageurl menuitem %}" class="allow-toggle">{{ menuitem.title }} <span><a class="caret-custom dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"></a></span></a>
+            {% top_menu_children parent=menuitem %}
+            {# Used to display child menu items #}
+        {% else %}
+            <a href="{% pageurl menuitem %}">{{ menuitem.title }}</a>
+        {% endif %}
+    </li>
 {% endfor %}

--- a/bakerydemo/templates/tags/top_menu_children.html
+++ b/bakerydemo/templates/tags/top_menu_children.html
@@ -1,7 +1,7 @@
 {% load navigation_tags wagtailcore_tags %}
 
 <ul class="dropdown-menu">
-  {% for child in menuitems_children %}
-    <li><a href="{% pageurl child %}">{{ child.title }}</a></li>
-  {% endfor %}
+    {% for child in menuitems_children %}
+        <li><a href="{% pageurl child %}">{{ child.title }}</a></li>
+    {% endfor %}
 </ul>

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -1,14 +1,14 @@
+import debug_toolbar
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-
-import debug_toolbar
-from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.documents import urls as wagtaildocs_urls
-from wagtail.contrib.sitemaps.views import sitemap
 from wagtail import urls as wagtail_urls
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.contrib.sitemaps.views import sitemap
+from wagtail.documents import urls as wagtaildocs_urls
 
 from bakerydemo.search import views as search_views
+
 from .api import api_router
 
 urlpatterns = [

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -12,16 +12,13 @@ from bakerydemo.search import views as search_views
 from .api import api_router
 
 urlpatterns = [
-    path('django-admin/', admin.site.urls),
-
-    path('admin/', include(wagtailadmin_urls)),
-    path('documents/', include(wagtaildocs_urls)),
-
-    path('search/', search_views.search, name='search'),
-
-    path('sitemap.xml', sitemap),
-    path('api/v2/', api_router.urls),
-    path('__debug__/', include(debug_toolbar.urls)),
+    path("django-admin/", admin.site.urls),
+    path("admin/", include(wagtailadmin_urls)),
+    path("documents/", include(wagtaildocs_urls)),
+    path("search/", search_views.search, name="search"),
+    path("sitemap.xml", sitemap),
+    path("api/v2/", api_router.urls),
+    path("__debug__/", include(debug_toolbar.urls)),
 ]
 
 
@@ -36,18 +33,17 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += [
         path(
-            'favicon.ico', RedirectView.as_view(
-                url=settings.STATIC_URL + 'img/bread-favicon.ico'
-            )
+            "favicon.ico",
+            RedirectView.as_view(url=settings.STATIC_URL + "img/bread-favicon.ico"),
         )
     ]
 
     # Add views for testing 404 and 500 templates
     urlpatterns += [
-        path('test404/', TemplateView.as_view(template_name='404.html')),
-        path('test500/', TemplateView.as_view(template_name='500.html')),
+        path("test404/", TemplateView.as_view(template_name="404.html")),
+        path("test500/", TemplateView.as_view(template_name="500.html")),
     ]
 
 urlpatterns += [
-    path('', include(wagtail_urls)),
+    path("", include(wagtail_urls)),
 ]

--- a/bakerydemo/wsgi.py
+++ b/bakerydemo/wsgi.py
@@ -12,7 +12,6 @@ import os
 import dotenv
 from django.core.wsgi import get_wsgi_application
 
-
 dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"))
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bakerydemo.settings.dev")

--- a/bakerydemo/wsgi.py
+++ b/bakerydemo/wsgi.py
@@ -13,7 +13,7 @@ import dotenv
 from django.core.wsgi import get_wsgi_application
 
 
-dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"))
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bakerydemo.settings.dev")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ services:
     restart: always
     image: postgres:14.1
     expose:
-      - "5432"
+      - '5432'
   redis:
     restart: always
     image: redis:6.2
     expose:
-      - "6379"
+      - '6379'
   app:
     environment:
       DJANGO_SECRET_KEY: changeme
@@ -29,7 +29,7 @@ services:
       - db:db
       - redis:redis
     ports:
-      - "8000:8000"
+      - '8000:8000'
     depends_on:
       - db
       - redis

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,6 @@ import sys
 
 import dotenv
 
-
 if __name__ == "__main__":
     dotenv.read_dotenv()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4350 @@
+{
+  "name": "bakerydemo",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bakerydemo",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "^8.8.0",
+        "prettier": "^2.5.1",
+        "stylelint": "^14.2.0",
+        "stylelint-config-prettier": "^9.0.3",
+        "stylelint-config-standard": "^26.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
+      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+      "dev": true,
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2",
+        "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "dependencies": {
+        "is-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.2",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "dependencies": {
+        "clone-regexp": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
+      "integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/html-tags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+      "dev": true
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true
+    },
+    "node_modules/stylelint": {
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+      "integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/selector-specificity": "^2.0.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
+        "cosmiconfig": "^7.0.1",
+        "css-functions-list": "^3.1.0",
+        "debug": "^4.3.4",
+        "execall": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "fastest-levenshtein": "^1.0.12",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.0",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.25.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.8.0",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/stylelint"
+      }
+    },
+    "node_modules/stylelint-config-prettier": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
+      "dev": true,
+      "bin": {
+        "stylelint-config-prettier": "bin/check.js",
+        "stylelint-config-prettier-check": "bin/check.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "stylelint": ">=11.0.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^14.8.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+      "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^8.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.9.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@csstools/selector-specificity": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
+      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^2.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "css-functions-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.2",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^2.1.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
+      "integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "html-tags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "known-css-properties": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
+    "mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true
+    },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        }
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+      "dev": true
+    },
+    "postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true
+    },
+    "stylelint": {
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+      "integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
+      "dev": true,
+      "requires": {
+        "@csstools/selector-specificity": "^2.0.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
+        "cosmiconfig": "^7.0.1",
+        "css-functions-list": "^3.1.0",
+        "debug": "^4.3.4",
+        "execall": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "fastest-levenshtein": "^1.0.12",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.0",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.25.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.8.0",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+          "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "stylelint-config-prettier": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
+      "dev": true,
+      "requires": {}
+    },
+    "stylelint-config-recommended": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "stylelint-config-standard": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+      "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^8.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bakerydemo",
+  "version": "1.0.0",
+  "repository": "https://github.com/wagtail/bakerydemo",
+  "private": true,
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.8.0",
+    "prettier": "^2.5.1",
+    "stylelint": "^14.2.0",
+    "stylelint-config-standard": "^26.0.0",
+    "stylelint-config-prettier": "^9.0.3"
+  },
+  "scripts": {
+    "fix:js": "eslint --ext .js --fix .",
+    "format": "prettier --write \"**/?(.)*.{css,js,json,yaml,yml}\"",
+    "lint:js": "eslint --ext .js --report-unused-disable-directives .",
+    "lint:css": "stylelint **/*.css",
+    "lint:format": "prettier --check \"**/?(.)*.{css,js,json,yaml,yml}\"",
+    "lint": "npm run lint:js && npm run lint:css && npm run lint:format"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ Now we're ready to set up the bakery demo project itself:
     cd ~/dev [or your preferred dev directory]
     git clone https://github.com/wagtail/bakerydemo.git
     cd bakerydemo
-    pip install -r requirements/base.txt
+    pip install -r requirements/development.txt
 
 Next, we'll set up our local environment variables. We use [django-dotenv](https://github.com/jpadilla/django-dotenv)
 to help with this. It reads environment variables located in a file name `.env` in the top level directory of the project. The only variable we need to start is `DJANGO_SETTINGS_MODULE`:

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,10 @@
+-r base.txt
+black==22.3.0
+flake8>=3.6.0
+isort==5.6.4  # leave this pinned - it tends to change rules between patch releases
+flake8-blind-except==0.1.1
+flake8-comprehensions==3.8.0
+flake8-print==2.0.2
+flake8-assertive==2.0.0
+curlylint==0.13.1
+djhtml==1.4.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,10 @@
 [flake8]
 max-line-length=120
-exclude=migrations
-ignore=F405,W503
+exclude=venv,.venv,bakerydemo/settings/local.py
+ignore=E501,F405,W503
+
+[isort]
+profile=black
+skip=migrations,.git,__pycache__,LC_MESSAGES,venv,.venv
+blocked_extensions=rst,html,js,svg,txt,css,scss,png,snap,ts,tsx
+default_section=THIRDPARTY


### PR DESCRIPTION
This PR formats the codebase with Black, isort, djhtml, Prettier, ESLint, and Stylelint. It also adds linting configuration for flake8 and curlylint. A GitHub Actions workflow configuration is also added.

Configs are based on Wagtail's setup where it makes sense (e.g. leaving out JSX, SCSS, etc.), otherwise the tools' recommended defaults are used.

`.git-blame-ignore-revs` will be added in a separate PR.