### PR TITLE
Add CONTRIBUTING.md with local setup and contribution guidelines

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,29 +1,100 @@
 # Contributing
 
-We love pull requests from everyone. By participating in this project, you
-agree to abide by the Wagtail [code of conduct](https://github.com/wagtail/wagtail/blob/master/CODE_OF_CONDUCT.md).
 
-If you do not have write access to the repo, fork, then clone the repo:
+Thank you for your interest in contributing to this project! Contributions of all kinds — code, documentation, testing, and discussion — are welcome.
 
-```bash
-git clone git@github.com:your-username/bakerydemo.git
-```
 
-Set up your machine for [development](https://github.com/wagtail/bakerydemo/blob/master/readme.md).
+This project is part of the Wagtail ecosystem and follows many of the same contribution practices. By participating, you agree to abide by the Wagtail
+[Code of Conduct](https://github.com/wagtail/wagtail/blob/main/CODE_OF_CONDUCT.md).
 
-Push to your fork and [submit a pull request](https://github.com/wagtail/bakerydemo/compare/).
 
-For contributors that have write access, if you create a PR that is not
-ready for review, please assign the **work in progress** label to the PR. Once ready
-for review, please remove **work in progress** label and assign the **needs review**
-label to the PR.
 
-Please use your best judgement if committing directly to master. All non-trivial development
-should be done on a branch.
 
-For all work, please cross reference and close issues in
-[commit messages](https://help.github.com/articles/closing-issues-via-commit-messages/).
+## Working on an issue
 
-At this point you're waiting on us. We like to at least comment on pull requests
-within three business days (and, typically, one business day). We may suggest
-some changes or improvements or alternatives.
+
+
+If an issue isn’t currently being worked on, feel free to jump in — **there is no need to ask to be assigned**. You are welcome to leave a comment outlining your approach so others know what you are working on.
+
+If you’re new to open-source contributions, you may find the following resources helpful:
+
+- [Your first contribution guide](https://docs.wagtail.org/en/stable/contributing/first_contribution_guide.html)
+- Issues labeled as *good first issue* in the Wagtail organization
+
+---
+
+## Local setup and development
+
+Instructions for setting up a local development environment are documented in the project README:
+
+- https://github.com/wagtail/bakerydemo/blob/main/README.md
+
+Please follow the README for the most up-to-date setup guidance.
+
+---
+
+## Contribution guidelines (summary)
+
+This project generally follows the Wagtail contribution guidelines. In particular:
+
+- If you make use of AI assistance, please disclose this in your pull request description and explain how you verified the changes.
+- Include tests for any new or changed behavior when appropriate, and ensure existing tests continue to pass.
+- Update documentation if your change affects user-facing or developer-facing behavior.
+- Follow the existing formatting and linting conventions used in the project.
+- For front-end changes, consider testing across common browsers and include screenshots when the visual output changes.
+
+For full details, see the Wagtail contributor documentation:
+- https://docs.wagtail.org/en/stable/contributing/index.html
+
+---
+
+## Submitting pull requests
+
+1. Fork the repository if you do not have write access:
+   ```bash
+   git clone git@github.com:your-username/bakerydemo.git
+2. Create a feature branch from main.
+
+3. Commit your changes with clear, descriptive commit messages.
+
+4. Push your branch and open a pull request:
+https://github.com/wagtail/bakerydemo/compare/
+
+If you have write access and your pull request is not ready for review, please apply the work in progress label. Once it is ready, remove that label and apply needs review.
+
+
+## Review process
+
+After submitting a pull request, maintainers aim to respond within a few business days. Feedback, suggestions, or requests for changes are a normal part of the review process, and collaboration is encouraged.
+
+
+
+Reporting bugs and feature requests
+
+To report bugs or suggest enhancements, please use the GitHub issue tracker:
+https://github.com/wagtail/bakerydemo/issues
+
+If you are unsure whether an idea is suitable, feel free to start a discussion or open an issue for clarification.
+
+
+## Additional resources
+
+The following resources may be useful when contributing to this project:
+
+- **Wagtail contributor documentation**  
+  https://docs.wagtail.org/en/stable/contributing/index.html  
+  Detailed guidelines on contributing to Wagtail projects, including development workflow, testing, and documentation practices.
+
+- **Developing with Wagtail**  
+  https://docs.wagtail.org/en/stable/contributing/developing.html  
+  Covers setting up development environments, running tests, linting, and formatting.
+
+- **Wagtail documentation**  
+  https://docs.wagtail.org/  
+  General reference for Wagtail features, APIs, and best practices.
+
+- **GitHub pull request documentation**  
+  https://docs.github.com/en/pull-requests  
+  Useful if you are new to creating or reviewing pull requests.
+
+These resources are not required reading, but they can help ensure contributions align well with the broader Wagtail ecosystem.


### PR DESCRIPTION
Adds a CONTRIBUTING.md with local setup steps, common development tasks, and
links to relevant Wagtail contributor docs.

There is already an open PR with a more minimal approach; this version adds a
bit more context for first-time contributors. Happy to trim if needed.

closes #581 