### PR TITLE
feat: add Person API endpoint

### DIFF
--- a/bakerydemo/api.py
+++ b/bakerydemo/api.py
@@ -4,6 +4,8 @@ from wagtail.contrib.redirects.api import RedirectsAPIViewSet
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
 from wagtail.images.api.v2.views import ImagesAPIViewSet
 
+from bakerydemo.base.api import PersonApiViewSet
+
 # Create the router. "wagtailapi" is the URL namespace
 api_router = WagtailAPIRouter("wagtailapi")
 
@@ -15,3 +17,4 @@ api_router.register_endpoint("pages", PagesAPIViewSet)
 api_router.register_endpoint("images", ImagesAPIViewSet)
 api_router.register_endpoint("documents", DocumentsAPIViewSet)
 api_router.register_endpoint("redirects", RedirectsAPIViewSet)
+api_router.register_endpoint("persons", PersonApiViewSet)

--- a/bakerydemo/base/api.py
+++ b/bakerydemo/base/api.py
@@ -1,0 +1,8 @@
+from wagtail.api.v2.views import BaseAPIViewSet
+
+from .models import Person
+
+
+class PersonApiViewSet(BaseAPIViewSet):
+    model = Person
+    name = "persons"


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #719 


### Description
Currently the project's API only demonstrates Wagtail's built-in API endpoint. This PR adds a custom endpoint for the Person model at `/api/v2/persons/ `as a demo of how to expose a non-page model through Wagtail's API.
Changes

- Created `bakerydemo/base/api.py` with `PersonAPIViewSet`
- Registered the endpoint in `bakerydemo/api.py
`
<!-- Please describe the problem you're fixing. -->
### Testing
Tested the endpoint manually by running the development server and visiting the following URLs:

`GET /api/v2/persons/`

<img width="571" height="804" alt="Screenshot From 2026-04-10 13-19-18" src="https://github.com/user-attachments/assets/b33a02fa-be27-4a57-b3a5-802930a50cd9" />

`GET /api/v2/persons/1 `

<img width="559" height="531" alt="Screenshot From 2026-04-10 13-18-59" src="https://github.com/user-attachments/assets/7521c8e5-334d-4c27-aa90-3e9cc37d650a" />


### AI usage
Used claude.ai in explaining [`wagtial/view.py`](https://github.com/wagtail/wagtail/blob/aac76d21a32352c7fe84c596e9306c8724c699a2/wagtail/api/v2/views.py)
<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
