### PR TITLE
Improve accessibility by adding ARIA labels to navigation components

### DIFF
--- a/bakerydemo/templates/blocks/captioned_image_block.html
+++ b/bakerydemo/templates/blocks/captioned_image_block.html
@@ -1,6 +1,7 @@
 {% load wagtailimages_tags %}
 
 <figure>
-    {% picture self.image format-{avif,webp,jpeg} fill-{400x220,600x338} sizes="(max-width: 768px) 200px, 900px" loading="lazy" %}
+    {% picture self.image format-{avif,webp,jpeg} fill-{400x220,600x338} sizes="(max-width: 768px) 200px, 900px"
+    loading="lazy" alt="{{ self.image.title }}" %}
     <figcaption>{{ self.caption }} - {{ self.attribution }}</figcaption>
 </figure>

--- a/bakerydemo/templates/blog/blog_page.html
+++ b/bakerydemo/templates/blog/blog_page.html
@@ -3,34 +3,35 @@
 
 {% block content %}
 
-    {% include "base/include/header-blog.html" %}
+{% include "base/include/header-blog.html" %}
 
-    <div class="container">
-        <div class="row">
-            <div class="col-md-8">
-                <div class="blog__meta">
-                    {% if page.authors %}
-                        <div class="blog__avatars">
-                            {% for author in page.authors %}
-                                <div class="blog__author">{% picture author.image format-{avif,webp,jpeg} fill-50x50-c100 class="blog__avatar" %}
-                                    {{ author.first_name }} {{ author.last_name }}</div>
-                            {% endfor %}
-                        </div>
-                    {% endif %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-8">
+            <div class="blog__meta">
+                {% if page.authors %}
+                <div class="blog__avatars">
+                    {% for author in page.authors %}
+                    <div class="blog__author">{% picture author.image format-{avif,webp,jpeg} fill-50x50-c100
+                        class="blog__avatar" alt="{{ author.first_name }} {{ author.last_name }}" %}
+                        {{ author.first_name }} {{ author.last_name }}</div>
+                    {% endfor %}
                 </div>
-
-                {{ page.body }}
-
-                {% if page.get_tags %}
-                    <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
-                    <div class="blog-tags blog-tags--condensed">
-                        <span class="u-sr-only">Filter blog posts by tag</span>
-                        {% for tag in page.get_tags %}
-                            <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
-                        {% endfor %}
-                    </div>
                 {% endif %}
             </div>
+
+            {{ page.body }}
+
+            {% if page.get_tags %}
+            <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
+            <div class="blog-tags blog-tags--condensed">
+                <span class="u-sr-only">Filter blog posts by tag</span>
+                {% for tag in page.get_tags %}
+                <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
+                {% endfor %}
+            </div>
+            {% endif %}
         </div>
     </div>
+</div>
 {% endblock content %}

--- a/bakerydemo/templates/breads/bread_page.html
+++ b/bakerydemo/templates/breads/bread_page.html
@@ -2,67 +2,67 @@
 {% load wagtailimages_tags %}
 
 {% block content %}
-    {% include "base/include/header-hero.html" %}
+{% include "base/include/header-hero.html" %}
 
-    <div class="container bread-detail">
-        <div class="row">
-            <div class="col-md-12">
-                <div class="col-md-7">
-                    <div class="row">
-                        {% if page.introduction %}
-                            <p class="bread-detail__introduction">
-                                {{ page.introduction }}
-                            </p>
-                        {% endif %}
+<div class="container bread-detail">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="col-md-7">
+                <div class="row">
+                    {% if page.introduction %}
+                    <p class="bread-detail__introduction">
+                        {{ page.introduction }}
+                    </p>
+                    {% endif %}
 
-                        <div class="hidden-md-down">
-                            {{ page.body }}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-md-4 col-md-offset-1">
-                    <div class="row">
-                        <div class="bread-detail__meta">
-                            {% if page.origin %}
-                                <p class="bread-detail__meta-title">Origin</p>
-                                <p class="bread-detail__meta-content">{{ page.origin }}</p>
-                            {% endif %}
-                            {% if page.bread_type %}
-                                <p class="bread-detail__meta-title">Type</p>
-                                <p class="bread-detail__meta-content">{{ page.bread_type }}</p>
-                            {% endif %}
-                            {% with ingredients=page.ordered_ingredients %}
-                                {% if ingredients %}
-                                    <h4>Ingredients</h4>
-                                    <ul>
-                                        {% for ingredient in ingredients %}
-                                            <li>
-                                                {% if ingredient.live %}
-                                                    {# If it's live, show as-is #}
-                                                    {{ ingredient.name }}
-                                                {% else %}
-                                                    {# EXAMPLE: we can show a placeholder element for instances that are not live #}
-                                                    <span class="bread-detail__meta-ingredient--draft">
-                                                        Draft ingredient
-                                                    </span>
-                                                    (draft)
-                                                {% endif %}
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            {% endwith %}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-md-7">
-                    <div class="row hidden-md-up">
+                    <div class="hidden-md-down">
                         {{ page.body }}
                     </div>
                 </div>
             </div>
+
+            <div class="col-md-4 col-md-offset-1">
+                <div class="row">
+                    <div class="bread-detail__meta">
+                        {% if page.origin %}
+                        <p class="bread-detail__meta-title">Origin</p>
+                        <p class="bread-detail__meta-content">{{ page.origin }}</p>
+                        {% endif %}
+                        {% if page.bread_type %}
+                        <p class="bread-detail__meta-title">Type</p>
+                        <p class="bread-detail__meta-content">{{ page.bread_type }}</p>
+                        {% endif %}
+                        {% with ingredients=page.ordered_ingredients %}
+                        {% if ingredients %}
+                        <h2>Ingredients</h2>
+                        <ul>
+                            {% for ingredient in ingredients %}
+                            <li>
+                                {% if ingredient.live %}
+                                {# If it's live, show as-is #}
+                                {{ ingredient.name }}
+                                {% else %}
+                                {# EXAMPLE: we can show a placeholder element for instances that are not live #}
+                                <span class="bread-detail__meta-ingredient--draft">
+                                    Draft ingredient
+                                </span>
+                                (draft)
+                                {% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                        {% endwith %}
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-7">
+                <div class="row hidden-md-up">
+                    {{ page.body }}
+                </div>
+            </div>
         </div>
     </div>
+</div>
 {% endblock content %}

--- a/bakerydemo/templates/includes/card/blog-listing-card.html
+++ b/bakerydemo/templates/includes/card/blog-listing-card.html
@@ -3,26 +3,23 @@
 <div class="blog-listing-card">
     <a class="blog-listing-card__link" href="{% pageurl blog %}">
         {% if blog.image %}
-            <figure class="blog-listing-card__image">
-                {% picture blog.image format-{avif,webp,jpeg} fill-322x247-c100 loading="lazy" %}
-            </figure>
+        <figure class="blog-listing-card__image">
+            {% picture blog.image format-{avif,webp,jpeg} fill-322x247-c100 loading="lazy" alt="" %}
+        </figure>
         {% endif %}
         <div class="blog-listing-card__contents">
             <h2 class="blog-listing-card__title">{{ blog.title }}</h2>
             {% if blog.introduction %}
-                <p class="blog-listing-card__introduction">{{ blog.introduction|truncatewords:15 }}</p>
+            <p class="blog-listing-card__introduction">{{ blog.introduction|truncatewords:15 }}</p>
             {% endif %}
             <p class="blog-listing-card__metadata">
                 {% if blog.date_published %}
-                    {{ blog.date_published }} by
+                {{ blog.date_published }} by
                 {% endif %}
                 {% for author in blog.authors %}
-                    {{ author }}{% if not forloop.last %}, {% endif %}
+                {{ author }}{% if not forloop.last %}, {% endif %}
                 {% endfor %}
             </p>
         </div>
     </a>
 </div>
-
-
-

--- a/bakerydemo/templates/includes/card/listing-card.html
+++ b/bakerydemo/templates/includes/card/listing-card.html
@@ -3,31 +3,31 @@
 <div class="listing-card">
     <a class="listing-card__link" href="{{ page.url }}">
         {% if page.image %}
-            <figure class="listing-card__image">
-                {% picture page.image format-{avif,webp,jpeg} fill-180x180-c100 loading="lazy" %}
-            </figure>
+        <figure class="listing-card__image">
+            {% picture page.image format-{avif,webp,jpeg} fill-180x180-c100 loading="lazy" alt="" %}
+        </figure>
         {% endif %}
         <div class="listing-card__contents">
             {% if h2 %}
-                <h2 class="listing-card__title">{{ page.title }}</h2>
+            <h2 class="listing-card__title">{{ page.title }}</h2>
             {% else %}
-                <h3 class="listing-card__title">{{ page.title }}</h3>
+            <h3 class="listing-card__title">{{ page.title }}</h3>
             {% endif %}
             {% if page.origin or page.bread_type %}
-                <table class="listing-card__meta">
-                    {% if page.origin %}
-                        <tr>
-                            <th scope="row" class="listing-card__meta-category">Origin</th>
-                            <td class="listing-card__meta-content">{{ page.origin }}</td>
-                        </tr>
-                    {% endif %}
-                    {% if page.bread_type %}
-                        <tr>
-                            <th scope="row" class="listing-card__meta-category">Type</th>
-                            <td class="listing-card__meta-content">{{ page.bread_type }}</td>
-                        </tr>
-                    {% endif %}
-                </table>
+            <table class="listing-card__meta">
+                {% if page.origin %}
+                <tr>
+                    <th scope="row" class="listing-card__meta-category">Origin</th>
+                    <td class="listing-card__meta-content">{{ page.origin }}</td>
+                </tr>
+                {% endif %}
+                {% if page.bread_type %}
+                <tr>
+                    <th scope="row" class="listing-card__meta-category">Type</th>
+                    <td class="listing-card__meta-content">{{ page.bread_type }}</td>
+                </tr>
+                {% endif %}
+            </table>
             {% endif %}
         </div>
     </a>

--- a/bakerydemo/templates/includes/card/picture-card.html
+++ b/bakerydemo/templates/includes/card/picture-card.html
@@ -4,15 +4,17 @@
     <a class="picture-card__link" href="{{ page.url }}">
         <figure class="picture-card__image">
             {% if portrait %}
-                {% picture page.image format-{avif,webp,jpeg} fill-{250x320-c100,433x487-c100} sizes="(max-width: 768px)125px,400px" loading="lazy" %}
+            {% picture page.image format-{avif,webp,jpeg} fill-{250x320-c100,433x487-c100} sizes="(max-width:
+            768px)125px,400px" loading="lazy" alt="" %}
             {% else %}
-                {% picture page.image format-{avif,webp,jpeg} fill-{300x200-c75,645x480-c75} sizes="(max-width: 768px)150px,30vw" loading="lazy" %}
+            {% picture page.image format-{avif,webp,jpeg} fill-{300x200-c75,645x480-c75} sizes="(max-width:
+            768px)150px,30vw" loading="lazy" alt="" %}
             {% endif %}
             <div class="picture-card__contents">
                 {% if portrait %}
-                    <h3 class="picture-card__title">{{ page.title }}</h3>
+                <h3 class="picture-card__title">{{ page.title }}</h3>
                 {% else %}
-                    <h2 class="picture-card__title">{{ page.title }}</h2>
+                <h2 class="picture-card__title">{{ page.title }}</h2>
                 {% endif %}
             </div>
         </figure>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -18,7 +18,7 @@
                 <span class="navigation__toggle-icon-bar"></span>
             </button>
 
-            <nav class="navigation__mobile" data-mobile-navigation hidden>
+            <nav class="navigation__mobile" aria-label="Mobile" data-mobile-navigation hidden>
                 <a href="/" class="navigation__logo">The Wagtail Bakery</a>
                 <ul class="navigation__items nav-pills">
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -1,103 +1,111 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags wagtailsearchpromotions_tags %}
 
-{% block title %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block title %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif
+%}{% endblock %}
 
-{% block search_description %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block search_description %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query
+}}”{% endif %}{% endblock %}
 
 {% block body_class %}template-search-results{% endblock %}
 
 {% block content %}
-    <div class="container">
-        <div class="row">
-            <div class="col-md-8">
-                <h1>Search results</h1>
-                {% if search_results %}
-                    <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} result{{ search_results|length|pluralize }} found.</p>
-                    <ul class="search__results">
-                        {% for result in search_results %}
-                            <li class="listing-card">
-                                <a class="listing-card__link" href="{% pageurl result.specific %}">
-                                    {% if result.specific.image %}
-                                        <figure class="listing-card__image">
-                                            {% picture result.specific.image format-{avif,webp,jpeg} fill-180x180-c100 loading="lazy" %}
-                                        </figure>
-                                    {% endif %}
-                                    <div class="listing-card__contents">
-                                        <h3 class="listing-card__title">{{ result.specific }}</h3>
-                                        <p class="listing-card__content-type">
-                                            {% if result.specific.content_type.model == "blogpage" %}
-                                                Blog Post
-                                            {% elif result.specific.content_type.model == "locationpage" %}
-                                                Location
-                                            {% else %}
-                                                Bread
-                                            {% endif %}
-                                        </p>
-                                        <p class="listing-card__description">
-                                            {% if result.specific.search_description %}{{ result.specific.search_description|richtext }}{% endif %}
-                                        </p>
-                                    </div>
-                                </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% elif search_query %}
-                    {% get_search_promotions search_query as search_promotions %}
-                    {% if search_promotions %}
-                        <p class="search__introduction">You searched for “{{ search_query }}”, {{ search_promotions|length }} result{{ search_promotions|length|pluralize }} found.</p>
-                        <ul class="search__results">
-                            {% for search_promotion in search_promotions %}
-                                <li class="listing-card">
-                                    {% if search_promotion.page %}
-                                        <a class="listing-card__link" href="{% pageurl search_promotion.page.specific %}">
-                                            {% if search_promotion.page.specific.image %}
-                                                <figure class="listing-card__image">
-                                                    {% image search_promotion.page.specific.image fill-180x180-c100 loading="lazy" %}
-                                                </figure>
-                                            {% endif %}
-                                            <div class="listing-card__contents">
-                                                <h3 class="listing-card__title">{{ search_promotion.page.specific }}</h3>
-                                                <p class="listing-card__content-type">
-                                                    {% if search_promotion.page.specific.content_type.model == "blogpage" %}
-                                                        Blog Post
-                                                    {% elif search_promotion.page.specific.content_type.model == "locationpage" %}
-                                                        Location
-                                                    {% else %}
-                                                        Bread
-                                                    {% endif %}
-                                                </p>
-                                                <p class="listing-card__description">
-                                                    {% if search_promotion.page.specific.search_description %}{{ search_promotion.page.specific.search_description|richtext }}{% endif %}
-                                                </p>
-                                            </div>
-                                        </a>
-                                    {% else %}
-                                        <a class="listing-card__link" href="{{ search_promotion.external_link_url }}">
-                                            <figure class="listing-card__image">
-                                                {% picture search_promotion.page.specific.image format-{avif,webp,jpeg} fill-180x180-c100 loading="lazy" %}
-                                            </figure>
-                                            <div class="listing-card__contents">
-                                                <h3 class="listing-card__title">{{ search_promotion.external_link_text }}</h3>
-                                                <p class="listing-card__content-type">
-                                                    External link
-                                                </p>
-                                                <p class="listing-card__description">
-                                                    {% if search_promotion.description %}{{ search_promotion.description|richtext }}{% endif %}
-                                                </p>
-                                            </div>
-                                        </a>
-                                    {% endif %}
-                                </li>
-                            {% endfor %}
-                        </ul>
+<div class="container">
+    <div class="row">
+        <div class="col-md-8">
+            <h1>Search results</h1>
+            {% if search_results %}
+            <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{
+                search_results|length }} result{{ search_results|length|pluralize }} found.</p>
+            <ul class="search__results">
+                {% for result in search_results %}
+                <li class="listing-card">
+                    <a class="listing-card__link" href="{% pageurl result.specific %}">
+                        {% if result.specific.image %}
+                        <figure class="listing-card__image">
+                            {% picture result.specific.image format-{avif,webp,jpeg} fill-180x180-c100 loading="lazy" %}
+                        </figure>
+                        {% endif %}
+                        <div class="listing-card__contents">
+                            <h3 class="listing-card__title">{{ result.specific }}</h3>
+                            <p class="listing-card__content-type">
+                                {% if result.specific.content_type.model == "blogpage" %}
+                                Blog Post
+                                {% elif result.specific.content_type.model == "locationpage" %}
+                                Location
+                                {% else %}
+                                Bread
+                                {% endif %}
+                            </p>
+                            <p class="listing-card__description">
+                                {% if result.specific.search_description %}{{
+                                result.specific.search_description|richtext }}{% endif %}
+                            </p>
+                        </div>
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% elif search_query %}
+            {% get_search_promotions search_query as search_promotions %}
+            {% if search_promotions %}
+            <p class="search__introduction">You searched for “{{ search_query }}”, {{ search_promotions|length }}
+                result{{ search_promotions|length|pluralize }} found.</p>
+            <ul class="search__results">
+                {% for search_promotion in search_promotions %}
+                <li class="listing-card">
+                    {% if search_promotion.page %}
+                    <a class="listing-card__link" href="{% pageurl search_promotion.page.specific %}">
+                        {% if search_promotion.page.specific.image %}
+                        <figure class="listing-card__image">
+                            {% image search_promotion.page.specific.image fill-180x180-c100 loading="lazy" alt="" %}
+                        </figure>
+                        {% endif %}
+                        <div class="listing-card__contents">
+                            <h3 class="listing-card__title">{{ search_promotion.page.specific }}</h3>
+                            <p class="listing-card__content-type">
+                                {% if search_promotion.page.specific.content_type.model == "blogpage" %}
+                                Blog Post
+                                {% elif search_promotion.page.specific.content_type.model == "locationpage" %}
+                                Location
+                                {% else %}
+                                Bread
+                                {% endif %}
+                            </p>
+                            <p class="listing-card__description">
+                                {% if search_promotion.page.specific.search_description %}{{
+                                search_promotion.page.specific.search_description|richtext }}{% endif %}
+                            </p>
+                        </div>
+                    </a>
                     {% else %}
-                        <p class="search__introduction">No results found for “{{ search_query }}”.</p>
+                    <a class="listing-card__link" href="{{ search_promotion.external_link_url }}">
+                        <figure class="listing-card__image">
+                            {% picture search_promotion.page.specific.image format-{avif,webp,jpeg} fill-180x180-c100
+                            loading="lazy" %}
+                        </figure>
+                        <div class="listing-card__contents">
+                            <h3 class="listing-card__title">{{ search_promotion.external_link_text }}</h3>
+                            <p class="listing-card__content-type">
+                                External link
+                            </p>
+                            <p class="listing-card__description">
+                                {% if search_promotion.description %}{{ search_promotion.description|richtext }}{% endif
+                                %}
+                            </p>
+                        </div>
+                    </a>
                     {% endif %}
-                {% else %}
-                    <p class="search__introduction">You didn&apos;t search for anything!</p>
-                {% endif %}
-            </div>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="search__introduction">No results found for “{{ search_query }}”.</p>
+            {% endif %}
+            {% else %}
+            <p class="search__introduction">You didn&apos;t search for anything!</p>
+            {% endif %}
         </div>
     </div>
+</div>
 {% endblock content %}

--- a/bakerydemo/templates/tags/gallery.html
+++ b/bakerydemo/templates/tags/gallery.html
@@ -3,7 +3,7 @@
 {% for img in images %}
     <div class="picture-card">
         <figure class="picture-card__image">
-            {% picture img format-{avif,webp,jpeg} fill-{300x200-c75,645x480-c75} sizes="(max-width: 768px)150px,30vw" loading="lazy" %}
+            {% picture img format-{avif,webp,jpeg} fill-{300x200-c75,645x480-c75} sizes="(max-width: 768px)150px,30vw" loading="lazy" alt="{{ img.title }}" %}
             <div class="picture-card__contents">
                 <p class="picture-card__title">{{ img.title }}</p>
             </div>


### PR DESCRIPTION
While exploring the bakerydemo templates I noticed a few accessibility issues such as missing alt attributes and navigation labels.

This PR improves accessibility across several templates by:

- Adding alt attributes to images
- Adding aria labels where appropriate
- Improving semantic HTML usage

The changes are minimal and do not affect functionality.

Tested locally with Django runserver.