### PR TITLE
Add missing end slash when generating tag URLs

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -109,10 +109,9 @@ class BlogPage(Page):
         We're additionally adding a URL to access BlogPage objects with that tag
         """
         tags = self.tags.all()
+        base_url = self.get_parent().url
         for tag in tags:
-            tag.url = "/" + "/".join(
-                s.strip("/") for s in [self.get_parent().url, "tags", tag.slug]
-            )
+            tag.url = f"{base_url}tags/{tag.slug}/"
         return tags
 
     # Specifies parent to BlogPage as being BlogIndexPages


### PR DESCRIPTION
as per #381, but more Pythonic and without doing a useless `self.get_parent()` database hit on every iteration