### PR TITLE
Add custom API endpoint for people

### DIFF
--- a/bakerydemo/base/api.py
+++ b/bakerydemo/base/api.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+
+from bakerydemo.base.models import Person
+
+
+class PersonImageSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    title = serializers.CharField(read_only=True)
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, image):
+        request = self.context.get("request")
+        url = image.file.url
+        return request.build_absolute_uri(url) if request else url
+
+
+class PersonSerializer(serializers.ModelSerializer):
+    image = PersonImageSerializer(read_only=True)
+
+    class Meta:
+        model = Person
+        fields = ("id", "first_name", "last_name", "job_title", "image")
+
+
+class PersonQuerysetMixin:
+    serializer_class = PersonSerializer
+
+    def get_queryset(self):
+        return Person.objects.filter(live=True).select_related("image").order_by(
+            "last_name", "first_name"
+        )
+
+
+class PersonListAPIView(PersonQuerysetMixin, ListAPIView):
+    pass
+
+
+class PersonDetailAPIView(PersonQuerysetMixin, RetrieveAPIView):
+    pass

--- a/bakerydemo/base/tests/test_person_api.py
+++ b/bakerydemo/base/tests/test_person_api.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from bakerydemo.base.models import Person
+
+
+class PersonAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.live_person = Person.objects.create(
+            first_name="Ada",
+            last_name="Lovelace",
+            job_title="Programmer",
+        )
+        cls.draft_person = Person.objects.create(
+            first_name="Grace",
+            last_name="Hopper",
+            job_title="Computer Scientist",
+            live=False,
+        )
+
+    def test_people_list_returns_live_people(self):
+        response = self.client.get(reverse("people_api"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "id": self.live_person.id,
+                    "first_name": "Ada",
+                    "last_name": "Lovelace",
+                    "job_title": "Programmer",
+                    "image": None,
+                }
+            ],
+        )
+
+    def test_person_detail_returns_live_person(self):
+        response = self.client.get(
+            reverse("person_api_detail", kwargs={"pk": self.live_person.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": self.live_person.id,
+                "first_name": "Ada",
+                "last_name": "Lovelace",
+                "job_title": "Programmer",
+                "image": None,
+            },
+        )
+
+    def test_person_detail_hides_draft_people(self):
+        response = self.client.get(
+            reverse("person_api_detail", kwargs={"pk": self.draft_person.pk})
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -8,6 +8,7 @@ from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images.views.serve import ServeView
 
+from bakerydemo.base.api import PersonDetailAPIView, PersonListAPIView
 from bakerydemo.search import views as search_views
 
 from .api import api_router
@@ -24,6 +25,8 @@ urlpatterns = [
     path("search/", search_views.search, name="search"),
     path("sitemap.xml", sitemap),
     path("api/v2/", api_router.urls),
+    path("api/people/", PersonListAPIView.as_view(), name="people_api"),
+    path("api/people/<int:pk>/", PersonDetailAPIView.as_view(), name="person_api_detail"),
     path("__debug__/", include(debug_toolbar.urls)),
 ]
 


### PR DESCRIPTION
Closes #719

## Summary

This PR adds a custom read-only API endpoint for the `Person` snippet model to demonstrate a non-page API example alongside the built-in Wagtail API endpoints.

## Changes

- added `GET /api/people/` to list live `Person` records
- added `GET /api/people/<id>/` to retrieve a single live `Person`
- returned `id`, `first_name`, `last_name`, `job_title`, and nested `image` data
- added tests for list and detail responses, including verifying that draft `Person` records are not exposed

## Example Responses

### `GET /api/people/`

```json
[
  {
    "id": 2,
    "first_name": "Olivia",
    "last_name": "Ava",
    "job_title": "Director",
    "image": {
      "id": 52,
      "title": "Olivia Ava",
      "url": "http://127.0.0.1:8000/media/original_images/olivia_ava.jpeg"
    }
  }
]
```

### `GET /api/people/1/`

```json
{
  "id": 1,
  "first_name": "Roberta",
  "last_name": "Johnson",
  "job_title": "Editorial Manager",
  "image": {
    "id": 8,
    "title": "Roberta Johnson",
    "url": "http://127.0.0.1:8000/media/original_images/roberta_johnson.jpeg"
  }
}
```

## Verification

I verified this locally by running:

```bash
./manage.py check --settings=bakerydemo.settings.test
./manage.py makemigrations --check --noinput --settings=bakerydemo.settings.test
./manage.py test bakerydemo.base.tests.test_person_api --settings=bakerydemo.settings.test
python -m ruff check bakerydemo/base/api.py bakerydemo/base/tests/test_person_api.py bakerydemo/urls.py
```

I also manually checked:
- `GET /api/people/`
- `GET /api/people/<id>/`
## AI Disclosure

I used AI assistance to help draft the implementation and tests. I reviewed the code and verified the behavior locally with the checks and tests listed above.