### PR TITLE
Bump Ruff from v0.15.2 to v0.15.15 and broaden lint rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.15
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/bakerydemo/base/management/commands/reset_admin_password.py
+++ b/bakerydemo/base/management/commands/reset_admin_password.py
@@ -7,8 +7,8 @@ class Command(BaseCommand):
     def handle(self, **options):
         try:
             admin_user = User.objects.get(username="admin")
-        except User.DoesNotExist:
-            raise CommandError("Cannot find admin user.")
+        except User.DoesNotExist as err:
+            raise CommandError("Cannot find admin user.") from err
 
         admin_user.set_password(settings.ADMIN_PASSWORD)
         admin_user.save(update_fields=["password"])

--- a/bakerydemo/base/models.py
+++ b/bakerydemo/base/models.py
@@ -134,7 +134,7 @@ class Person(
         return PreviewableMixin.DEFAULT_PREVIEW_MODES + [("blog_post", _("Blog post"))]
 
     def __str__(self):
-        return "{} {}".format(self.first_name, self.last_name)
+        return f"{self.first_name} {self.last_name}"
 
     def get_preview_template(self, request, mode_name):
         from bakerydemo.blog.models import BlogPage

--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -186,7 +186,7 @@ class BlogIndexPage(RoutablePageMixin, Page):
     # date that they were published
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
-        context = super(BlogIndexPage, self).get_context(request)
+        context = super().get_context(request)
         context["posts"] = (
             BlogPage.objects.descendant_of(self).live().order_by("-date_published")
         )
@@ -203,7 +203,7 @@ class BlogIndexPage(RoutablePageMixin, Page):
             tag = Tag.objects.get(slug=tag)
         except Tag.DoesNotExist:
             if tag:
-                msg = 'There are no blog posts tagged with "{}"'.format(tag)
+                msg = f'There are no blog posts tagged with "{tag}"'
                 messages.add_message(request, messages.INFO, msg)
             return redirect(self.url)
 

--- a/bakerydemo/breads/models.py
+++ b/bakerydemo/breads/models.py
@@ -252,7 +252,7 @@ class BreadsIndexPage(Page):
     # Returns the above to the get_context method that is used to populate the
     # template
     def get_context(self, request):
-        context = super(BreadsIndexPage, self).get_context(request)
+        context = super().get_context(request)
 
         # BreadPage objects (get_breads) are passed through pagination
         breads = self.paginate(request, self.get_breads())

--- a/bakerydemo/locations/models.py
+++ b/bakerydemo/locations/models.py
@@ -52,7 +52,7 @@ class OperatingHours(models.Model):
             closed = self.closing_time.strftime("%H:%M")
         else:
             closed = "--"
-        return "{}: {} - {} {}".format(self.day, opening, closed, settings.TIME_ZONE)
+        return f"{self.day}: {opening} - {closed} {settings.TIME_ZONE}"
 
 
 class LocationOperatingHours(Orderable, OperatingHours):
@@ -98,7 +98,7 @@ class LocationsIndexPage(Page):
     # items, that are live, by the title alphabetical order.
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
-        context = super(LocationsIndexPage, self).get_context(request)
+        context = super().get_context(request)
         context["locations"] = (
             LocationPage.objects.descendant_of(self).live().order_by("title")
         )
@@ -200,7 +200,7 @@ class LocationPage(Page):
     # Makes additional context available to the template so that we can access
     # the latitude, longitude and map API key to render the map
     def get_context(self, request):
-        context = super(LocationPage, self).get_context(request)
+        context = super().get_context(request)
         context["lat"] = self.lat_long.split(",")[0]
         context["long"] = self.lat_long.split(",")[1]
         context["google_map_api_key"] = settings.GOOGLE_MAP_API_KEY

--- a/bakerydemo/people/models.py
+++ b/bakerydemo/people/models.py
@@ -100,7 +100,7 @@ class PersonPage(Page):
     ]
 
     def get_context(self, request):
-        context = super(PersonPage, self).get_context(request)
+        context = super().get_context(request)
 
         platform_block = SocialMediaBlock().child_blocks["platform"]
         platform_labels = dict(platform_block.field.choices)
@@ -179,7 +179,7 @@ class PeopleIndexPage(Page):
     # Returns the above to the get_context method that is used to populate the
     # template
     def get_context(self, request):
-        context = super(PeopleIndexPage, self).get_context(request)
+        context = super().get_context(request)
 
         # PersonPage objects (get_people) are passed through pagination
         people = self.paginate(request, self.get_people())

--- a/bakerydemo/recipes/models.py
+++ b/bakerydemo/recipes/models.py
@@ -176,7 +176,7 @@ class RecipeIndexPage(Page):
     # date that they were published
     # https://docs.wagtail.org/en/stable/getting_started/tutorial.html#overriding-context
     def get_context(self, request):
-        context = super(RecipeIndexPage, self).get_context(request)
+        context = super().get_context(request)
         context["recipes"] = (
             RecipePage.objects.descendant_of(self).live().order_by("-date_published")
         )

--- a/bakerydemo/settings/dev.py
+++ b/bakerydemo/settings/dev.py
@@ -1,4 +1,4 @@
-from .base import *  # noqa: F403, F401
+from .base import *  # noqa: F403
 
 DEBUG = True
 

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -265,7 +265,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # dev and testing settings.
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-hsts-seconds
 DEFAULT_HSTS_SECONDS = 30 * 24 * 60 * 60  # 30 days
-SECURE_HSTS_SECONDS = int(os.environ.get("SECURE_HSTS_SECONDS", DEFAULT_HSTS_SECONDS))  # noqa
+SECURE_HSTS_SECONDS = int(os.environ.get("SECURE_HSTS_SECONDS", DEFAULT_HSTS_SECONDS))
 
 # Do not use the `includeSubDomains` directive for HSTS. This needs to be prevented
 # because the apps are running on client domains (or our own for staging), that are
@@ -283,7 +283,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 # Referrer-policy header settings.
 # https://django-referrer-policy.readthedocs.io/en/1.0/
 
-REFERRER_POLICY = os.environ.get(  # noqa
+REFERRER_POLICY = os.environ.get(
     "SECURE_REFERRER_POLICY", "no-referrer-when-downgrade"
 ).strip()
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
 -r base.txt
-ruff==0.15.2
+ruff==0.15.15
 curlylint==0.13.1
 djhtml==3.0.10

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,16 +1,21 @@
-exclude = ["wagtail/project_template/*","node_modules","venv",".venv","migrations"]
+exclude = ["node_modules","venv",".venv","migrations"]
 line-length = 88
 
 target-version = "py312"  # minimum target version
 
 [lint]
+# B: flake8-bugbear
 # E: pycodestyle errors
 # F: Pyflakes
 # I: isort
 # T20: flake8-print
 # BLE: flake8-blind-except
 # C4: flake8-comprehensions
-select = ["E", "F", "I", "T20", "BLE", "C4"]
+# RUF100: unused noqa
+# UP: pyupgrade
+# W: pycodestyle warnings
+select = ["B", "BLE", "C4", "E", "F", "I", "RUF100", "T20", "UP", "W"]
+fixable = ["C4", "E", "F", "I", "RUF100", "UP"]
 # D100: Missing docstring in public module
 # D101: Missing docstring in public class
 # D102: Missing docstring in public method
@@ -18,4 +23,7 @@ select = ["E", "F", "I", "T20", "BLE", "C4"]
 # D105: Missing docstring in magic method
 # N806: Variable in function should be lowercase
 # E501: Line too long
-ignore = ["D100","D101","D102","D103","D105","N806","E501"]
+ignore = ["D100","D101","D102","D103","D105","E501","N806"]
+
+[format]
+docstring-code-format = true


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Task of #739 


### Description

<!-- Please describe the problem you're fixing. -->
This updates bakerydemo’s Ruff setup to a newer version and broadens the lint configuration from the current minimal rule set.

The goal of this PR is to modernize the existing Ruff configuration in a reviewable way, based on the earlier discussion in #739, while keeping the scope limited to Ruff-related changes only.

**Tested locally:**

<img width="1076" height="263" alt="Screenshot 2026-06-04 at 5 25 56 PM" src="https://github.com/user-attachments/assets/2930e9bf-8145-4dd2-a3d2-c3ecfda0f62d" />


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

I used GPT to help with the lint rule broadening, and I manually reviewed the changes and verified them locally.
