### PR TITLE
More human-friendly WAGTAIL_SITE_NAME

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -194,7 +194,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 # Wagtail settings
-WAGTAIL_SITE_NAME = "bakerydemo"
+WAGTAIL_SITE_NAME = "The Wagtail Bakery"
 
 WAGTAIL_I18N_ENABLED = True
 


### PR DESCRIPTION
As of Wagtail 6.3 `WAGTAIL_SITE_NAME` is used as the heading for the admin dashboard, so let's make it a human-friendly title (and avoid creating the temptation for developers to try and munge the capitalisation in code, as we did in [#12592](https://github.com/wagtail/wagtail/issues/12592) :-) )
![Screenshot 2024-11-19 at 14 48 11](https://github.com/user-attachments/assets/735e4371-4338-4072-aed6-3c58555c34e6)
