### PR TITLE
Add styles for `EmbedBlock`

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -397,6 +397,13 @@ blockquote .attribute-name {
   text-decoration: underline;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
+.block-embed_block iframe {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  height: 100%;
+}
+
 @media screen and (min-width: 768px) {
   .header,
   .footer {


### PR DESCRIPTION
## Before

<img width="917" alt="Unstyled EmbedBlock, the iframe is too small" src="https://user-images.githubusercontent.com/6379424/196699213-6fdbd91f-e619-4026-9fa7-8338d8b1c784.png">

## After

<img width="917" alt="Styled EmbedBlock, the iframe now looks normal" src="https://user-images.githubusercontent.com/6379424/196699485-da4c271b-16e4-4453-98cd-9f1debbe70f6.png">
