### PR TITLE
Fix hardcoded /breads URL with {% pageurl %} in home_page.html

### DIFF
--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -36,8 +36,8 @@
                                 </li>
                             {% endfor %}
                         </ul>
-                        <a class="featured-cards__link" href="/breads">
-                            <span>View more of our breads</span>
+                        <a class="featured-cards__link" href="{% pageurl page.featured_section_1 %}">
+                              <span>View more of {{ page.featured_section_1_title|lower }}</span>
                             {% include "includes/chevron-icon.html" with class="featured-cards__chevron-icon" %}
                         </a>
                     {% endif %}


### PR DESCRIPTION
Fixes #656

### Description
In `home_page.html` line 39, the "View more" link used a 
hardcoded `href="/breads"`. This silently breaks with a 404 
error if a Wagtail admin changes the page slug in the CMS.

Also, the link text "View more of our breads" was hardcoded,
meaning it would not update if `featured_section_1` pointed 
to a different section.

**Changes made:**
- Replaced hardcoded `href="/breads"` with `{% pageurl page.featured_section_1 %}`
- Replaced static link text with `{{ page.featured_section_1_title|lower }}`

This makes the URL and link text fully dynamic, consistent 
with how every other internal link in the project is handled.

### AI usage
None
