### PR TITLE
Move all page content within landmarks

### DIFF
--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -40,11 +40,12 @@
             {% breadcrumbs %}
         {% endblock breadcrumbs %}
 
-        {% block messages %}
-            {% include "includes/messages.html" %}
-        {% endblock messages %}
 
         <main>
+            {% block messages %}
+                {% include "includes/messages.html" %}
+            {% endblock messages %}
+
             {% block content %}
             {% endblock content %}
         </main>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -1,6 +1,6 @@
 {% load navigation_tags %}
 
-<div class="header clearfix">
+<header class="header clearfix">
     <div class="container">
         <div class="navigation" data-navigation>
             <a href="/" class="navigation__logo">The Wagtail Bakery</a>
@@ -54,4 +54,4 @@
             </form>
         </div>
     </div>
-</div>
+</header>


### PR DESCRIPTION
Fixes accessibility issues detected by the Wagtail accessibility checker – page content being present outside of a landmark. This was raised by the header navigation, which is now in a `<header>` element. I’ve also moved the messages within `main` (no changes to how they display).