### PR TITLE
Update Dockerfile to have Debian Trixie compatible packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN set -ex \
     && RUN_DEPS=" \
         libexpat1 \
         libjpeg62-turbo \
-        libpcre3 \
+        libpcre2-posix3 \
         libpq5 \
-        mime-support \
+        shared-mime-info \
         postgresql-client \
         procps \
         zlib1g \
@@ -29,7 +29,7 @@ RUN set -ex \
         git \
         libexpat1-dev \
         libjpeg62-turbo-dev \
-        libpcre3-dev \
+        libpcre2-dev \
         libpq-dev \
         zlib1g-dev \
     " \


### PR DESCRIPTION
The underlying default base image for python:3.12-slim was updated and some debian packages have changed