### PR TITLE
Feature: Add DRY pagination to Blog and Location Index pages

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -36,6 +36,8 @@ from wagtail.models import (
 )
 from wagtail.search import index
 
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+
 from .blocks import BaseStreamBlock
 
 # Allow filtering by collection
@@ -641,3 +643,23 @@ class UserApprovalTask(Task):
     @classmethod
     def get_description(cls):
         return _("Only a specific user can approve this task")
+
+
+class PaginatedIndexMixin:
+    """
+    A mixin to add standard pagination to index pages.
+    """
+
+    items_per_page = 12
+
+    def paginate(self, request, queryset):
+        page = request.GET.get("page")
+        paginator = Paginator(queryset, getattr(self, "items_per_page", 12))
+        try:
+            pages = paginator.page(page)
+        except PageNotAnInteger:
+            pages = paginator.page(1)
+        except EmptyPage:
+            pages = paginator.page(paginator.num_pages)
+        return pages
+

--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -12,6 +12,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
+from bakerydemo.base.models import PaginatedIndexMixin
 
 
 class BlogPersonRelationship(Orderable, models.Model):
@@ -142,7 +143,7 @@ class BlogPage(Page):
     subpage_types = []
 
 
-class BlogIndexPage(RoutablePageMixin, Page):
+class BlogIndexPage(PaginatedIndexMixin, RoutablePageMixin, Page):
     """
     Index page for blogs.
     We need to alter the page model's context to return the child page objects,
@@ -185,9 +186,8 @@ class BlogIndexPage(RoutablePageMixin, Page):
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
         context = super(BlogIndexPage, self).get_context(request)
-        context["posts"] = (
-            BlogPage.objects.descendant_of(self).live().order_by("-date_published")
-        )
+        posts = BlogPage.objects.descendant_of(self).live().order_by("-date_published")
+        context["posts"] = self.paginate(request, posts)
         return context
 
     # This defines a Custom view that utilizes Tags. This view will return all
@@ -206,6 +206,7 @@ class BlogIndexPage(RoutablePageMixin, Page):
             return redirect(self.url)
 
         posts = self.get_posts(tag=tag)
+        posts = self.paginate(request, posts)
         context = {"self": self, "tag": tag, "posts": posts}
         return render(request, "blog/blog_index_page.html", context)
 

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.contrib.contenttypes.fields import GenericRelation
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from modelcluster.fields import ParentalManyToManyField
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
@@ -10,6 +9,7 @@ from wagtail.models import DraftStateMixin, Orderable, Page, RevisionMixin
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
+from bakerydemo.base.models import PaginatedIndexMixin
 
 
 class Country(models.Model):
@@ -189,7 +189,7 @@ class BreadPage(Page):
         return self.ingredients.order_by("sort_order", "name")
 
 
-class BreadsIndexPage(Page):
+class BreadsIndexPage(PaginatedIndexMixin, Page):
     """
     Index page for breads.
 
@@ -233,20 +233,6 @@ class BreadsIndexPage(Page):
     # content
     def children(self):
         return self.get_children().specific().live()
-
-    # Pagination for the index page. We use the `django.core.paginator` as any
-    # standard Django app would, but the difference here being we have it as a
-    # method on the model rather than within a view function
-    def paginate(self, request, *args):
-        page = request.GET.get("page")
-        paginator = Paginator(self.get_breads(), 12)
-        try:
-            pages = paginator.page(page)
-        except PageNotAnInteger:
-            pages = paginator.page(1)
-        except EmptyPage:
-            pages = paginator.page(paginator.num_pages)
-        return pages
 
     # Returns the above to the get_context method that is used to populate the
     # template

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -11,6 +11,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
+from bakerydemo.base.models import PaginatedIndexMixin
 from bakerydemo.locations.choices import DAY_CHOICES
 
 
@@ -71,7 +72,7 @@ class LocationOperatingHours(Orderable, OperatingHours):
     )
 
 
-class LocationsIndexPage(Page):
+class LocationsIndexPage(PaginatedIndexMixin, Page):
     """
     A Page model that creates an index page (a listview)
     """
@@ -100,9 +101,8 @@ class LocationsIndexPage(Page):
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
         context = super(LocationsIndexPage, self).get_context(request)
-        context["locations"] = (
-            LocationPage.objects.descendant_of(self).live().order_by("title")
-        )
+        locations = LocationPage.objects.descendant_of(self).live().order_by("title")
+        context["locations"] = self.paginate(request, locations)
         return context
 
     content_panels = Page.content_panels + [

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -2,51 +2,60 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
 
 {% if tag %}
-    {% block title %}
-        {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
-    {% endblock %}
+{% block title %}
+{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
+{% endblock %}
 
-    {% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
+{% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
 {% endif %}
 
 {% block content %}
-    {% if not tag %}
-        {% include "base/include/header-index.html" %}
-    {% endif %}
+{% if not tag %}
+{% include "base/include/header-index.html" %}
+{% endif %}
 
-    <div class="container">
-        {% if tag %}
-            <div class="row">
-                <div class="col-md-12">
-                    <h1 class="index-header__title">Blog</h1>
-                </div>
-                <div class="col-md-12">
-                    <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag }}</span>.</p>
-                </div>
-            </div>
-        {% endif %}
-
-        {% if page.get_child_tags %}
-            <ul class="blog-tags">
-                <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
-                {% for tag in page.get_child_tags %}
-                    <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-
-        <div class="blog-list">
-            {% if posts %}
-                {% wagtailcache 500 posts tag %}
-                    {% for blog in posts %}
-                        {% include "includes/card/blog-listing-card.html" %}
-                    {% endfor %}
-                {% endwagtailcache %}
-            {% else %}
-                <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
-                </div>
-            {% endif %}
+<div class="container">
+    {% if tag %}
+    <div class="row">
+        <div class="col-md-12">
+            <h1 class="index-header__title">Blog</h1>
+        </div>
+        <div class="col-md-12">
+            <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span
+                    class="blog-tags__tag">{{ tag }}</span>.</p>
         </div>
     </div>
+    {% endif %}
+
+    {% if page.get_child_tags %}
+    <ul class="blog-tags">
+        <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
+        {% for tag in page.get_child_tags %}
+        <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    <div class="blog-list">
+        {% if posts %}
+        {% wagtailcache 500 posts tag %}
+        {% for blog in posts %}
+        {% include "includes/card/blog-listing-card.html" %}
+        {% endfor %}
+        {% endwagtailcache %}
+        {% else %}
+        <div class="col-md-12">
+            <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if posts.paginator.num_pages > 1 %}
+    <div class="row mt-5">
+        <div class="col-sm-12">
+            {% include "includes/pagination.html" with subpages=posts %}
+        </div>
+    </div>
+    {% endif %}
+</div>
 {% endblock content %}

--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -2,25 +2,25 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
-    {% include "base/include/header-index.html" %}
+{% include "base/include/header-index.html" %}
 
-    <div class="container">
-        <ul class="bread-list">
-            {% for bread in breads %}
-                <li>
-                    {% include "includes/card/listing-card.html" with page=bread h2=True %}
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+<div class="container">
+    <ul class="bread-list">
+        {% for bread in breads %}
+        <li>
+            {% include "includes/card/listing-card.html" with page=bread h2=True %}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
 
-    {% if breads.paginator.count > 12 %}
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-12">
-                    {% include "includes/pagination.html" with subpages=breads %}
-                </div>
-            </div>
+{% if breads.paginator.num_pages > 1 %}
+<div class="container">
+    <div class="row">
+        <div class="col-sm-12">
+            {% include "includes/pagination.html" with subpages=breads %}
         </div>
-    {% endif %}
+    </div>
+</div>
+{% endif %}
 {% endblock content %}

--- a/bakerydemo/templates/locations/locations_index_page.html
+++ b/bakerydemo/templates/locations/locations_index_page.html
@@ -3,13 +3,21 @@
 
 {% block content %}
 
-    {% include "base/include/header-index.html" %}
+{% include "base/include/header-index.html" %}
 
-    <div class="container">
-        <div class="location-list-page">
-            {% for location in locations %}
-                {% include "includes/card/picture-card.html" with page=location portrait=False %}
-            {% endfor %}
+<div class="container">
+    <div class="location-list-page">
+        {% for location in locations %}
+        {% include "includes/card/picture-card.html" with page=location portrait=False %}
+        {% endfor %}
+    </div>
+
+    {% if locations.paginator.num_pages > 1 %}
+    <div class="row mt-5">
+        <div class="col-sm-12">
+            {% include "includes/pagination.html" with subpages=locations %}
         </div>
     </div>
+    {% endif %}
+</div>
 {% endblock content %}


### PR DESCRIPTION
This PR addresses the GSoC requirement of supporting "Capabilities to test Wagtail with large amounts of content". 
Currently, [BlogIndexPage] and [LocationsIndexPage] load all child pages without pagination. This PR introduces a DRY [PaginatedIndexMixin] to standardise and fix pagination across [BlogIndexPage], [LocationsIndexPage], and [BreadsIndexPage], ensuring the demo scales cleanly.
### Related Issues
Resolves #661