### PR TITLE
Add `.git-blame-ignore-revs` and fix CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,18 @@
+# git-blame ignored revisions
+# To configure, run
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Requires Git > 2.23
+# See https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+
+# Reformatting PR was primarily done in #347
+
+# Initial black reformatting
+40696f941ca2a2b30938fbd2bcb8e197a46024d5
+# Initial isort reformatting
+6732b719834fc3a7d72dfd78f684f066a1fcf11f
+# Initial djhtml reformatting
+707ac77ba190742a6c4bd3d019e64e684eb67276
+# Initial Prettier reformatting
+dfa2c511b1ad1fe9030e9d1772c24f3473b1dbda
+# Initial Stylelint reformatting
+c02c9116a85a4919be087c0355193ca3c30921f1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
         additional_dependencies:
           - flake8-comprehensions
           - flake8-assertive
+          - flake8-print
   - repo: https://github.com/rtts/djhtml
     rev: v1.4.13
     hooks:

--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         fixtures_dir = os.path.join(settings.PROJECT_DIR, "base", "fixtures")
         fixture_file = os.path.join(fixtures_dir, "bakerydemo.json")
 
-        print("Copying media files to configured storage...")
+        print("Copying media files to configured storage...")  # noqa: T201
         local_storage = FileSystemStorage(os.path.join(fixtures_dir, "media"))
         self._copy_files(local_storage, "")  # file storage paths are relative
 
@@ -40,6 +40,6 @@ class Command(BaseCommand):
         call_command("loaddata", fixture_file, verbosity=0)
         call_command("update_index", verbosity=0)
 
-        print(
+        print(  # noqa: T201
             "Awesome. Your data is loaded! The bakery's doors are almost ready to open..."
         )

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -14,7 +14,7 @@ if "DJANGO_SECRET_KEY" in os.environ:
     SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 else:
     # Use if/else rather than a default value to avoid calculating this if we don't need it
-    print(
+    print(  # noqa: T201
         "WARNING: DJANGO_SECRET_KEY not found in os.environ. Generating ephemeral SECRET_KEY."
     )
     SECRET_KEY = "".join(

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,7 +4,7 @@ flake8>=3.6.0
 isort==5.6.4  # leave this pinned - it tends to change rules between patch releases
 flake8-blind-except==0.1.1
 flake8-comprehensions==3.8.0
-flake8-print==2.0.2
+flake8-print==5.0.0
 flake8-assertive==2.0.0
 curlylint==0.13.1
 djhtml==1.4.13


### PR DESCRIPTION
This adds a `.git-blame-ignore-revs` file per https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Also fix issues with flake8-print by upgrading it to 5.0.0 and add some `# noqa` comments on `print()` statements per https://github.com/wagtail/wagtail/pull/8935 