### PR TITLE
Avoid bare except in thumb_image

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -130,7 +130,7 @@ class Person(
         # file can't be found.
         try:
             return self.image.get_rendition("fill-50x50").img_tag()
-        except:  # noqa: E722 FIXME: remove bare 'except:'
+        except Exception:
             return ""
 
     @property


### PR DESCRIPTION
Replaces a bare except: block in thumb_image with except Exception:.

Bare except blocks can unintentionally catch system-exiting exceptions and are generally discouraged.

This change preserves existing behavior while narrowing the exception handling.