### PR TITLE
Fix missing RecipePage in search and timezone-naive is_open()

### DIFF
--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from django.utils import timezone
 
 from django.conf import settings
 from django.core.validators import RegexValidator
@@ -182,9 +182,9 @@ class LocationPage(Page):
         hours = self.hours_of_operation.all()
         return hours
 
-    # Determines if the location is currently open. It is timezone naive
+    # Determines if the location is currently open.
     def is_open(self):
-        now = datetime.now()
+        now = timezone.localtime()
         current_time = now.time()
         current_day = now.strftime("%a").upper()
         try:

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -1,8 +1,7 @@
-from django.utils import timezone
-
 from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
+from django.utils import timezone
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtail.api import APIField

--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -35,7 +35,9 @@ def search(request):
             recipe_results = RecipePage.objects.live().search(search_query)
             recipe_page_ids = [p.page_ptr.id for p in recipe_results]
 
-            page_ids = blog_page_ids + bread_page_ids + location_result_ids + recipe_page_ids
+            page_ids = (
+                blog_page_ids + bread_page_ids + location_result_ids + recipe_page_ids
+            )
             search_results = Page.objects.live().filter(id__in=page_ids)
 
         query = Query.get(search_query)

--- a/bakerydemo/search/views.py
+++ b/bakerydemo/search/views.py
@@ -7,6 +7,7 @@ from wagtail.models import Page
 from bakerydemo.blog.models import BlogPage
 from bakerydemo.breads.models import BreadPage
 from bakerydemo.locations.models import LocationPage
+from bakerydemo.recipes.models import RecipePage
 
 
 def search(request):
@@ -31,7 +32,10 @@ def search(request):
             location_results = LocationPage.objects.live().search(search_query)
             location_result_ids = [p.page_ptr.id for p in location_results]
 
-            page_ids = blog_page_ids + bread_page_ids + location_result_ids
+            recipe_results = RecipePage.objects.live().search(search_query)
+            recipe_page_ids = [p.page_ptr.id for p in recipe_results]
+
+            page_ids = blog_page_ids + bread_page_ids + location_result_ids + recipe_page_ids
             search_results = Page.objects.live().filter(id__in=page_ids)
 
         query = Query.get(search_query)

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -30,6 +30,8 @@
                                                 Blog Post
                                             {% elif result.specific.content_type.model == "locationpage" %}
                                                 Location
+                                            {% elif result.specific.content_type.model == "recipepage" %}
+                                                Recipe
                                             {% else %}
                                                 Bread
                                             {% endif %}


### PR DESCRIPTION
- Add RecipePage to native DB search fallback in search/views.py
- Replace datetime.now() with timezone.localtime() in LocationPage.is_open()

Fixes #...

### Description

- `search/views.py`: `RecipePage` was added to the project but never included in the native DB search fallback, making recipe pages invisible to search queries. Added it alongside `BlogPage`, `BreadPage`, and `LocationPage`.

- `locations/models.py`: `is_open()` was using `datetime.now()` which is timezone-naive and ignores Django's `TIME_ZONE` setting. Replaced with `timezone.localtime()` to return the correct local time.

### AI usage

Used Amazon Q Developer (AI assistant in IDE) to identify the issues and suggest fixes. Manually reviewed and verified both changes against the existing codebase before submitting.