### PR TITLE
Fix iframe dimensions in rich text. Fix #417

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -405,6 +405,13 @@ blockquote .attribute-name {
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
+.block-paragraph_block iframe {
+  aspect-ratio: 16 / 9 ;
+  width: 100%;
+  height: 100%;
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
 :is(.block-table_block, .block-typed_table_block) :is(table, tr, td, th) {
   border: 1px solid var(--dark);
   padding: 0.25em;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -406,7 +406,7 @@ blockquote .attribute-name {
 
 /* stylelint-disable-next-line selector-class-pattern */
 .block-paragraph_block iframe {
-  aspect-ratio: 16 / 9 ;
+  aspect-ratio: 16 / 9;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
Fixes #147 

**Description:**

This pull request addresses the issue with iframe dimensions within the .block-paragraph_block containers. The existing CSS selector for .block-embed_block iframe does not cover iframes within paragraph blocks. To resolve this, the proposed solution includes an additional CSS rule to adjust iframe dimensions within paragraph blocks. 

**Changes Made:**

Added CSS selector to target iframes within .block-paragraph_block container:

![image](https://github.com/wagtail/bakerydemo/assets/93925338/56dd9d79-695c-441c-9612-1048abd20840)

![Screenshot_2023-06-16_15-46-30](https://github.com/wagtail/bakerydemo/assets/93925338/85e07dda-0695-479e-8092-4c3d6eb92770)

**Note to Reviewers:**

Your feedback and suggestions regarding the proposed solution are highly appreciated. Please review the changes and let me know if there are any further improvements or alternative approaches to consider.