### PR TITLE
Fix help text for EmbedBlock

### DIFF
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -73,7 +73,7 @@ class BaseStreamBlock(StreamBlock):
     image_block = ImageBlock()
     block_quote = BlockQuote()
     embed_block = EmbedBlock(
-        help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+        help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
         icon="fa-s15",
         template="blocks/embed_block.html",
     )

--- a/bakerydemo/base/migrations/0001_initial.py
+++ b/bakerydemo/base/migrations/0001_initial.py
@@ -228,7 +228,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -348,7 +348,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -490,7 +490,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -683,7 +683,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),

--- a/bakerydemo/base/migrations/0002_auto_20170329_0055.py
+++ b/bakerydemo/base/migrations/0002_auto_20170329_0055.py
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -172,7 +172,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -256,7 +256,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -340,7 +340,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -171,7 +171,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -256,7 +256,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),
@@ -341,7 +341,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/blog/migrations/0001_initial.py
+++ b/bakerydemo/blog/migrations/0001_initial.py
@@ -120,7 +120,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -246,7 +246,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),

--- a/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/breads/migrations/0001_initial.py
+++ b/bakerydemo/breads/migrations/0001_initial.py
@@ -134,7 +134,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -245,7 +245,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),

--- a/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/locations/migrations/0001_initial.py
+++ b/bakerydemo/locations/migrations/0001_initial.py
@@ -164,7 +164,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),
@@ -301,7 +301,7 @@ class Migration(migrations.Migration):
                             (
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
-                                    help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                                    help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                                     icon="fa-s15",
                                     template="blocks/embed_block.html",
                                 ),

--- a/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),

--- a/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
                     (
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
-                            help_text="Insert an embed URL e.g https://www.youtube.com/embed/SGJFWirQ3ks",
+                            help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
                             icon="fa-s15",
                             template="blocks/embed_block.html",
                         ),


### PR DESCRIPTION
The URL suggested in the help text for EmbedBlock is incorrect - users should specify the Youtube page URL (`/watch`) to have it translated to an embed snippet via oembed. Passing an `/embed/` URL fails, as the oembed endpoint doesn't recognise these.