### PR TITLE
Remove unnecessary underline from breadcrumb (Issue #415)

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -840,7 +840,6 @@ footer {
   line-height: 1.5;
   margin-bottom: 0;
   padding-left: 0;
-  text-decoration: underline;
   background-color: transparent;
 }
 


### PR DESCRIPTION
I removed a line in `bakerydemo/static/css/main.css` which was causing the page names in breadcrumb to have an unnecessary line, as suggested by @laymonage in #415 

**Before:**
![image](https://github.com/wagtail/bakerydemo/assets/93925338/2946d2ed-6707-484c-a0bf-12feb0685835)

**After:**
![image](https://github.com/wagtail/bakerydemo/assets/93925338/2dbcece0-48b8-44c7-8461-6f6998be3f57)
