### PR TITLE
Fix hardcoded pagination condition in breads and people index templates

### DIFF
--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -14,7 +14,7 @@
         </ul>
     </div>
 
-    {% if breads.paginator.count > 12 %}
+    {% if breads.has_other_pages %}
         <div class="container">
             <div class="row">
                 <div class="col-sm-12">

--- a/bakerydemo/templates/people/people_index_page.html
+++ b/bakerydemo/templates/people/people_index_page.html
@@ -14,7 +14,7 @@
         </ul>
     </div>
 
-    {% if people.paginator.count > 12 %}
+    {% if people.has_other_pages %}
         <div class="container">
             <div class="row">
                 <div class="col-sm-12">


### PR DESCRIPTION
Fixes #658.

## Changes

Replace hardcoded `{% if breads.paginator.count > 12 %}` with `{% if breads.has_other_pages %}` in `breads_index_page.html`, and the same fix in `people_index_page.html` which had the identical issue.

This makes the pagination condition independent of page size and aligns with Django best practices.

## AI usage

I used Claude (claude.ai) to help identify the fix and locate the same issue in other templates.