### PR TITLE
Set python path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
     && rm -rf /var/lib/apt/lists/*
 
 ADD requirements/ /requirements/
-ENV VIRTUAL_ENV=/venv PATH=/venv/bin:$PATH
+ENV VIRTUAL_ENV=/venv PATH=/venv/bin:$PATH PYTHONPATH=/code/
 
 RUN set -ex \
     && BUILD_DEPS=" \


### PR DESCRIPTION
This is needed to allow the `django-admin` command to work