### PR TITLE
Call rebuild_references_index on initial load

### DIFF
--- a/bakerydemo/base/management/commands/load_initial_data.py
+++ b/bakerydemo/base/management/commands/load_initial_data.py
@@ -39,6 +39,7 @@ class Command(BaseCommand):
 
         call_command("loaddata", fixture_file, verbosity=0)
         call_command("update_index", verbosity=0)
+        call_command("rebuild_references_index", verbosity=0)
 
         print(  # noqa: T201
             "Awesome. Your data is loaded! The bakery's doors are almost ready to open..."

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-Django>=4.0,<4.1
+Django>=4.1,<4.2
 django-dotenv==1.4.1
-wagtail>=4.0,<5
+wagtail>=4.1,<5
 wagtailfontawesome>=1.1.3,<1.2
 django-debug-toolbar>=3.2,<4


### PR DESCRIPTION
Bump Wagtail version to 4.1 (and Django to 4.1) and add a call to rebuild_references_index as part of the load_initial_data management command, so that the "Used X times" reference counts for images and snippets are accurate.