### PR TITLE
Remove unnecessary variables from base.html

### DIFF
--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -32,7 +32,7 @@
         {% wagtailuserbar %}
 
         {% block header %}
-            {% include "includes/header.html" with parent=site_root calling_page=self %}
+            {% include "includes/header.html" %}
         {% endblock header %}
 
         {% block breadcrumbs %}


### PR DESCRIPTION
I was revising the code in base.html and I think the variables in line 35 are not needed for the navigation menu to work, since they are already defined in header.html. I tested the site deleting the variables and the menu renders fine.