### PR TITLE
Fix gallery image titles by replacing placeholder names with descript…

### DIFF
--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -12141,7 +12141,7 @@
     "pk": 9,
     "fields": {
       "collection": 2,
-      "title": "Breads 1",
+      "title": "Sourdough Loaf",
       "file": "original_images/breads1.jpg",
       "description": "Brown bread with powdered sugar sprinkled on top",
       "width": 1080,
@@ -12161,7 +12161,7 @@
     "pk": 10,
     "fields": {
       "collection": 2,
-      "title": "Breads 2",
+      "title": "Artisan Bread Selection",
       "file": "original_images/breads2.jpg",
       "description": "High-angle close-up view of several loaves of artisan bread",
       "width": 1080,
@@ -12181,7 +12181,7 @@
     "pk": 11,
     "fields": {
       "collection": 2,
-      "title": "Breads 3",
+      "title": "Granola Bar",
       "file": "original_images/breads3.jpg",
       "description": "High-angle close-up view of a rectangular granola bar resting on a sheet of brown parchment paper, which is itself laid over a white linen cloth with thin red stripes",
       "width": 1080,
@@ -12201,7 +12201,7 @@
     "pk": 12,
     "fields": {
       "collection": 2,
-      "title": "Breads 4",
+      "title": "Rustic Loaf",
       "file": "original_images/breads4.jpg",
       "description": "A loaf of bread resting on a rustic wooden table, showcasing its golden crust and inviting texture",
       "width": 1080,
@@ -12221,7 +12221,7 @@
     "pk": 14,
     "fields": {
       "collection": 2,
-      "title": "Breads 5",
+      "title": "Freshly Baked Loaves",
       "file": "original_images/bread5.jpg",
       "description": "Two freshly baked loaves of bread resting on a wooden tray, showcasing their golden crusts and inviting aroma",
       "width": 800,
@@ -12241,7 +12241,7 @@
     "pk": 15,
     "fields": {
       "collection": 2,
-      "title": "Breads 6",
+      "title": "Cooling Rack Loaf",
       "file": "original_images/bread6.jpg",
       "description": "A freshly baked loaf of bread resting on a cooling rack, showcasing its golden crust and inviting texture",
       "width": 1008,


### PR DESCRIPTION
Fixes #640 

The `/gallery/ page `showed generic placeholder titles like “Breads 1”, “Breads 2” due to non-descriptive titles in bakerydemo/base/fixtures/bakerydemo.json.
This fix updates 6 image titles in the fixture file with meaningful descriptive names, improving gallery readability.

File Updated: `bakerydemo/base/fixtures/bakerydemo.json`