### PR TITLE
Use separate wagtail-modeladmin package

### DIFF
--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -1,12 +1,8 @@
 from wagtail import hooks
 from wagtail.admin.userbar import AccessibilityItem
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
+from wagtail_modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
 
 from bakerydemo.base.models import FooterText, Person
 from bakerydemo.breads.models import BreadIngredient, BreadType, Country

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -58,7 +58,7 @@ INSTALLED_APPS = [
     "wagtail.contrib.routable_page",
     "wagtail.contrib.table_block",
     "wagtail.contrib.typed_table_block",
-    "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtail.contrib.search_promotions",
     "wagtail.contrib.settings",
     "wagtail.contrib.simple_translation",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ Django>=4.2,<4.3
 django-dotenv==1.4.1
 wagtail>=5,<5.1
 wagtail-font-awesome-svg>=0.0.3,<1
+wagtail-modeladmin>=1.0.0,<2
 django-debug-toolbar>=3.2,<4
 django-extensions==3.2.1
 django-csp==3.7


### PR DESCRIPTION
Not sure if we want this in bakerydemo, as we'd probably want to fully remove modeladmin from bakerydemo once the contrib module is out of the Wagtail repository anyway.

Putting this here just for demonstrating the replacement of `wagtail.contrib.modeladmin` with `wagtail_modeladmin`.