### PR TITLE
docs:remove spaces around slashes in 'admin / changeme' in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This is a demonstration project for the amazing [Wagtail CMS](https://github.com/wagtail/wagtail).
 
-The demo site is designed to provide examples of common features and recipes to introduce you to Wagtail development. Beyond the code, it will also let you explore the admin / editorial interface of the CMS.
+The demo site is designed to provide examples of common features and recipes to introduce you to Wagtail development. Beyond the code, it will also let you explore the admin/editorial interface of the CMS.
 
 Note we do _not_ recommend using this project to start your own site - the demo is intended to be a springboard to get you started. Feel free to copy code from the demo into your own project.
 
@@ -46,7 +46,7 @@ Set up a development environment and run this demo website with a single click (
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wagtail/bakerydemo/)
 
 Once Gitpod has fully started, and a preview of the bakery website has appeared in the "Simple Browser" panel, click the arrow button to the right of the URL bar to open the website in a new tab.
-Go to `/admin/` and login with `admin / changeme`.
+Go to `/admin/` and login with `admin/changeme`.
 
 ## Setup with Vagrant
 
@@ -71,7 +71,7 @@ vagrant ssh
 The demo site will now be accessible at [http://localhost:8000/](http://localhost:8000/) and the Wagtail admin
 interface at [http://localhost:8000/admin/](http://localhost:8000/admin/).
 
-Log into the admin with the credentials `admin / changeme`.
+Log into the admin with the credentials `admin/changeme`.
 
 Use `Ctrl+c` to stop the local server. To stop the Vagrant environment, run `exit` then `vagrant halt`.
 
@@ -107,7 +107,7 @@ docker compose up
 The demo site will now be accessible at [http://localhost:8000/](http://localhost:8000/) and the Wagtail admin
 interface at [http://localhost:8000/admin/](http://localhost:8000/admin/).
 
-Log into the admin with the credentials `admin / changeme`.
+Log into the admin with the credentials `admin/changeme`.
 
 **Important:** This `docker-compose.yml` is configured for local testing only, and is _not_ intended for production use.
 
@@ -168,7 +168,7 @@ To set up your database and load initial data, run the following commands:
 ./manage.py runserver
 ```
 
-Log into the admin with the credentials `admin / changeme`.
+Log into the admin with the credentials `admin/changeme`.
 
 # Next steps
 


### PR DESCRIPTION
Corrects the display of admin credentials from "admin / changeme" to
"admin/changeme" to prevent confusion, as spaces around slashes are
misleading and invalid in URLs.