### PR TITLE
Add Content Security Policy testing setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # If the variables defined here are loaded into the environment, CSP will be enabled.
 
 # Careful about the quoting of directives! It is easy to break.
-export CSP_DEFAULT_SRC="'self'"
+# CSP_DEFAULT_SRC="'self'"
 
 # Enable this rule to allow font awesome to load from CDN
-# export CSP_FONT_SRC="'self', https://cdnjs.cloudflare.com"
+# CSP_FONT_SRC="'self', https://cdnjs.cloudflare.com"

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -204,3 +204,32 @@ WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
 ]
 
 ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "changeme")
+
+# Content Security policy settings
+# http://django-csp.readthedocs.io/en/latest/configuration.html
+
+# Only enable CSP when enabled through environment variables.
+if "CSP_DEFAULT_SRC" in os.environ:
+    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+
+    # Only report violations, don't enforce policy
+    CSP_REPORT_ONLY = True
+
+    # The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', and 'none' must be quoted!
+    # e.g.: CSP_DEFAULT_SRC = "'self'" Without quotes they will not work as intended.
+
+    CSP_DEFAULT_SRC = os.environ.get("CSP_DEFAULT_SRC").split(",")
+    if "CSP_SCRIPT_SRC" in os.environ:
+        CSP_SCRIPT_SRC = os.environ.get("CSP_SCRIPT_SRC").split(",")
+    if "CSP_STYLE_SRC" in os.environ:
+        CSP_STYLE_SRC = os.environ.get("CSP_STYLE_SRC").split(",")
+    if "CSP_IMG_SRC" in os.environ:
+        CSP_IMG_SRC = os.environ.get("CSP_IMG_SRC").split(",")
+    if "CSP_CONNECT_SRC" in os.environ:
+        CSP_CONNECT_SRC = os.environ.get("CSP_CONNECT_SRC").split(",")
+    if "CSP_FONT_SRC" in os.environ:
+        CSP_FONT_SRC = os.environ.get("CSP_FONT_SRC").split(",")
+    if "CSP_BASE_URI" in os.environ:
+        CSP_BASE_URI = os.environ.get("CSP_BASE_URI").split(",")
+    if "CSP_OBJECT_SRC" in os.environ:
+        CSP_OBJECT_SRC = os.environ.get("CSP_OBJECT_SRC").split(",")

--- a/csp.env
+++ b/csp.env
@@ -1,0 +1,8 @@
+# This file contains Content Security Policy (CSP) directives.
+# If the variables defined here are loaded into the environment, CSP will be enabled.
+
+# Careful about the quoting of directives! It is easy to break.
+export CSP_DEFAULT_SRC="'self'"
+
+# Enable this rule to allow font awesome to load from CDN
+# export CSP_FONT_SRC="'self', https://cdnjs.cloudflare.com"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,5 @@ wagtail>=5,<5.1
 wagtail-font-awesome-svg>=0.0.3,<1
 django-debug-toolbar>=3.2,<4
 django-extensions==3.2.1
+django-csp==3.7
 dj-database-url==0.4.1


### PR DESCRIPTION
To be used to test Wagtail's compatibility with [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).

By default, CSP is only enabled when the `CSP_DEFAULT_SRC` environment variable is set. This environment variable functions as a feature flag because we don't want to frustrate normal users with a broken website or a lot of CSP violation errors in the browser console.

A default configuration for `CSP_DEFAULT_SRC` can be loaded by sourcing the `csp.env` file added by this PR. Other CSP policy values can be influenced through environment variables as well.

Related:
- https://github.com/wagtail/wagtail/issues/1288
- https://github.com/wagtail/bakerydemo/issues/423