### PR TITLE
Update imports that reference wagtail.core

### DIFF
--- a/bakerydemo/base/management/commands/create_random_data.py
+++ b/bakerydemo/base/management/commands/create_random_data.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import lorem_ipsum, timezone
 from django.utils.text import slugify
-from wagtail.core.rich_text import RichText
 from wagtail.images.models import Image
+from wagtail.rich_text import RichText
 from willow.image import Image as WillowImage
 
 from bakerydemo.base.models import FooterText, HomePage, Person, StandardPage

--- a/bakerydemo/recipes/blocks.py
+++ b/bakerydemo/recipes/blocks.py
@@ -1,7 +1,5 @@
 from django import forms
-from wagtail.contrib.table_block.blocks import TableBlock
-from wagtail.contrib.typed_table_block.blocks import TypedTableBlock
-from wagtail.core.blocks import (
+from wagtail.blocks import (
     CharBlock,
     ChoiceBlock,
     FloatBlock,
@@ -10,6 +8,8 @@ from wagtail.core.blocks import (
     StreamBlock,
     StructBlock,
 )
+from wagtail.contrib.table_block.blocks import TableBlock
+from wagtail.contrib.typed_table_block.blocks import TypedTableBlock
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import ImageChooserBlock
 


### PR DESCRIPTION
wagtail.core has been deprecated since 3.0, outputs warnings as of 4.2, and is due for removal in 5.0.

(Note that wagtailfontawesome still references `wagtail.core.hooks`, and since that has been unmaintained for a while we'll probably need to either switch away from that to an SVG solution, or fork / take ownership of wagtailfontawesome, before we can proceed with fully dropping wagtail.core)