### PR TITLE
Strip whitespace from search query input

### DIFF
--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -11,7 +11,7 @@ from bakerydemo.locations.models import LocationPage
 
 def search(request):
     # Search
-    search_query = request.GET.get("q", None)
+    search_query = request.GET.get("q", "").strip()
     if search_query:
         if "elasticsearch" in settings.WAGTAILSEARCH_BACKENDS["default"]["BACKEND"]:
             # In production, use ElasticSearch and a simplified search query, per


### PR DESCRIPTION
This PR improves handling of the search query input in `search/views.py`.

Previously, the query string was retrieved using:

`request.GET.get("q", None)`

This could allow leading or trailing whitespace in the search query, which may lead to inconsistent search behavior.

The change updates the code to:

`request.GET.get("q", "").strip()`

This removes unnecessary whitespace before processing the search query, ensuring cleaner input and more consistent results.

AI usage:
I used AI assistance while exploring the repository and understanding the search implementation, but reviewed and verified the final code before submitting this PR.
