### PR TITLE
Add nightly deployment config

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,35 @@
+name: Deploy nightly build
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 AM UTC every day
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  deploy-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # We intentionally don't set `persist-credentials` to `false` because we
+        # want to push to the nightly branch. This is safe because we only use
+        # our own commands and there are no external actions beyond this point.
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update heroku.yml
+        run: |
+          sed -i 's/NIGHTLY: 0/NIGHTLY: 1/' heroku.yml
+
+      - name: Create and push commit to nightly branch
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          git checkout -B nightly
+          git add heroku.yml
+          git commit -m "deploy: $TIMESTAMP"
+          git push --force origin nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim
+ARG NIGHTLY=0
 
 # Install packages needed to run your application (not build deps):
 # We need to recreate the /usr/share/man/man{1..8} directories first because
@@ -33,6 +34,11 @@ RUN set -ex \
         zlib1g-dev \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS \
+    && if [ "$NIGHTLY" = "1" ]; then \
+        NIGHTLY_URL=$(curl -s https://releases.wagtail.org/nightly/latest.json | \
+            grep -o 'https://[^"]*') \
+        && sed -i "s|wagtail>=.*|${NIGHTLY_URL}|" /requirements/base.txt; \
+    fi \
     && python3.12 -m venv ${VIRTUAL_ENV} \
     && python3.12 -m pip install -U pip \
     && python3.12 -m pip install --no-cache-dir -r /requirements/production.txt \

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,6 +2,8 @@ build:
   docker:
     web:
       dockerfile: Dockerfile
+  config:
+    NIGHTLY: 0
 
 release:
   image: web


### PR DESCRIPTION
- Add a `NIGHTLY` build arg to the `Dockerfile` that would replace the `wagtail` dependency in `requirements/base.txt` with a link to the nightly wheel.
- Add a GitHub Actions workflow configuration that:
  - checks out the `main` branch,
  - sets the `NIGHTLY` build arg in `heroku.yml` to `1`
  - commits and pushes to the `nightly` branch (with `--force` to ensure it's up to date with latest `main`)

Heroku will pick up the push to the `nightly` branch and deploy it to our nightly demo app. We don't set `NIGHTLY: 1` directly in `heroku.yml` because we also deploy the demo with the latest stable version of Wagtail as defined in `requirements/base.txt`.