### PR TITLE
Add v5.2, v6.0, and v6.1 tags to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -229,6 +229,14 @@ By default, `django-csp` is not enabled since Wagtail isn't fully compatible yet
 
 The `main` branch of this demo is designed to work with both the latest stable release and the latest `main` branch (development version) of Wagtail. To run the demo against a specific version of Wagtail, we have created [git tags](https://github.com/wagtail/bakerydemo/tags) for the latest commits that work with each feature release.
 
+- [`v6.1`](https://github.com/wagtail/bakerydemo/releases/tag/v6.1)
+- [`v6.0`](https://github.com/wagtail/bakerydemo/releases/tag/v6.0)
+- [`v5.2`](https://github.com/wagtail/bakerydemo/releases/tag/v5.2)
+
+<details>
+
+<summary>Older tags</summary>
+
 - [`v5.1`](https://github.com/wagtail/bakerydemo/releases/tag/v5.1)
 - [`v5.0`](https://github.com/wagtail/bakerydemo/releases/tag/v5.0)
 - [`v4.2`](https://github.com/wagtail/bakerydemo/releases/tag/v4.2)
@@ -236,6 +244,8 @@ The `main` branch of this demo is designed to work with both the latest stable r
 - [`v4.0`](https://github.com/wagtail/bakerydemo/releases/tag/v4.0)
 - [`v3.0`](https://github.com/wagtail/bakerydemo/releases/tag/v3.0)
 - [`v2.16`](https://github.com/wagtail/bakerydemo/releases/tag/v2.16)
+
+</details>
 
 The tags point to the last commit just before the requirements were updated to the next Wagtail version. For example, the `v4.2` tag points to the commit just before the bakerydemo was updated to use Wagtail 5.0. This ensures that the tagged demo code contains the latest updates possible for the supported version.
 


### PR DESCRIPTION
Only immediately show the latest three tags, and put the rest inside a `<details>` tag.