### PR TITLE
Stop using `.local` as a settings file

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ ports:
 tasks:
   - init: |
       cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py
-      echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env
+      echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.dev" > .env
       python -m pip install -r requirements.txt
       python manage.py makemigrations
       python manage.py migrate

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -31,7 +31,7 @@ chmod a+x $PROJECT_DIR/manage.py
 # copy local settings file
 cp $PROJECT_DIR/bakerydemo/settings/local.py.example $PROJECT_DIR/bakerydemo/settings/local.py
 # add .env file for django-dotenv environment variable definitions
-echo DJANGO_SETTINGS_MODULE=$PROJECT_NAME.settings.local > $PROJECT_DIR/.env
+echo DJANGO_SETTINGS_MODULE=$PROJECT_NAME.settings.dev > $PROJECT_DIR/.env
 
 if [ -n "$USE_POSTGRESQL" ]
 then


### PR DESCRIPTION
This file is merely for includes to the `.dev` settings, rather than being a settings file in itself

Fixes #398

Regression from #393 