### PR TITLE
Don't restart containers if stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,12 @@ services:
       POSTGRES_DB: app_db
       POSTGRES_USER: app_user
       POSTGRES_PASSWORD: changeme
-    restart: always
+    restart: unless-stopped
     image: postgres:14.1
     expose:
       - '5432'
   redis:
-    restart: always
+    restart: unless-stopped
     image: redis:6.2
     expose:
       - '6379'


### PR DESCRIPTION
When containers are stopped explicitly, it is very confusing to have them restart automatically. 
This is especially an issue in local dev where there is no needed for the db and redis containers to be running on every system/docker start.

This commit changes the restart policy to only restart when they have not been explicitly stopped. 
Explicitly stopping the container will not lead to a restart anymore.

See also: 
* https://docs.docker.com/compose/compose-file/#restart
