### PR TITLE
Remove the need for inline styles for hero images

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -280,11 +280,17 @@ figure img {
 
 /* Hero image area */
 .hero {
-  background-size: cover;
-  background-position: center;
   padding: 300px 0 0;
   position: relative;
   margin: 0 0 10px;
+}
+
+.hero-image {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 @media screen and (min-width: 768px) {

--- a/bakerydemo/templates/base/gallery_page.html
+++ b/bakerydemo/templates/base/gallery_page.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags gallery_tags %}
 
 {% block content %}
-    {% image self.image fill-1920x600 as hero_img %}
     {% include "base/include/header-hero.html" %}
 
     <div class="container gallery__container">

--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -4,8 +4,8 @@
 {% block content %}
     <div class="homepage">
 
-        {% image page.image fill-1920x600 as image %}
-        <div class="container-fluid hero" style="background-image:url('{{ image.url }}')">
+        <div class="container-fluid hero">
+            {% image page.image fill-1920x600 class="hero-image" alt="" %}
             <div class="hero-gradient-mask"></div>
             <div class="container">
                 <div class="row">

--- a/bakerydemo/templates/base/include/header-blog.html
+++ b/bakerydemo/templates/base/include/header-blog.html
@@ -1,8 +1,9 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% if page.image %}
-    {% image page.image fill-1920x600 as image %}
-    <div class="container-fluid hero hero--blog" style="background-image:url('{{ image.url }}')"></div>
+    <div class="container-fluid hero hero--blog">
+        {% image page.image fill-1920x600 class="hero-image" alt="" %}
+    </div>
 {% endif %}
 <div class="container">
     <div class="row">

--- a/bakerydemo/templates/base/include/header-hero.html
+++ b/bakerydemo/templates/base/include/header-hero.html
@@ -1,8 +1,8 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% if page.image %}
-    {% image page.image fill-1920x600 as image %}
-    <div class="container-fluid hero" style="background-image:url('{{ image.url }}')">
+    <div class="container-fluid hero">
+        {% image page.image fill-1920x600 class="hero-image" alt="" %}
         <div class="hero__container">
             <h1 class="hero__title">{{ page.title }}</h1>
         </div>

--- a/bakerydemo/templates/blog/blog_page.html
+++ b/bakerydemo/templates/blog/blog_page.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 
-    {% image self.image fill-1920x600 as hero_img %}
     {% include "base/include/header-blog.html" %}
 
     <div class="container">

--- a/bakerydemo/templates/breads/bread_page.html
+++ b/bakerydemo/templates/breads/bread_page.html
@@ -2,7 +2,6 @@
 {% load wagtailimages_tags %}
 
 {% block content %}
-    {% image page.image fill-1920x600 as hero_img %}
     {% include "base/include/header-hero.html" %}
 
     <div class="container bread-detail">

--- a/bakerydemo/templates/recipes/recipe_page.html
+++ b/bakerydemo/templates/recipes/recipe_page.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 
-    {% image self.image fill-1920x600 as hero_img %}
     {% include "base/include/header-blog.html" %}
 
     <div class="container">


### PR DESCRIPTION
Follow-up to #232. I’ve switched to `image` tags without alt text to preserve the same behavior as before. As far as I can see the pages should look 1:1 identical, and this also works when the page doesn’t have an image.

Along the way I also noted we have lots of useless `{% image %}` tag usage. I’ve removed those.