### PR TITLE
Add empty state to locations index page

### DIFF
--- a/bakerydemo/templates/locations/locations_index_page.html
+++ b/bakerydemo/templates/locations/locations_index_page.html
@@ -7,9 +7,15 @@
 
     <div class="container">
         <div class="location-list-page">
-            {% for location in locations %}
-                {% include "includes/card/picture-card.html" with page=location portrait=False %}
-            {% endfor %}
+            {% if locations %}
+                {% for location in locations %}
+                    {% include "includes/card/picture-card.html" with page=location portrait=False %}
+                {% endfor %}
+            {% else %}
+                <div class="col-md-12">
+                    <p>No locations available right now.</p>
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
Fix #726 

This adds a simple empty state to the locations index page.

Right now, when there are no locations, the page doesn’t show any feedback. This change adds a small fallback message so users aren’t left with an empty page.

This also keeps the behavior consistent with other listing pages in the demo.