### PR TITLE
Move all remaining ModelAdmin usage to Snippets

### DIFF
--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -2,7 +2,6 @@ from wagtail import hooks
 from wagtail.admin.userbar import AccessibilityItem
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
-from wagtail_modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
 
 from bakerydemo.base.models import FooterText, Person
 from bakerydemo.breads.models import BreadIngredient, BreadType, Country
@@ -44,7 +43,7 @@ def replace_userbar_accessibility_item(request, items):
     ]
 
 
-class BreadIngredientAdmin(ModelAdmin):
+class BreadIngredientViewSet(SnippetViewSet):
     # These stub classes allow us to put various models into the custom "Wagtail Bakery" menu item
     # rather than under the default Snippets section.
     model = BreadIngredient
@@ -52,21 +51,21 @@ class BreadIngredientAdmin(ModelAdmin):
     inspect_view_enabled = True
 
 
-class BreadTypeAdmin(ModelAdmin):
+class BreadTypeViewSet(SnippetViewSet):
     model = BreadType
     search_fields = ("title",)
 
 
-class BreadCountryAdmin(ModelAdmin):
+class BreadCountryViewSet(SnippetViewSet):
     model = Country
     search_fields = ("title",)
 
 
-class BreadModelAdminGroup(ModelAdminGroup):
+class BreadSnippetViewSetGroup(SnippetViewSetGroup):
     menu_label = "Bread Categories"
     menu_icon = "suitcase"  # change as required
     menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
-    items = (BreadIngredientAdmin, BreadTypeAdmin, BreadCountryAdmin)
+    items = (BreadIngredientViewSet, BreadTypeViewSet, BreadCountryViewSet)
 
 
 class PersonViewSet(SnippetViewSet):
@@ -91,7 +90,7 @@ class BakerySnippetViewSetGroup(SnippetViewSetGroup):
     items = (PersonViewSet, FooterTextViewSet)
 
 
-# When using a ModelAdminGroup class to group several ModelAdmin classes together,
-# you only need to register the ModelAdminGroup class with Wagtail:
-modeladmin_register(BreadModelAdminGroup)
+# When using a SnippetViewSetGroup class to group several SnippetViewSet classes together,
+# you only need to register the SnippetViewSetGroup class with Wagtail:
+register_snippet(BreadSnippetViewSetGroup)
 register_snippet(BakerySnippetViewSetGroup)

--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -4,7 +4,6 @@ from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 
 from bakerydemo.base.models import FooterText, Person
-from bakerydemo.breads.models import BreadIngredient, BreadType, Country
 
 """
 N.B. To see what icons are available for use in Wagtail menus and StreamField block types,
@@ -43,32 +42,12 @@ def replace_userbar_accessibility_item(request, items):
     ]
 
 
-class BreadIngredientViewSet(SnippetViewSet):
-    # These stub classes allow us to put various models into the custom "Wagtail Bakery" menu item
-    # rather than under the default Snippets section.
-    model = BreadIngredient
-    search_fields = ("name",)
-    inspect_view_enabled = True
-
-
-class BreadTypeViewSet(SnippetViewSet):
-    model = BreadType
-    search_fields = ("title",)
-
-
-class BreadCountryViewSet(SnippetViewSet):
-    model = Country
-    search_fields = ("title",)
-
-
-class BreadSnippetViewSetGroup(SnippetViewSetGroup):
-    menu_label = "Bread Categories"
-    menu_icon = "suitcase"  # change as required
-    menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
-    items = (BreadIngredientViewSet, BreadTypeViewSet, BreadCountryViewSet)
-
-
 class PersonViewSet(SnippetViewSet):
+    # Instead of decorating the Person model class definition in models.py with
+    # @register_snippet - which has Wagtail automatically generate an admin interface for this model - we can also provide our own
+    # SnippetViewSet class which allows us to customize the admin interface for this snippet.
+    # See the documentation for SnippetViewSet for more details
+    # https://docs.wagtail.org/en/stable/reference/viewsets.html#snippetviewset
     model = Person
     menu_label = "People"  # ditch this to use verbose_name_plural from model
     icon = "group"  # change as required
@@ -92,5 +71,4 @@ class BakerySnippetViewSetGroup(SnippetViewSetGroup):
 
 # When using a SnippetViewSetGroup class to group several SnippetViewSet classes together,
 # you only need to register the SnippetViewSetGroup class with Wagtail:
-register_snippet(BreadSnippetViewSetGroup)
 register_snippet(BakerySnippetViewSetGroup)

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -6,18 +6,16 @@ from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import DraftStateMixin, Page, RevisionMixin
 from wagtail.search import index
-from wagtail.snippets.models import register_snippet
 
 from bakerydemo.base.blocks import BaseStreamBlock
 
 
-@register_snippet
 class Country(models.Model):
     """
     A Django model to store set of countries of origin.
-    It uses the `@register_snippet` decorator to allow it to be accessible
-    via the Snippets UI (e.g. /admin/snippets/breads/country/) In the BreadPage
-    model you'll see we use a ForeignKey to create the relationship between
+    It is made accessible in the Wagtail admin interface through the CountrySnippetViewSet
+    class in wagtail_hooks.py. This allows us to customize the admin interface for this snippet.
+    In the BreadPage model you'll see we use a ForeignKey to create the relationship between
     Country and BreadPage. This allows a single relationship (e.g only one
     Country can be added) that is one-way (e.g. Country will have no way to
     access related BreadPage objects).
@@ -32,12 +30,12 @@ class Country(models.Model):
         verbose_name_plural = "Countries of Origin"
 
 
-@register_snippet
 class BreadIngredient(DraftStateMixin, RevisionMixin, models.Model):
     """
-    Standard Django model that is displayed as a snippet within the admin due
-    to the `@register_snippet` decorator. We use a new piece of functionality
-    available to Wagtail called the ParentalManyToManyField on the BreadPage
+    A Django model to store a single ingredient.
+    It is made accessible in the Wagtail admin interface through the BreadIngredientSnippetViewSet
+    class in wagtail_hooks.py. This allows us to customize the admin interface for this snippet.
+    We use a piece of functionality available to Wagtail called the ParentalManyToManyField on the BreadPage
     model to display this. The Wagtail Docs give a slightly more detailed example
     https://docs.wagtail.org/en/stable/getting_started/tutorial.html#categories
     """
@@ -55,12 +53,12 @@ class BreadIngredient(DraftStateMixin, RevisionMixin, models.Model):
         verbose_name_plural = "Bread ingredients"
 
 
-@register_snippet
 class BreadType(RevisionMixin, models.Model):
     """
     A Django model to define the bread type
-    It uses the `@register_snippet` decorator to allow it to be accessible
-    via the Snippets UI. In the BreadPage model you'll see we use a ForeignKey
+    It is made accessible in the Wagtail admin interface through the BreadTypeSnippetViewSet
+    class in wagtail_hooks.py. This allows us to customize the admin interface for this snippet.
+    In the BreadPage model you'll see we use a ForeignKey
     to create the relationship between BreadType and BreadPage. This allows a
     single relationship (e.g only one BreadType can be added) that is one-way
     (e.g. BreadType will have no way to access related BreadPage objects)

--- a/bakerydemo/breads/wagtail_hooks.py
+++ b/bakerydemo/breads/wagtail_hooks.py
@@ -1,0 +1,46 @@
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
+
+from bakerydemo.breads.models import BreadIngredient, BreadType, Country
+
+
+class BreadIngredientSnippetViewSet(SnippetViewSet):
+    model = BreadIngredient
+    ordering = ("name",)
+    search_fields = ("name",)
+    inspect_view_enabled = True
+
+
+class BreadTypeSnippetViewSet(SnippetViewSet):
+    model = BreadType
+    ordering = ("title",)
+    search_fields = ("title",)
+
+
+class CountrySnippetViewSet(SnippetViewSet):
+    model = Country
+    ordering = ("title",)
+    search_fields = ("title",)
+
+
+# We want to group several snippets together in the admin menu.
+# This is done by defining a SnippetViewSetGroup class that contains a list of
+# SnippetViewSet classes.
+# When using a SnippetViewSetGroup class to group several SnippetViewSet classes together,
+# you only need to register the SnippetViewSetGroup class with Wagtail.
+# No need to register the individual SnippetViewSet classes.
+#
+# See the documentation for SnippetViewSet for more details.
+# https://docs.wagtail.org/en/stable/reference/viewsets.html#snippetviewsetgroup
+class BreadMenuGroup(SnippetViewSetGroup):
+    menu_label = "Bread Categories"
+    menu_icon = "suitcase"  # change as required
+    menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
+    items = (
+        BreadIngredientSnippetViewSet,
+        BreadTypeSnippetViewSet,
+        CountrySnippetViewSet,
+    )
+
+
+register_snippet(BreadMenuGroup)

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -66,7 +66,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "modelcluster",
     "taggit",
-    "wagtail_modeladmin",
     "wagtailfontawesomesvg",
     "debug_toolbar",
     "django_extensions",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,6 @@
 Django>=4.2,<4.3
 django-dotenv==1.4.1
 wagtail>=5.1,<5.2
-wagtail-modeladmin>=1,<2
 wagtail-font-awesome-svg>=0.0.3,<1
 django-debug-toolbar>=3.2,<4
 django-extensions==3.2.1


### PR DESCRIPTION
Addresses https://github.com/wagtail/bakerydemo/issues/441

The models were already registered as snippets through the `@register_snippet` decorator on their definition.

I've replicated the ModelAdmin grouping in Snippets by creating custom SnippetViewSet and SnippetViewSetGroup classes. While at it, I've touched up the comments in the code a bit.