### PR TITLE
Fix Person.search_fields missing SearchField for job_title

### DIFF
--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -113,6 +113,7 @@ class Person(
         index.SearchField("first_name"),
         index.SearchField("last_name"),
         index.FilterField("job_title"),
+        index.SearchField("job_title"),
         index.AutocompleteField("first_name"),
         index.AutocompleteField("last_name"),
     ]


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #723 

### Description

<!-- Please describe the problem you're fixing. -->
The `Person` model in `bakerydemo/base/models.py` defined `job_title` as an `index.FilterField` but not as an `index.SearchField`. This caused full-text search (q=) in the Wagtail admin People snippet to return no results when searching by job title even though the filter worked correctly.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude (claude.ai) was used to help with git commands only. The bug was independently discovered and the fix was written manually.