### PR TITLE
feat: use faker for realistic people data in create_random_data

### DIFF
--- a/bakerydemo/base/management/commands/create_random_data.py
+++ b/bakerydemo/base/management/commands/create_random_data.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import lorem_ipsum, timezone
 from django.utils.text import slugify
+from faker import Faker
 from wagtail.images.models import Image
 from wagtail.rich_text import RichText
 from willow.image import Image as WillowImage
@@ -139,11 +140,24 @@ class Command(BaseCommand):
             BreadType.objects.create(title=self.make_title())
 
         self.stdout.write("Creating people...")
+        fake = Faker()
+        BAKERY_JOB_TITLES = [
+            "Head Baker",
+            "Pastry Chef",
+            "Sous Chef",
+            "Bread Artisan",
+            "Bakery Manager",
+            "Cake Decorator",
+            "Dough Specialist",
+            "Confectionery Chef",
+            "Bakery Assistant",
+            "Production Baker",
+        ]
         for _ in range(snippet_count):
             Person.objects.create(
-                first_name=lorem_ipsum.words(1, common=False),
-                last_name=lorem_ipsum.words(1, common=False),
-                job_title=lorem_ipsum.words(1, common=False),
+                first_name=fake.first_name(),
+                last_name=fake.last_name(),
+                job_title=random.choice(BAKERY_JOB_TITLES),
                 image=self.get_random_model(Image),
             )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ django-debug-toolbar>=4.2,<5
 django-extensions>=4.1,<5
 django-csp>=3.8,<4
 dj-database-url>=3.1.0,<4
+faker


### PR DESCRIPTION

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...
Related to https://github.com/wagtail/bakerydemo/issues/676
### Description

<!-- Please describe the problem you're fixing. -->
This PR improves the create_random_data management command by replacing "lorem_ipsum" with "faker" for generating "Person" objects, and introduces a selected list of bakery-specific job titles.

Previously, people were created with "lorem_ipsum.words(1)" for names and job titles, producing unrealistic output like "lorem Baker" or "ipsum Manager". This change generates realistic first and last names via faker, paired with domain-appropriate job titles such as "Head Baker", "Pastry Chef", and "Sous Chef".

### Changes
1) Added "faker" to "requirements/base.txt"
2) Replaced "lorem_ipsum" usage in the Person creation loop with "fake.first_name()" and "fake.last_name()"
3) Introduced "BAKERY_JOB_TITLES", a selected list of bakery-specific roles replacing random lorem words for "job_title".

### Testing
Tested locally by running:
python manage.py create_random_data 5 5 0
Verified via Django shell as people are getting created with realistic names and bakery job titles.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Used Claude (claude.ai) for debugging help. The idea to combine faker with a selected list of bakery job titles came from reading the https://github.com/wagtail/bakerydemo/issues/676 discussion.