### PR TITLE
Replace `docker-compose` with `docker compose` in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build container
-        run: docker-compose build && docker-compose pull
+        run: docker compose build && docker compose pull
       - name: Run migrations
-        run: docker-compose run app /venv/bin/python manage.py migrate
+        run: docker compose run app /venv/bin/python manage.py migrate
       - name: Load initial data
-        run: docker-compose run app /venv/bin/python manage.py load_initial_data
+        run: docker compose run app /venv/bin/python manage.py load_initial_data
       - name: Run tests
-        run: docker-compose run app /venv/bin/python manage.py test
+        run: docker compose run app /venv/bin/python manage.py test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
   build-container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build container
         run: docker compose build && docker compose pull
       - name: Run migrations


### PR DESCRIPTION
Docker Compose v1 has been removed from `ubuntu-latest` runner images per July 29, 2024.

See https://github.com/actions/runner-images/issues/9692