### PR TITLE
Comment out django_debug_toolbar settings from dev settings

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -29,7 +29,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-# Uncomment this (and adjust as appropriate) to enable django-debug-toolbar
+# Uncomment (and adjust as appropriate) to enable django-debug-toolbar
 # INTERNAL_IPS = [
 #     '127.0.0.1',
 # ]
@@ -67,7 +67,8 @@ INSTALLED_APPS = [
     "modelcluster",
     "taggit",
     "wagtailfontawesomesvg",
-    "debug_toolbar",
+    # Uncomment to enable django-debug-toolbar
+    # "debug_toolbar",
     "django_extensions",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -79,7 +80,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
+    # Uncomment to enable django-debug-toolbar
+    # "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
The current version (4.4.2) of django-debug-toolbar aborts when running ./manage.py test with the toolbar enabled. While bakerydemo doesn't have any tests, .github/workflows/docker.yml runs this anyway, presumably as a sort of sanity check, and thus we need to properly disable django-debug-toolbar rather than just leaving it inactive via INTERNAL_IPS.

(The `__debug__` route is still defined in bakerydemo.urls, but this seems to be harmless.)