### PR TITLE
Add image rendition update step to Docker setup instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Wait 10 seconds for the database setup to complete. Then run:
 
 ```bash
 docker compose run app /venv/bin/python manage.py load_initial_data
+docker compose run app /venv/bin/python manage.py wagtail_update_image_renditions
 ```
 If this fails with a database error, wait 10 more seconds and re-try. Finally, run:
 


### PR DESCRIPTION
Before, when following the Docker setup instructions, the images would not be served.

Running the update renditions step fixes this.

Fixes #388 