### PR TITLE
Fix #640: Update gallery image titles with descriptive names

### DIFF
--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -12141,7 +12141,7 @@
     "pk": 9,
     "fields": {
       "collection": 2,
-      "title": "Breads 1",
+      "title": "Dark Rye Sourdough",
       "file": "original_images/breads1.jpg",
       "description": "Brown bread with powdered sugar sprinkled on top",
       "width": 1080,
@@ -12161,7 +12161,7 @@
     "pk": 10,
     "fields": {
       "collection": 2,
-      "title": "Breads 2",
+      "title": "Sourdough Boules",
       "file": "original_images/breads2.jpg",
       "description": "High-angle close-up view of several loaves of artisan bread",
       "width": 1080,
@@ -12181,7 +12181,7 @@
     "pk": 11,
     "fields": {
       "collection": 2,
-      "title": "Breads 3",
+      "title": "Seeded Harvest Loaf",
       "file": "original_images/breads3.jpg",
       "description": "High-angle close-up view of a rectangular granola bar resting on a sheet of brown parchment paper, which is itself laid over a white linen cloth with thin red stripes",
       "width": 1080,
@@ -12201,7 +12201,7 @@
     "pk": 12,
     "fields": {
       "collection": 2,
-      "title": "Breads 4",
+      "title": "Rustic Country Loaf",
       "file": "original_images/breads4.jpg",
       "description": "A loaf of bread resting on a rustic wooden table, showcasing its golden crust and inviting texture",
       "width": 1080,
@@ -12221,7 +12221,7 @@
     "pk": 14,
     "fields": {
       "collection": 2,
-      "title": "Breads 5",
+      "title": "Golden Baguettes",
       "file": "original_images/bread5.jpg",
       "description": "Two freshly baked loaves of bread resting on a wooden tray, showcasing their golden crusts and inviting aroma",
       "width": 800,
@@ -12241,7 +12241,7 @@
     "pk": 15,
     "fields": {
       "collection": 2,
-      "title": "Breads 6",
+      "title": "Artisan Boule",
       "file": "original_images/bread6.jpg",
       "description": "A freshly baked loaf of bread resting on a cooling rack, showcasing its golden crust and inviting texture",
       "width": 1008,


### PR DESCRIPTION
Fixes #640 
## Changes Made
Updated image  titles in bakerydemo.json fixture from generic placeholder names ("Breads 1","Breads 2") to meaningful descriptive names:
- "Breads 1" → "Dark Rye Sourdough"
- "Breads 2" → "Sourdough Boules"
- "Breads 3" → "Seeded Harvest Loaf"
- "Breads 4" → "Rustic Country Loaf"
- "Breads 5" → "Golden Baguettes"
- "Breads 6" → "Artisan Boule"
##Root Cause
Images were  uploaded with placeholder titles.The gallery template displays {{img.title}} directly,so meaningless titles appeared on the gallery page at /gallery/
## Testing 
- Verified gallery page now shows descreptive image titles 
- Only 6 lines changed in fixture file

## AI usage
- Identifying appropriate descriptive names for 
  bread images based on visual appearance, since 
  image filenames were generic (breads1.jpg, 
  breads2.jpg etc.) with no descriptive information
- Troubleshooting Windows-specific UTF-8 encoding 
  issues during dumpdata (CRLF/LF line ending 
  conflicts, BOM characters)
