### PR TITLE
fix: replace placeholder help text in HomePage admin panels

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -382,7 +382,7 @@ class HomePage(Page):
             ],
             heading="Hero section",
         ),
-        HelpPanel("This is a help panel"),
+        HelpPanel("Use the sections below to configure the homepage hero image, promotional content, and featured site sections."),
         MultiFieldPanel(
             [
                 FieldPanel("lead_image"),
@@ -390,7 +390,7 @@ class HomePage(Page):
                 FieldPanel("lead_text"),
             ],
             heading="Promo section",
-            help_text="This is just a help text",
+            help_text="Configure the lead image, title and text shown in the promotional section.",
         ),
         FieldPanel("body"),
         MultiFieldPanel(

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -382,7 +382,10 @@ class HomePage(Page):
             ],
             heading="Hero section",
         ),
-        HelpPanel("Use the sections below to configure the homepage hero image, promotional content, and featured site sections."),
+        HelpPanel(
+            "Use the sections below to configure "
+            "the homepage hero, promo, and featured sections."
+        ),
         MultiFieldPanel(
             [
                 FieldPanel("lead_image"),
@@ -390,7 +393,7 @@ class HomePage(Page):
                 FieldPanel("lead_text"),
             ],
             heading="Promo section",
-            help_text="Configure the lead image, title and text shown in the promotional section.",
+            help_text="Configure the lead image, title and text for the promotional section.",
         ),
         FieldPanel("body"),
         MultiFieldPanel(


### PR DESCRIPTION

Fixes #655 

### Description
The HomePage admin editing interface contained two placeholder texts that provided no useful guidance to editors:

1. `HelpPanel("This is a help panel")` — sitting between the Hero section and Promo section with  no meaningful content

2. `help_text="This is just a help text"` — shown  as a blue info box inside the Promo section

These are clearly leftover placeholder texts that were never replaced. For a demo site used by thousands of developers to evaluate Wagtail, this makes the admin interface look unfinished.

This PR replaces both with meaningful descriptions:
- HelpPanel now explains the purpose of the homepage sections below it
- Promo section help_text now explains what  the lead image, title and text fields are for


### AI usage
None
