### PR TITLE
Fix BlogPage.search_fields missing SearchField for introduction and subtitle

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -92,6 +92,8 @@ class BlogPage(Page):
     ]
 
     search_fields = Page.search_fields + [
+        index.SearchField("introduction"),
+        index.SearchField("subtitle"),
         index.SearchField("body"),
     ]
 


### PR DESCRIPTION

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #729 

### Description
BlogPage.search_fields was only indexing "title" and "body", leaving "introduction" and "subtitle" unsearchable.

Searching for words that exist exclusively in a blog post's "introduction" returned no results — verified locally with 
"?q=prolonged" and "?q=normally" against the "Bread and Circuses" page.

This fix adds both fields, consistent with the approach taken in #704 (BreadPage) and #724 (Person).

### AI usage
I used AI assistance (Claude) to help investigate and diagnose this bug and specifically to trace the search_fields audit, verify words exclusively in introduction via shell, and confirm the UI behaviour. The fix itself is a 2-line change I understood, verified, and applied independently.
