### PR TITLE
Add django.contrib.postgres to installed apps

### DIFF
--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -77,7 +77,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sitemaps",
-    "django.contrib.postgres",
 ]
 
 MIDDLEWARE = [
@@ -123,6 +122,8 @@ WSGI_APPLICATION = "bakerydemo.wsgi.application"
 
 if "DATABASE_URL" in os.environ:
     DATABASES = {"default": dj_database_url.config(conn_max_age=500)}
+    if os.environ["DATABASE_URL"].startswith("postgres://"):
+        INSTALLED_APPS.append("django.contrib.postgres")
 else:
     DATABASES = {
         "default": {


### PR DESCRIPTION
Since Wagtail v7.2.1 it is required to add `django.contrib.postgres` to the *INSTALLED_APPS*

Source: https://docs.wagtail.org/en/v7.1.2/topics/search/backends.html#database-backend-default

Without it running the BakeryDemo fails with this error:

```
SystemCheckError: System check identified some issues:

ERRORS:
wagtailsearch.IndexEntry.autocomplete: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use SearchVectorField.
wagtailsearch.IndexEntry.body: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use SearchVectorField.
wagtailsearch.IndexEntry.title: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use SearchVectorField.
wagtailsearch.IndexEntry: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use GinIndex.
wagtailsearch.IndexEntry: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use GinIndex.
wagtailsearch.IndexEntry: (postgres.E005) 'django.contrib.postgres' must be in INSTALLED_APPS in order to use GinIndex.
```

This PR adds the entry to the `bakerydemo/settings/base.py` file to get the Bakery Demo running again