### PR TITLE
Replace deprecated AccessibilityItem with ContentCheckerItem

### DIFF
--- a/bakerydemo/base/wagtail_hooks.py
+++ b/bakerydemo/base/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from wagtail import hooks
 from wagtail.admin.filters import WagtailFilterSet
-from wagtail.admin.userbar import AccessibilityItem
+from wagtail.admin.userbar import ContentCheckerItem
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 
@@ -32,14 +32,14 @@ def register_icons(icons):
     ]
 
 
-class CustomAccessibilityItem(AccessibilityItem):
+class CustomAccessibilityItem(ContentCheckerItem):
     axe_run_only = None
 
 
 @hooks.register("construct_wagtail_userbar")
 def replace_userbar_accessibility_item(request, items, page):
     items[:] = [
-        CustomAccessibilityItem() if isinstance(item, AccessibilityItem) else item
+        CustomAccessibilityItem() if isinstance(item, ContentCheckerItem) else item
         for item in items
     ]
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


### Description

<!-- Please describe the problem you're fixing. -->


This PR updates `bakerydemo/base/wagtail_hooks.py` to replace the deprecated
`AccessibilityItem` userbar item with `ContentCheckerItem`.

The current implementation raises a deprecation warning on Wagtail 8.0 alpha:

> RemovedInWagtail90Warning: The userbar item 'AccessibilityItem' is deprecated. Please use 'ContentCheckerItem' instead.

This change keeps the existing behavior the same while removing that warning.


**Before:**
<img width="1049" height="100" alt="Screenshot 2026-05-27 at 12 32 04 AM" src="https://github.com/user-attachments/assets/2ea2cbb6-686e-408c-babd-7c1469ef42ff" />

**After:**

<img width="629" height="46" alt="Screenshot 2026-05-27 at 12 46 30 AM" src="https://github.com/user-attachments/assets/60113a81-cf33-41cc-93ab-07f6741aca3c" />


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

None

