### PR TITLE
Switch to wagtail-font-awesome-svg

### DIFF
--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from wagtail import hooks
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin,
     ModelAdminGroup,
@@ -19,9 +20,17 @@ INSTALLED_APPS = (
 
 or see https://thegrouchy.dev/general/2015/12/06/wagtail-streamfield-icons.html
 
-This demo project includes the full font-awesome set via CDN in base.html, so the entire
-font-awesome icon set is available to you. Options are at https://fontawesome.com/icons .
+This demo project also includes the wagtail-font-awesome-svg package, allowing further icons to be
+installed as detailed here: https://github.com/allcaps/wagtail-font-awesome-svg#usage
 """
+
+
+@hooks.register("register_icons")
+def register_icons(icons):
+    return icons + [
+        "wagtailfontawesomesvg/solid/suitcase.svg",
+        "wagtailfontawesomesvg/solid/utensils.svg",
+    ]
 
 
 class BreadIngredientAdmin(ModelAdmin):
@@ -43,7 +52,7 @@ class BreadCountryAdmin(ModelAdmin):
 
 class BreadModelAdminGroup(ModelAdminGroup):
     menu_label = "Bread Categories"
-    menu_icon = "fa-suitcase"  # change as required
+    menu_icon = "suitcase"  # change as required
     menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
     items = (BreadIngredientAdmin, BreadTypeAdmin, BreadCountryAdmin)
 
@@ -51,7 +60,7 @@ class BreadModelAdminGroup(ModelAdminGroup):
 class PersonModelAdmin(ModelAdmin):
     model = Person
     menu_label = "People"  # ditch this to use verbose_name_plural from model
-    menu_icon = "fa-users"  # change as required
+    menu_icon = "group"  # change as required
     list_display = ("first_name", "last_name", "job_title", "thumb_image")
     list_filter = ("job_title",)
     search_fields = ("first_name", "last_name", "job_title")
@@ -65,7 +74,7 @@ class FooterTextAdmin(ModelAdmin):
 
 class BakeryModelAdminGroup(ModelAdminGroup):
     menu_label = "Bakery Misc"
-    menu_icon = "fa-cutlery"  # change as required
+    menu_icon = "utensils"  # change as required
     menu_order = 300  # will put in 4th place (000 being 1st, 100 2nd)
     items = (PersonModelAdmin, FooterTextAdmin)
 

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -64,7 +64,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "modelcluster",
     "taggit",
-    "wagtailfontawesome",
+    "wagtailfontawesomesvg",
     "debug_toolbar",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,4 +1,4 @@
-{% load navigation_tags static wagtailuserbar wagtailfontawesome %}
+{% load navigation_tags static wagtailuserbar %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -24,7 +24,7 @@
         {% endif %}
 
         <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
-        {% fontawesome_css %}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
         <link rel="stylesheet" href="{% static 'css/font-marcellus.css' %}">
         <link rel="stylesheet" href="{% static 'css/font-open-sans.css' %}">
         <link rel="stylesheet" href="{% static 'css/main.css' %}">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Django>=4.1,<4.2
 django-dotenv==1.4.1
 wagtail>=4.1,<5
-wagtailfontawesome>=1.1.3,<1.2
+wagtail-font-awesome-svg>=0.0.3,<1
 django-debug-toolbar>=3.2,<4


### PR DESCRIPTION
The only remaining uses of font-based icons in the admin backend appear to be the sidebar menu items - switch those to wagtail-font-awesome-svg. For the front-end (where wagtailfontawesome was being used for the footer icons), import the font-awesome 4.7 CSS directly from cdnjs (as this is the version wagtailfontawesome was using).