### PR TITLE
implement new django csp baseline

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/stable/ref/settings/
 import os
 
 import dj_database_url
+from django.utils.csp import CSP
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -226,30 +227,14 @@ ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "changeme")
 
 # Only enable CSP when enabled through environment variables.
 if "CSP_DEFAULT_SRC" in os.environ:
-    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+    MIDDLEWARE.append("django.middleware.csp.ContentSecurityPolicyMiddleware")
+    # Gravatar images should be disabled for strict CSP
+    WAGTAIL_GRAVATAR_PROVIDER_URL = None
 
-    # Only report violations, don't enforce policy
-    CSP_REPORT_ONLY = True
+# To enforce a CSP policy in report-only mode:
+SECURE_CSP_REPORT_ONLY = {
+    "default-src": [CSP.SELF, "*.wagtail.org"],
+    # Add more directives as needed.
+}
 
-    # The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', and 'none' must be quoted!
-    # e.g.: CSP_DEFAULT_SRC = "'self'" Without quotes they will not work as intended.
-
-    CSP_DEFAULT_SRC = os.environ.get("CSP_DEFAULT_SRC").split(",")
-    if "CSP_SCRIPT_SRC" in os.environ:
-        CSP_SCRIPT_SRC = os.environ.get("CSP_SCRIPT_SRC").split(",")
-    if "CSP_STYLE_SRC" in os.environ:
-        CSP_STYLE_SRC = os.environ.get("CSP_STYLE_SRC").split(",")
-    if "CSP_IMG_SRC" in os.environ:
-        CSP_IMG_SRC = os.environ.get("CSP_IMG_SRC").split(",")
-    if "CSP_CONNECT_SRC" in os.environ:
-        CSP_CONNECT_SRC = os.environ.get("CSP_CONNECT_SRC").split(",")
-    if "CSP_FONT_SRC" in os.environ:
-        CSP_FONT_SRC = os.environ.get("CSP_FONT_SRC").split(",")
-    if "CSP_BASE_URI" in os.environ:
-        CSP_BASE_URI = os.environ.get("CSP_BASE_URI").split(",")
-    if "CSP_OBJECT_SRC" in os.environ:
-        CSP_OBJECT_SRC = os.environ.get("CSP_OBJECT_SRC").split(",")
-    if "CSP_FRAME_SRC" in os.environ:
-        CSP_FRAME_SRC = os.environ.get("CSP_FRAME_SRC").split(",")
-    if "CSP_REPORT_URI" in os.environ:
-        CSP_REPORT_URI = os.environ.get("CSP_REPORT_URI")
+WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django>=5.2,<5.3
+Django>=6.0,<7.0
 django-dotenv==1.4.2
 wagtail>=7.0,<7.1
 wagtail-font-awesome-svg>=1,<2


### PR DESCRIPTION
## Introduction
From [Django 6.0](https://docs.djangoproject.com/en/dev/releases/6.0/) which should be released in December 2025, Django will have an in-built CSP package, and will no longer need the external [django-csp](https://django-csp.readthedocs.io/en/latest/) package.

This PR, although small, has some months to go before being ready for a merge, but it's good to have this under our radar.