### PR TITLE
Fixed navbar links reflowing into a column at 1150px

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -722,7 +722,7 @@ caption {
   padding: 0;
 }
 
-@media (max-width: 1150px) {
+@media (max-width: 1149px) {
   .collapse.in {
     flex-basis: 100%;
     overflow-y: hidden;
@@ -760,7 +760,7 @@ caption {
 }
 
 /* Mobile menu styling */
-@media (max-width: 1150px) {
+@media (max-width: 1149px) {
   .nav-pills > .presentation {
     float: none;
     width: 100%;


### PR DESCRIPTION
Fixes #629

### Description

There was a reflow issue on the homepage header navbar where the navlinks would align themselves into a single column at only 1150px breakpoint which is clearly not the intended UI. The problem was caused by a clashing of `min-width:1150px` and `max-width:1150px` breakpoint rules in the "bakerydemo/static/css/main.css" file, I fixed this by changing `max-width:1150px` into `max-width:1149px` in all areas where it was used.


### AI usage

No AI was used in this PR or code
