### PR TITLE
Bump django-storages version for Django 4 compatibility

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,7 +7,7 @@ psycopg2>=2.7,<3.0
 whitenoise>=5.0,<5.1
 boto3==1.9.189
 google-cloud-storage==1.20.0
-django-storages>=1.8,<1.9
+django-storages>=1.13,<1.14
 # For retrieving credentials and signing requests to Elasticsearch
 botocore>=1.12.33,<1.13
 aws-requests-auth==0.4.0


### PR DESCRIPTION
Fixes import error in storages/backends/s3boto3.py when deploying with Django 4.1

    ImportError: cannot import name 'force_text' from 'django.utils.encoding'

django-storages version 0.13 is first release with official Django 4.1 support.

Refs: https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#113-2022-08-05