### PR TITLE
fix: improve accessibility of blog tag filters

### DIFF
--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -27,12 +27,14 @@
         {% endif %}
 
         {% if page.get_child_tags %}
-            <ul class="blog-tags">
-                <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
-                {% for tag in page.get_child_tags %}
-                    <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
-                {% endfor %}
-            </ul>
+            <nav aria-label="Blog tag filters">
+                <ul class="blog-tags">
+                    <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
+                    {% for tag in page.get_child_tags %}
+                        <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
+                    {% endfor %}
+                </ul>
+            </nav>
         {% endif %}
 
         <div class="blog-list">


### PR DESCRIPTION
Wrap blog tag filters in <nav> element with aria-label for better screen reader support, as requested in issue #636.