### PR TITLE
Add `GenericRelation` to revisions and workflow states

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.translation import gettext as _
 from modelcluster.fields import ParentalKey
@@ -65,6 +66,22 @@ class Person(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
+    )
+
+    workflow_states = GenericRelation(
+        "wagtailcore.WorkflowState",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="person",
+        for_concrete_model=False,
+    )
+
+    revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="person",
+        for_concrete_model=False,
     )
 
     panels = [
@@ -162,6 +179,14 @@ class FooterText(
     """
 
     body = RichTextField()
+
+    revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="footer_text",
+        for_concrete_model=False,
+    )
 
     panels = [
         FieldPanel("body"),

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.contenttypes.fields import GenericRelation
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from modelcluster.fields import ParentalManyToManyField
@@ -42,6 +43,14 @@ class BreadIngredient(DraftStateMixin, RevisionMixin, models.Model):
 
     name = models.CharField(max_length=255)
 
+    revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="bread_ingredient",
+        for_concrete_model=False,
+    )
+
     panels = [
         FieldPanel("name"),
     ]
@@ -65,6 +74,14 @@ class BreadType(RevisionMixin, models.Model):
     """
 
     title = models.CharField(max_length=255)
+
+    revisions = GenericRelation(
+        "wagtailcore.Revision",
+        content_type_field="base_content_type",
+        object_id_field="object_id",
+        related_query_name="bread_type",
+        for_concrete_model=False,
+    )
 
     panels = [
         FieldPanel("title"),


### PR DESCRIPTION
Prevent issues like https://github.com/wagtail/wagtail/pull/11300 and https://github.com/wagtail/wagtail/pull/11591. Wagtail's docs have already been updated to state that the `GenericRelation`s should be defined.