### PR TITLE
Additional panel definitions clean-up for Wagtail 4

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -421,7 +421,7 @@ class FormPage(AbstractEmailForm):
     content_panels = AbstractEmailForm.content_panels + [
         FieldPanel("image"),
         FieldPanel("body"),
-        InlinePanel("form_fields", label="Form fields"),
+        InlinePanel("form_fields", heading="Form fields", label="Field"),
         FieldPanel("thank_you_text"),
         MultiFieldPanel(
             [

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -64,8 +64,8 @@ class Person(
             [
                 FieldRowPanel(
                     [
-                        FieldPanel("first_name", classname="col6"),
-                        FieldPanel("last_name", classname="col6"),
+                        FieldPanel("first_name"),
+                        FieldPanel("last_name"),
                     ]
                 )
             ],
@@ -427,8 +427,8 @@ class FormPage(AbstractEmailForm):
             [
                 FieldRowPanel(
                     [
-                        FieldPanel("from_address", classname="col6"),
-                        FieldPanel("to_address", classname="col6"),
+                        FieldPanel("from_address"),
+                        FieldPanel("to_address"),
                     ]
                 ),
                 FieldPanel("subject"),

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -344,7 +344,6 @@ class HomePage(Page):
                 ),
             ],
             heading="Featured homepage sections",
-            classname="collapsible",
         ),
     ]
 

--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -78,7 +78,11 @@ class BlogPage(Page):
         FieldPanel("body"),
         FieldPanel("date_published"),
         InlinePanel(
-            "blog_person_relationship", label="Author(s)", panels=None, min_num=1
+            "blog_person_relationship",
+            heading="Authors",
+            label="Author",
+            panels=None,
+            min_num=1,
         ),
         FieldPanel("tags"),
     ]

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -131,7 +131,7 @@ class BreadPage(Page):
                 ),
             ],
             heading="Additional Metadata",
-            classname="collapsible collapsed",
+            classname="collapsed",
         ),
     ]
 

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -147,7 +147,7 @@ class LocationPage(Page):
         FieldPanel("body"),
         FieldPanel("address"),
         FieldPanel("lat_long"),
-        InlinePanel("hours_of_operation", label="Hours of Operation"),
+        InlinePanel("hours_of_operation", heading="Hours of Operation", label="Slot"),
     ]
 
     def __str__(self):


### PR DESCRIPTION
Follow-up to #371. This removes additional classes that no longer need adding to panels, and updates our InlinePanel definitions to use a different section heading and item label. Using different text isn’t required but helps a lot in understanding the interface.