### PR TITLE
Update PostgreSQL and Redis images to latest versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       POSTGRES_USER: app_user
       POSTGRES_PASSWORD: changeme
     restart: unless-stopped
-    image: postgres:14.1
+    image: postgres:18.1
     expose:
       - '5432'
 
   redis:
     restart: unless-stopped
-    image: redis:6.2
+    image: redis:8.4
     expose:
       - '6379'
 


### PR DESCRIPTION
The images mentioned in the `docker-compose.yml` are quite dated.

- Redis support for 6.2 ended in 27 Apr 2022.
- Although Postgres 14 is still in support (Until Nov. 2026) it is now close 4 years old. 

This PR updates the images from:
- Postgres 14.1 -> Postgres 18.1
- Redis 6.2 -> Redis 8.4

No further changes are needed to get Wagtail Bakery Demo up and running.

## Fixes / Closes

- Merging this will also make https://github.com/wagtail/bakerydemo/pull/556 obsolete which proposed something similar