### PR TITLE
Fix cache collision on filtered blog lists (#590)

### DIFF
--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -2,51 +2,52 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
 
 {% if tag %}
-    {% block title %}
-        {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
-    {% endblock %}
+{% block title %}
+{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
+{% endblock %}
 
-    {% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
+{% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
 {% endif %}
 
 {% block content %}
-    {% if not tag %}
-        {% include "base/include/header-index.html" %}
-    {% endif %}
+{% if not tag %}
+{% include "base/include/header-index.html" %}
+{% endif %}
 
-    <div class="container">
-        {% if tag %}
-            <div class="row">
-                <div class="col-md-12">
-                    <h1 class="index-header__title">Blog</h1>
-                </div>
-                <div class="col-md-12">
-                    <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag }}</span>.</p>
-                </div>
-            </div>
-        {% endif %}
-
-        {% if page.get_child_tags %}
-            <ul class="blog-tags">
-                <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
-                {% for tag in page.get_child_tags %}
-                    <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-
-        <div class="blog-list">
-            {% if posts %}
-                {% wagtailcache 500 posts %}
-                    {% for blog in posts %}
-                        {% include "includes/card/blog-listing-card.html" %}
-                    {% endfor %}
-                {% endwagtailcache %}
-            {% else %}
-                <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
-                </div>
-            {% endif %}
+<div class="container">
+    {% if tag %}
+    <div class="row">
+        <div class="col-md-12">
+            <h1 class="index-header__title">Blog</h1>
+        </div>
+        <div class="col-md-12">
+            <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span
+                    class="blog-tags__tag">{{ tag }}</span>.</p>
         </div>
     </div>
+    {% endif %}
+
+    {% if page.get_child_tags %}
+    <ul class="blog-tags">
+        <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
+        {% for tag in page.get_child_tags %}
+        <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    <div class="blog-list">
+        {% if posts %}
+        {% wagtailcache 500 posts tag %}
+        {% for blog in posts %}
+        {% include "includes/card/blog-listing-card.html" %}
+        {% endfor %}
+        {% endwagtailcache %}
+        {% else %}
+        <div class="col-md-12">
+            <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
+        </div>
+        {% endif %}
+    </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This PR fixes a caching issue where the wagtailcache tag in 
blog_index_page.html did not account for active tag filters. This resulted in the main index page and tag-filtered pages sharing the same cache key, causing users to see the wrong list of posts (e.g., seeing all posts when a filter should be active, or vice-versa).

Fix
I have updated the {% wagtailcache %} tag to include the tag variable in the cache key arguments.

Before: {% wagtailcache 500 posts %}
After: {% wagtailcache 500 posts tag %}
This ensures that the cache varies based on the active tag, creating separate cache entries for the "All Posts" view and each filtered view (e.g., tag:None, tag:bread, etc.).

Related Issue
Fixes #590

Testing
Verified locally that switching between the main blog index and specific tag URLs (e.g., /blog/tags/bread/) now correctly renders the filtered content even after the cache has been warmed up.
Confirmed that the page still caches effectively (URLs load instantly on repeat visits) but respects the filter.
