### PR TITLE
Add required_on_save=True to HomePage hero_text field

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -377,7 +377,7 @@ class HomePage(Page):
         MultiFieldPanel(
             [
                 FieldPanel("image"),
-                FieldPanel("hero_text"),
+                FieldPanel("hero_text", required_on_save=True),
                 MultiFieldPanel(
                     [
                         FieldPanel("hero_cta"),


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #538 

### Description

This PR adds `required_on_save=True` to the `hero_text` field on the `HomePage` 
  to showcase the new deferred validation feature from Wagtail 7.0 release notes.

### AI usage

None
