### PR TITLE
Bump to Wagtail 6.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django>=4.2,<5.0
 django-dotenv==1.4.2
-wagtail>=6.0,<6.1
+wagtail>=6.1,<6.2
 wagtail-font-awesome-svg>=1,<2
 django-debug-toolbar>=4.2,<5
 django-extensions==3.2.3


### PR DESCRIPTION
Looks like bakerydemo is not affected by any of the upgrade considerations: https://docs.wagtail.org/en/stable/releases/6.1.html