### PR TITLE
Fix TypeError in BlogIndexPage.get_child_tags sorting (#735)

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -229,5 +229,8 @@ class BlogIndexPage(RoutablePageMixin, Page):
         for post in self.get_posts():
             # Not tags.append() because we don't want a list of lists
             tags += post.get_tags
-        tags = sorted(set(tags))
+        # Tag instances do not implement __lt__, so `sorted(set(tags))` with
+        # no key raises TypeError as soon as any blog post has tags (#735).
+        # Deduplicate by slug, then sort by display name.
+        tags = sorted({tag.slug: tag for tag in tags}.values(), key=lambda t: t.name)
         return tags


### PR DESCRIPTION
Closes #735.

`BlogIndexPage.get_child_tags` called `sorted(set(tags))` on `taggit.models.Tag` instances. Tag (Django model) doesn't implement `__lt__`, so any blog post with tags makes the blog index page crash with `TypeError: '<' not supported between instances of 'Tag' and 'Tag'`.

Switches to slug-based dedup (avoiding the assumption that `set(tags)` hashes by identity / slug consistently) and sorts by `name` for stable user-facing alphabetical order.

Verified the pre-fix raises `TypeError` and the post-fix returns the expected alphabetical list on a minimal Tag-shape reproducer.
