### PR TITLE
Fix N+1 query in BlogIndexPage.get_child_tags()

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -13,7 +13,6 @@ from wagtail.search import index
 
 from bakerydemo.base.blocks import BaseStreamBlock
 
-
 class BlogPersonRelationship(Orderable, models.Model):
     """
     This defines the relationship between the `Person` within the `base`
@@ -225,9 +224,11 @@ class BlogIndexPage(RoutablePageMixin, Page):
 
     # Returns the list of Tags for all child posts of this BlogPage.
     def get_child_tags(self):
-        tags = []
-        for post in self.get_posts():
-            # Not tags.append() because we don't want a list of lists
-            tags += post.get_tags
-        tags = sorted(set(tags))
-        return tags
+        posts = self.get_posts()
+        tags = (
+            Tag.objects.filter(
+                blog_blogpagetag_items__content_object__in=posts,
+            )
+            .distinct()
+        )
+        return sorted(tags, key=lambda t: t.name)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...732

### Description

#### Problem
"get_child_tags()" iterated over every blog post and called "post.get_tags", firing 2 DB queries per post (taggit query + page query).

With current fixture data (16 posts) = 35 queries just to render tag nav.
At GSoC #566 redesign scale target of 50 posts = ~150 queries per page load.

#### Root cause
The original loop:
```python
for post in self.get_posts():
    tags += post.get_tags  # 2 DB queries per post
```
<!-- Please describe the problem you're fixing. -->

#### Fix 
Replace loop with single JOIN query via "BlogPageTag"'s reverse accessor "blog_blogpagetag_items", fetching all tags across all posts in one shot.

#### Query count
| Scenario | Before | After |
|---|---|---|
| 16 posts (current fixture) | 35 | 4 |
| 50 posts (GSoC #566 target) | ~150 | 4 |

#### Verified locally
Tested via Django shell -> "connection.queries" count confirmed.
Tags returned correctly: "[baking, dessert, fermentation, fire, grain, sandwich, soda, yeast]"

### AI usage
Used Claude to help identify the correct reverse accessor name ("blog_blogpagetag_items") and iterate on the query approach. All code was verified locally via Django shell before committing and also confirmed query count drop and correct tag output.
