### PR TITLE
Update Dockerfile (#351). Fix #360

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ENV UWSGI_STATIC_MAP="/media/=/code/bakerydemo/media/"
 RUN DATABASE_URL=postgres://none REDIS_URL=none /venv/bin/python manage.py collectstatic --noinput
 
 # make sure static files are writable by uWSGI process
-RUN mkdir -p /code/bakerydemo/media/images && chown -R 1000:2000 /code/bakerydemo/media
+RUN mkdir -p /code/bakerydemo/media/images && mkdir -p /code/bakerydemo/media/original_images && chown -R 1000:2000 /code/bakerydemo/media
 
 # mark the destination for images as a volume
 VOLUME ["/code/bakerydemo/media/images/"]


### PR DESCRIPTION
some distros of Linux seem to flag original_images with root perms and UWSGI uploads of images to e.g., /admin/uploads/multiple/add will fail with [Errno 13 / Permission Denied].