### PR TITLE
Bump psycopg to 3.2

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,7 +2,7 @@
 elasticsearch==5.5.3
 # Additional dependencies for Heroku, AWS, and Google Cloud deployment
 uwsgi>=2.0.17,<2.1
-psycopg[binary]>=3.1,<3.2
+psycopg[binary]>=3.2.2,<3.3
 whitenoise==6.6.0
 boto3>=1.37,<1.38
 google-cloud-storage==2.13.0


### PR DESCRIPTION
To allow the use of Python 3.13 (fixes #531).