### PR TITLE
Add rel='noopener noreferer' to  external link

### DIFF
--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -20,7 +20,7 @@
 
         {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}
-            <base target="_blank">
+            <base target="_blank" rel="noopener noreferrer">
         {% endif %}
 
         <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">


### PR DESCRIPTION
This PR adds rel="noopener noreferrer" to links that use target="_blank".
This improves security by preventing reverse tabnabbing and follows HTML best practices. 