### PR TITLE
Fix live preview for `BlogPage` and `RecipePage` authors

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -13,7 +13,6 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
-from bakerydemo.base.models import Person
 
 
 class BlogPersonRelationship(Orderable, models.Model):
@@ -99,7 +98,13 @@ class BlogPage(Page):
         with a loop on the template. If we tried to access the blog_person_
         relationship directly we'd print `blog.BlogPersonRelationship.None`
         """
-        return Person.objects.filter(live=True, person_blog_relationship__page=self)
+        # Only return authors that are not in draft
+        return [
+            n.person
+            for n in self.blog_person_relationship.filter(
+                person__live=True
+            ).select_related("person")
+        ]
 
     @property
     def get_tags(self):

--- a/bakerydemo/recipes/models.py
+++ b/bakerydemo/recipes/models.py
@@ -6,7 +6,6 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
-from bakerydemo.base.models import Person
 
 from .blocks import RecipeStreamBlock
 
@@ -104,13 +103,19 @@ class RecipePage(Page):
 
     def authors(self):
         """
-        Returns the BlogPage's related people. Again note that we are using
-        the ParentalKey's related_name from the BlogPersonRelationship model
+        Returns the RecipePage's related people. Again note that we are using
+        the ParentalKey's related_name from the RecipePersonRelationship model
         to access these objects. This allows us to access the Person objects
-        with a loop on the template. If we tried to access the blog_person_
-        relationship directly we'd print `blog.BlogPersonRelationship.None`
+        with a loop on the template. If we tried to access the recipe_person_
+        relationship directly we'd print `recipe.RecipePersonRelationship.None`
         """
-        return Person.objects.filter(live=True, person_recipe_relationship__page=self)
+        # Only return authors that are not in draft
+        return [
+            n.person
+            for n in self.recipe_person_relationship.filter(
+                person__live=True
+            ).select_related("person")
+        ]
 
     # Specifies parent to Recipe as being RecipeIndexPages
     parent_page_types = ["RecipeIndexPage"]


### PR DESCRIPTION
This was a regression in f381355cfe60cd56daef6eee49294dbcc63ebc72

I was curious why we had to do `[n.person for n in self.blog_person_relationship.all()]` before that commit, which would mean that we're querying the relationship table and then for each relationship record, we have to fetch the related `Person` object.

Thus, in that commit I changed it to query the person directly. However, in doing so it made the live preview not updating the Authors when you change the selections in the inline panel.

It turns out we needed to access the authors through `blog_person_relationship` so that we make use of django-modelcluster's features to allow reflecting the relationship changes without committing them to the database.

This reverts the logic to use the original logic, but I added a `select_related` to optimise the performance when accessing the method with real `blog_person_relationship` DB queries. Not sure if that's something django-modelcluster will keep under the hood, but at least it doesn't break...