### PR TITLE
Add missing end slash when generating tag URLs

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -110,8 +110,12 @@ class BlogPage(Page):
         """
         tags = self.tags.all()
         for tag in tags:
-            tag.url = "/" + "/".join(
-                s.strip("/") for s in [self.get_parent().url, "tags", tag.slug]
+            tag.url = (
+                "/"
+                + "/".join(
+                    s.strip("/") for s in [self.get_parent().url, "tags", tag.slug]
+                )
+                + "/"
             )
         return tags
 


### PR DESCRIPTION
On the blog index page, we output a link to each tag, but don’t have a slash at the end:

```html
<ul class="blog-tags">
<li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>          
<li><a class="blog-tags__pill" aria-label="Filter by tag name baking" href="/blog/tags/baking">baking</a></li>                
<li><a class="blog-tags__pill" aria-label="Filter by tag name dessert" href="/blog/tags/dessert">dessert</a></li>
[…]
</ul>
```

Django will redirect to a route with a trailing slash (for example `/blog/tags/baking/`) when following those links, so everything is working – but we can generate the URLs with the slash to start with, to skip the redirect.