### PR TITLE
Fix `LegacyKeyValueFormat` warning in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex \
 RUN mkdir /code/
 WORKDIR /code/
 ADD . /code/
-ENV PORT 8000
+ENV PORT=8000
 EXPOSE 8000
 
 # Add custom environment variables needed by Django or your settings file here:


### PR DESCRIPTION
https://docs.docker.com/reference/build-checks/legacy-key-value-format/

Will merge this right away, as we already use the new syntax elsewhere in the `Dockerfile`.