### PR TITLE
Replace FontAwesome usage with built-in icons for StreamField blocks

### DIFF
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -56,7 +56,7 @@ class BlockQuote(StructBlock):
     attribute_name = CharBlock(blank=True, required=False, label="e.g. Mary Berry")
 
     class Meta:
-        icon = "fa-quote-left"
+        icon = "openquote"
         template = "blocks/blockquote.html"
 
 
@@ -68,12 +68,12 @@ class BaseStreamBlock(StreamBlock):
 
     heading_block = HeadingBlock()
     paragraph_block = RichTextBlock(
-        icon="fa-paragraph", template="blocks/paragraph_block.html"
+        icon="pilcrow", template="blocks/paragraph_block.html"
     )
     image_block = ImageBlock()
     block_quote = BlockQuote()
     embed_block = EmbedBlock(
         help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-        icon="fa-s15",
+        icon="media",
         template="blocks/embed_block.html",
     )

--- a/bakerydemo/base/migrations/0001_initial.py
+++ b/bakerydemo/base/migrations/0001_initial.py
@@ -184,7 +184,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -229,7 +229,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -304,7 +304,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -349,7 +349,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -446,7 +446,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -491,7 +491,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -639,7 +639,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -684,7 +684,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),

--- a/bakerydemo/base/migrations/0002_auto_20170329_0055.py
+++ b/bakerydemo/base/migrations/0002_auto_20170329_0055.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -173,7 +173,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -216,7 +216,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -300,7 +300,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -341,7 +341,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -131,7 +131,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -172,7 +172,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -216,7 +216,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),
@@ -301,7 +301,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -342,7 +342,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/blog/migrations/0001_initial.py
+++ b/bakerydemo/blog/migrations/0001_initial.py
@@ -76,7 +76,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -121,7 +121,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -202,7 +202,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -247,7 +247,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),

--- a/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/breads/migrations/0001_initial.py
+++ b/bakerydemo/breads/migrations/0001_initial.py
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -135,7 +135,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -201,7 +201,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -246,7 +246,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),

--- a/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/locations/migrations/0001_initial.py
+++ b/bakerydemo/locations/migrations/0001_initial.py
@@ -120,7 +120,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -165,7 +165,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),
@@ -257,7 +257,7 @@ class Migration(migrations.Migration):
                             (
                                 "paragraph_block",
                                 wagtail.blocks.RichTextBlock(
-                                    icon="fa-paragraph",
+                                    icon="pilcrow",
                                     template="blocks/paragraph_block.html",
                                 ),
                             ),
@@ -302,7 +302,7 @@ class Migration(migrations.Migration):
                                 "embed_block",
                                 wagtail.embeds.blocks.EmbedBlock(
                                     help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                                    icon="fa-s15",
+                                    icon="media",
                                     template="blocks/embed_block.html",
                                 ),
                             ),

--- a/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),

--- a/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                     (
                         "paragraph_block",
                         wagtail.blocks.RichTextBlock(
-                            icon="fa-paragraph", template="blocks/paragraph_block.html"
+                            icon="pilcrow", template="blocks/paragraph_block.html"
                         ),
                     ),
                     (
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                         "embed_block",
                         wagtail.embeds.blocks.EmbedBlock(
                             help_text="Insert an embed URL e.g https://www.youtube.com/watch?v=SGJFWirQ3ks",
-                            icon="fa-s15",
+                            icon="media",
                             template="blocks/embed_block.html",
                         ),
                     ),


### PR DESCRIPTION
StreamField only supports SVG icons since v2.15 (https://github.com/wagtail/wagtail/issues/8533). This switches the block icon definitions from FontAwesome with SVG icons built into Wagtail.

- `fa-quote-left` becomes `openquote`. 
- `fa-paragrpah` becomes`pilcrow`.
- `fa-s15` (a bathtub as I recall?) becomes `media` (same icon used for embeds in Wagtail within rich text.

I’ve updated the existing migrations directly, as the icon is unlikely to be something we’d actively use in a migration anyway.