### PR TITLE
add migrate command to docker-compose instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,7 @@ Run the following commands:
 git clone https://github.com/wagtail/bakerydemo.git
 cd bakerydemo
 docker-compose up --build -d
+docker-compose run app /venv/bin/python manage.py migrate
 docker-compose run app /venv/bin/python manage.py load_initial_data
 docker-compose up
 ```


### PR DESCRIPTION
Hi!

I think a command to run migrations is missing in docker-compose instructions. Added one.