### PR TITLE
Fix TypedTableBlock preview on Wagtail 6.4

### DIFF
--- a/bakerydemo/recipes/blocks.py
+++ b/bakerydemo/recipes/blocks.py
@@ -29,6 +29,13 @@ class RecipeStepBlock(StructBlock):
         icon = "tick"
 
 
+class CustomTypedTableBlock(TypedTableBlock):
+    # Remove this class in Wagtail 6.5+ as it will no longer be necessary
+
+    def get_preview_value(self):
+        return self.to_python(self.meta.preview_value)
+
+
 class RecipeStreamBlock(StreamBlock):
     """
     Define the custom blocks that `StreamField` will utilize
@@ -52,7 +59,7 @@ class RecipeStreamBlock(StreamBlock):
             ],
         },
     )
-    typed_table_block = TypedTableBlock(
+    typed_table_block = CustomTypedTableBlock(
         [
             ("text", CharBlock()),
             ("numeric", FloatBlock()),


### PR DESCRIPTION
https://github.com/wagtail/bakerydemo/pull/521#discussion_r1927329974

The PR is merged in Wagtail but only available for 6.5+ as it's still in `main`.