### PR TITLE
Fix docker setup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Bakerydemo CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build container
+        run: docker-compose build && docker-compose pull
+      - name: Run migrations
+        run: docker-compose run app /venv/bin/python manage.py migrate
+      - name: Load initial data
+        run: docker-compose run app /venv/bin/python manage.py load_initial_data
+      - name: Run tests
+        run: docker-compose run app /venv/bin/python manage.py test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Bakerydemo CI
+name: Docker build
 
 on:
   push:

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -10,8 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
-import dj_database_url
 import os
+
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -117,9 +117,7 @@ WSGI_APPLICATION = "bakerydemo.wsgi.application"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 if "DATABASE_URL" in os.environ:
-    DATABASES = {
-        "default": dj_database_url.config(conn_max_age=500)
-    }
+    DATABASES = {"default": dj_database_url.config(conn_max_age=500)}
 else:
     DATABASES = {
         "default": {

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
+import dj_database_url
 import os
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
@@ -114,12 +115,17 @@ WSGI_APPLICATION = "bakerydemo.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "bakerydemodb"),
+if "DATABASE_URL" in os.environ:
+    DATABASES = {
+        "default": dj_database_url.config(conn_max_age=500)
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": os.path.join(BASE_DIR, "bakerydemodb"),
+        }
+    }
 
 
 # Password validation

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -2,8 +2,6 @@ import os
 import random
 import string
 
-import dj_database_url
-
 from .base import *  # noqa: F403
 
 DEBUG = False
@@ -34,9 +32,6 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 # URLs. Please set to the domain that users will access the admin site.
 if "PRIMARY_HOST" in os.environ:
     WAGTAILADMIN_BASE_URL = "https://{}".format(os.environ["PRIMARY_HOST"])
-
-db_from_env = dj_database_url.config(conn_max_age=500)
-DATABASES["default"].update(db_from_env)
 
 # AWS creds may be used for S3 and/or Elasticsearch
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ docker compose up --build -d
 After this command completes and returns to the command prompt, wait 10 more seconds for the database setup to complete. Then run:
 
 ```bash
+docker compose run app /venv/bin/python manage.py migrate
 docker compose run app /venv/bin/python manage.py load_initial_data
 ```
 If this fails with a database error, wait 10 more seconds and re-try. Finally, run:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,4 @@ django-dotenv==1.4.1
 wagtail>=4.1,<5
 wagtail-font-awesome-svg>=0.0.3,<1
 django-debug-toolbar>=3.2,<4
+dj-database-url==0.4.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,7 +1,6 @@
 -r base.txt
 elasticsearch==5.5.3
 # Additional dependencies for Heroku, AWS, and Google Cloud deployment
-dj-database-url==0.4.1
 uwsgi>=2.0.17,<2.1
 psycopg2>=2.7,<3.0
 whitenoise>=5.0,<5.1


### PR DESCRIPTION
Fixes #409 

- Ensure we always use `$DATABASE_URL` if it's available - it's used in the `docker-compose.yml`
- Add a CI file to build the docker environment, to stop this happening in future
- Update setup instructions to run migrations before loading data