### PR TITLE
Add Light dark theme support

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -23,6 +23,9 @@ each detail view
 :root {
   color-scheme: light dark;
 
+  --page-bg: light-dark(#fff, #11161d);
+  --surface-bg: light-dark(#fff, #11161d);
+  --surface-alt: light-dark(#f5f3e9, #1a222d);
   --dark: light-dark(#333, #f1f4f8);
   --grey: light-dark(#6e6e6e, #acb5c0);
   --border-grey: light-dark(#e1dcd3, #3e4855);
@@ -30,14 +33,14 @@ each detail view
     rgb(135 116 79 / 25%),
     rgb(164 180 201 / 30%)
   );
-  --white: light-dark(#fff, #11161d);
-  --cream: light-dark(#f5f3e9, #1a222d);
+  --white: #fff;
+  --cream: var(--surface-alt);
   --light-brown: light-dark(#87744f, #c8b083);
   --mid-brown: light-dark(#825600, #f0b45d);
   --dark-brown: light-dark(#553801, #ffe0b0);
   --orange: light-dark(#c55302, #f0b45d);
   --dark-orange: light-dark(#833701, #ffd29b);
-  --black: light-dark(#000, #d9d3d3);
+  --black: #000;
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
   --overlay-black: rgb(0 0 0 / 60%);
@@ -87,7 +90,7 @@ body {
   line-height: 1.5;
   padding-top: 0;
   padding-bottom: 0;
-  background: var(--white);
+  background: var(--page-bg);
   color: var(--dark);
   min-height: 100vh;
 }
@@ -483,7 +486,7 @@ caption {
 .header {
   padding: 0;
   width: 100%;
-  background: var(--white);
+  background: var(--surface-bg);
   z-index: 10;
 }
 
@@ -492,7 +495,7 @@ caption {
   position: absolute;
   top: -100%;
   padding: 20px;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
 }
 
 .skip-link:focus {
@@ -579,7 +582,7 @@ caption {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
   z-index: 10;
   display: flex;
   flex-direction: column;
@@ -917,7 +920,7 @@ hr {
 
 footer {
   padding: 55px 0 30px;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
 }
 
 .footer__icon a {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -381,7 +381,7 @@ caption {
 }
 
 .hero__title {
-  color: var(--text-on-media);
+  color: var(--white);
   font-weight: 400;
   font-size: 2.875rem;
   line-height: 1.09;
@@ -642,7 +642,6 @@ caption {
   position: absolute;
   right: 13px;
   top: 13px;
-  color: var(--dark);
 }
 
 @media (min-width: 768px) {
@@ -652,29 +651,11 @@ caption {
 }
 
 .navigation__search-input {
-  background-color: var(--white);
   color: var(--dark);
   font-size: var(--font-sm);
   line-height: 1.5;
   border: 1px solid var(--dark);
   padding: 10px;
-}
-
-.navigation__theme-toggle {
-  appearance: none;
-  margin: 0 0 0 10px;
-  border: 1px solid var(--dark);
-  background-color: var(--white);
-  color: var(--dark);
-  padding: 10px 12px;
-  font-size: 0.875rem;
-  line-height: 1;
-}
-
-.navigation__theme-toggle:hover,
-.navigation__theme-toggle:focus {
-  background-color: var(--dark);
-  color: var(--white);
 }
 
 .navigation__items {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -1391,7 +1391,7 @@ select {
 
 .form-page input[type='submit'] {
   border: none;
-  color: var(--white);
+  color: light-dark(var(--white), var(--black));
   background-color: var(--orange);
   font-weight: 700;
   padding: 15px 25px;
@@ -1513,7 +1513,7 @@ input[type='radio'] {
 }
 
 .homepage .home-hero .hero-cta-link {
-  color: var(--white);
+  color: light-dark(var(--white), var(--black));
   background-color: var(--orange);
   font-weight: 700;
   padding: 15px 25px;
@@ -1525,7 +1525,7 @@ input[type='radio'] {
 }
 
 .homepage .home-hero .hero-cta-link:hover {
-  background-color: var(--white);
+  background-color: light-dark(var(--white), var(--black));
   color: var(--dark-orange);
 }
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -21,17 +21,23 @@ each detail view
 
 /* CSS Variables */
 :root {
-  --dark: #333;
-  --grey: #6e6e6e;
-  --border-grey: #e1dcd3;
-  --transparent-border: rgb(135 116 79 / 25%);
-  --white: #fff;
-  --cream: #f5f3e9;
-  --light-brown: #87744f;
-  --mid-brown: #825600;
-  --dark-brown: #553801;
-  --orange: #c55302;
-  --dark-orange: #833701;
+  color-scheme: light dark;
+
+  --dark: light-dark(#333, #f1f4f8);
+  --grey: light-dark(#6e6e6e, #acb5c0);
+  --border-grey: light-dark(#e1dcd3, #3e4855);
+  --transparent-border: light-dark(
+    rgb(135 116 79 / 25%),
+    rgb(164 180 201 / 30%)
+  );
+  --white: light-dark(#fff, #11161d);
+  --cream: light-dark(#f5f3e9, #1a222d);
+  --light-brown: light-dark(#87744f, #c8b083);
+  --mid-brown: light-dark(#825600, #f0b45d);
+  --dark-brown: light-dark(#553801, #ffe0b0);
+  --orange: light-dark(#c55302, #f0b45d);
+  --dark-orange: light-dark(#833701, #ffd29b);
+  --color-text: light-dark(#333, #f1f4f8);
   --black: #000;
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
@@ -104,7 +110,7 @@ h2,
 h3 {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 h1 {
@@ -128,7 +134,7 @@ h4 {
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.35;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 p {
@@ -137,7 +143,7 @@ p {
   font-weight: 400;
   font-size: var(--font-sm);
   line-height: 1.5;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 @media (min-width: 768px) {
@@ -179,7 +185,7 @@ ul {
 }
 
 .hero h1 {
-  color: var(--text-on-media);
+  color: var(--color-text);
   position: relative;
 }
 
@@ -686,15 +692,98 @@ caption {
 
   .navigation__search {
     display: block;
-    margin: 0 0 0 10px;
+    margin: 0 0 0 16px;
   }
 
   .navigation__items {
     padding: 0 0 0 20px;
   }
+}
 
-  .navigation__theme-toggle {
-    margin: 0 0 0 auto;
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  margin: 15px 12px 0 auto;
+}
+
+.theme-toggle--mobile {
+  margin: 20px 0 0;
+}
+
+.theme-toggle__label {
+  color: var(--dark);
+  font-family: var(--font--secondary);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.theme-toggle__button {
+  padding: 0;
+  width: 48px;
+  height: 28px;
+  border: 0;
+  outline: none;
+  overflow: hidden;
+  position: relative;
+  border-radius: 14px;
+  margin: 0 8px;
+  display: inline-block;
+  cursor: pointer;
+  background: light-dark(var(--grey), var(--light-grey));
+}
+
+.theme-toggle__button::before {
+  top: 4px;
+  inset-inline-start: 24px;
+  content: '';
+  width: 20px;
+  height: 20px;
+  display: block;
+  position: absolute;
+  border-radius: 12px;
+  background-color: light-dark(var(--light-grey), var(--black));
+  transition: inset-inline-start 0.2s ease-in-out;
+}
+
+.theme-toggle__button::after {
+  content: '';
+  top: 14px;
+  inset-inline-end: 2px;
+  width: 1px;
+  height: 1px;
+  display: block;
+  position: absolute;
+  border-radius: 0.5px;
+  background: light-dark(var(--dark), var(--light-grey));
+}
+
+.dark-only {
+  display: none;
+}
+
+html:has([name='color-scheme'][content^='dark']) .dark-only {
+  display: block;
+}
+
+html:has([name='color-scheme'][content^='dark']) .light-only {
+  display: none;
+}
+
+html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::before {
+  inset-inline-start: 4px;
+}
+
+html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::after {
+  top: -2px;
+  inset-inline-end: 2px;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+}
+
+@media (min-width: 1150px) {
+  .theme-toggle {
+    margin: 0 24px 0 auto;
   }
 }
 
@@ -1427,7 +1516,7 @@ input[type='radio'] {
 .homepage .home-hero .lead {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--text-on-media);
+  color: var(--color-text);
   margin: 40px auto;
   font-size: 1.625rem;
   line-height: 1.15;
@@ -1790,7 +1879,7 @@ input[type='radio'] {
 }
 
 .picture-card__title {
-  color: var(--text-on-media);
+  color: var(--color-text);
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -37,8 +37,7 @@ each detail view
   --dark-brown: light-dark(#553801, #ffe0b0);
   --orange: light-dark(#c55302, #f0b45d);
   --dark-orange: light-dark(#833701, #ffd29b);
-  --color-text: light-dark(#333, #f1f4f8);
-  --black: #000;
+  --black: light-dark(#000, #d9d3d3);
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
   --overlay-black: rgb(0 0 0 / 60%);
@@ -110,7 +109,7 @@ h2,
 h3 {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 h1 {
@@ -134,7 +133,7 @@ h4 {
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.35;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 p {
@@ -143,7 +142,7 @@ p {
   font-weight: 400;
   font-size: var(--font-sm);
   line-height: 1.5;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 @media (min-width: 768px) {
@@ -185,7 +184,7 @@ ul {
 }
 
 .hero h1 {
-  color: var(--color-text);
+  color: var(--white);
   position: relative;
 }
 
@@ -1516,7 +1515,7 @@ input[type='radio'] {
 .homepage .home-hero .lead {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--color-text);
+  color: var(--white);
   margin: 40px auto;
   font-size: 1.625rem;
   line-height: 1.15;
@@ -1879,7 +1878,7 @@ input[type='radio'] {
 }
 
 .picture-card__title {
-  color: var(--color-text);
+  color: var(--white);
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,45 +1,59 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navigation = document.querySelector('[data-navigation]');
-  const themeToggle = document.querySelector('[data-theme-toggle]');
-  const htmlElement = document.documentElement;
-  const storage = {
-    get(key) {
-      try {
-        return localStorage.getItem(key);
-      } catch {
-        return null;
-      }
-    },
-    set(key, value) {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        // Ignore storage failures and keep the theme change in-memory only.
-      }
-    },
-  };
+  const body = document.querySelector('body');
+  const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+  const mobileNavigation = navigation?.querySelector(
+    '[data-mobile-navigation]',
+  );
+  const mobileNavigationToggle = navigation?.querySelector(
+    '[data-mobile-navigation-toggle]',
+  );
+  const themeToggles = document.querySelectorAll('[data-theme-toggle]');
 
-  function updateThemeToggleLabel() {
-    if (!themeToggle) {
-      return;
+  function getPreferredTheme() {
+    try {
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'light' || storedTheme === 'dark') {
+        return storedTheme;
+      }
+    } catch {
+      // Ignore storage access errors and fall back to the system preference.
     }
-    const isDarkTheme = htmlElement.dataset.theme === 'dark';
-    themeToggle.textContent = isDarkTheme ? 'Light theme' : 'Dark theme';
-    themeToggle.setAttribute('aria-pressed', isDarkTheme ? 'true' : 'false');
-    themeToggle.setAttribute(
-      'aria-label',
-      isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme',
-    );
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
   }
 
-  if (navigation) {
-    const mobileNavigation = navigation.querySelector(
-      '[data-mobile-navigation]',
-    );
-    const body = document.querySelector('body');
-    const mobileNavigationToggle = navigation.querySelector(
-      '[data-mobile-navigation-toggle]',
-    );
+  function applyTheme(theme) {
+    document.documentElement.style.colorScheme = theme;
+
+    if (colorSchemeMeta) {
+      colorSchemeMeta.setAttribute('content', theme);
+    }
+
+    themeToggles.forEach((toggle) => {
+      const isDark = theme === 'dark';
+
+      toggle.setAttribute('aria-pressed', String(isDark));
+      toggle.setAttribute(
+        'aria-label',
+        `Switch to ${isDark ? 'light' : 'dark'} theme`,
+      );
+    });
+  }
+
+  function toggleTheme() {
+    const nextTheme = getPreferredTheme() === 'dark' ? 'light' : 'dark';
+
+    try {
+      localStorage.setItem('theme', nextTheme);
+    } catch {
+      // Ignore storage access errors and still apply the theme for this page view.
+    }
+
+    applyTheme(nextTheme);
+  }
 
     function toggleMobileNavigation() {
       if (mobileNavigation.hidden) {
@@ -53,19 +67,17 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+  if (mobileNavigation && mobileNavigationToggle) {
     mobileNavigationToggle.addEventListener('click', () => {
       toggleMobileNavigation();
     });
   }
 
-  if (themeToggle) {
-    updateThemeToggleLabel();
+  applyTheme(getPreferredTheme());
 
-    themeToggle.addEventListener('click', () => {
-      const nextTheme = htmlElement.dataset.theme === 'dark' ? 'light' : 'dark';
-      htmlElement.dataset.theme = nextTheme;
-      storage.set('theme', nextTheme);
-      updateThemeToggleLabel();
+  themeToggles.forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      toggleTheme();
     });
-  }
+  });
 });

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navigation = document.querySelector('[data-navigation]');
   const body = document.querySelector('body');
-  const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
   const mobileNavigation = navigation?.querySelector(
     '[data-mobile-navigation]',
   );
@@ -9,51 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     '[data-mobile-navigation-toggle]',
   );
   const themeToggles = document.querySelectorAll('[data-theme-toggle]');
-
-  function getPreferredTheme() {
-    try {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'light' || storedTheme === 'dark') {
-        return storedTheme;
-      }
-    } catch {
-      // Ignore storage access errors and fall back to the system preference.
-    }
-
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light';
-  }
-
-  function applyTheme(theme) {
-    document.documentElement.style.colorScheme = theme;
-
-    if (colorSchemeMeta) {
-      colorSchemeMeta.setAttribute('content', theme);
-    }
-
-    themeToggles.forEach((toggle) => {
-      const isDark = theme === 'dark';
-
-      toggle.setAttribute('aria-pressed', String(isDark));
-      toggle.setAttribute(
-        'aria-label',
-        `Switch to ${isDark ? 'light' : 'dark'} theme`,
-      );
-    });
-  }
-
-  function toggleTheme() {
-    const nextTheme = getPreferredTheme() === 'dark' ? 'light' : 'dark';
-
-    try {
-      localStorage.setItem('theme', nextTheme);
-    } catch {
-      // Ignore storage access errors and still apply the theme for this page view.
-    }
-
-    applyTheme(nextTheme);
-  }
 
     function toggleMobileNavigation() {
       if (mobileNavigation.hidden) {
@@ -73,11 +27,31 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  applyTheme(getPreferredTheme());
+  function updateThemeToggleState() {
+    const isDark =
+      document.documentElement.style.colorScheme === 'dark' ||
+      document.querySelector('meta[name="color-scheme"]')?.content === 'dark';
+
+    themeToggles.forEach((toggle) => {
+      toggle.setAttribute('aria-pressed', String(isDark));
+      toggle.setAttribute(
+        'aria-label',
+        `Switch to ${isDark ? 'light' : 'dark'} theme`,
+      );
+    });
+  }
+
+  document.addEventListener('theme:toggle-theme-mode', () => {
+    window.requestAnimationFrame(() => {
+      updateThemeToggleState();
+    });
+  });
+
+  updateThemeToggleState();
 
   themeToggles.forEach((toggle) => {
     toggle.addEventListener('click', () => {
-      toggleTheme();
+      document.dispatchEvent(new CustomEvent('theme:toggle-theme-mode'));
     });
   });
 });

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -9,17 +9,17 @@ document.addEventListener('DOMContentLoaded', () => {
   );
   const themeToggles = document.querySelectorAll('[data-theme-toggle]');
 
-    function toggleMobileNavigation() {
-      if (mobileNavigation.hidden) {
-        body.classList.add('no-scroll');
-        mobileNavigation.hidden = false;
-        mobileNavigationToggle.setAttribute('aria-expanded', 'true');
-      } else {
-        body.classList.remove('no-scroll');
-        mobileNavigation.hidden = true;
-        mobileNavigationToggle.setAttribute('aria-expanded', 'false');
-      }
+  function toggleMobileNavigation() {
+    if (mobileNavigation.hidden) {
+      body.classList.add('no-scroll');
+      mobileNavigation.hidden = false;
+      mobileNavigationToggle.setAttribute('aria-expanded', 'true');
+    } else {
+      body.classList.remove('no-scroll');
+      mobileNavigation.hidden = true;
+      mobileNavigationToggle.setAttribute('aria-expanded', 'false');
     }
+  }
 
   if (mobileNavigation && mobileNavigationToggle) {
     mobileNavigationToggle.addEventListener('click', () => {

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -17,6 +17,7 @@
         </title>
         <meta name="description" content="{% block search_description %}{% if page.search_description %}{{ page.search_description }}{% endif %}{% endblock %}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="light dark">
 
         {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}
@@ -32,7 +33,12 @@
                     storedTheme = null;
                 }
                 const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-                document.documentElement.dataset.theme = storedTheme || (prefersDark ? "dark" : "light");
+                const theme = storedTheme || (prefersDark ? "dark" : "light");
+                document.documentElement.style.colorScheme = theme;
+                const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+                if (colorSchemeMeta) {
+                    colorSchemeMeta.setAttribute("content", theme);
+                }
             })();
         </script>
 

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -25,20 +25,60 @@
         {% endif %}
 
         <script>
-            (() => {
-                let storedTheme = null;
+            /**
+             * IMPORTANT: This script runs before the rest of the page to avoid
+             * showing the wrong theme on first paint.
+             */
+            function updateThemeMode(event, { isInitial = false } = {}) {
+                const DARK = "dark";
+                const LIGHT = "light";
+                const STORAGE_KEY = "wagtail-theme";
+
+                let currentMode;
+                let applyMode;
+                let savedThemeMode;
+
                 try {
-                    storedTheme = localStorage.getItem("theme");
+                    savedThemeMode = localStorage.getItem(STORAGE_KEY);
                 } catch (error) {
-                    storedTheme = null;
+                    savedThemeMode = null;
                 }
-                const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-                const theme = storedTheme || (prefersDark ? "dark" : "light");
-                document.documentElement.style.colorScheme = theme;
+
+                if (savedThemeMode) {
+                    currentMode = savedThemeMode === LIGHT ? LIGHT : DARK;
+                } else {
+                    const prefersDarkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
+                    currentMode = prefersDarkMode ? DARK : LIGHT;
+                }
+
+                if (isInitial) {
+                    applyMode = currentMode === DARK ? DARK : LIGHT;
+                } else {
+                    applyMode = currentMode === DARK ? LIGHT : DARK;
+                }
+
+                document.documentElement.style.colorScheme = applyMode;
+
                 const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
                 if (colorSchemeMeta) {
-                    colorSchemeMeta.setAttribute("content", theme);
+                    colorSchemeMeta.setAttribute("content", applyMode);
                 }
+
+                if (savedThemeMode || event) {
+                    try {
+                        localStorage.setItem(STORAGE_KEY, applyMode);
+                    } catch (error) {
+                        // Ignore storage write failures and continue with the in-memory choice.
+                    }
+                }
+            }
+
+            document.addEventListener("theme:toggle-theme-mode", updateThemeMode, {
+                passive: true,
+            });
+
+            (() => {
+                updateThemeMode(null, { isInitial: true });
             })();
         </script>
 

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -32,7 +32,7 @@
             function updateThemeMode(event, { isInitial = false } = {}) {
                 const DARK = "dark";
                 const LIGHT = "light";
-                const STORAGE_KEY = "wagtail-theme";
+                const STORAGE_KEY = "demo-theme";
 
                 let currentMode;
                 let applyMode;

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -26,6 +26,20 @@
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}
                     {% top_menu parent=site_root calling_page=self %}
                 </ul>
+                <div class="theme-toggle theme-toggle--mobile">
+                    <span class="theme-toggle__label">Dark</span>
+                    <button
+                        class="theme-toggle__button"
+                        type="button"
+                        data-theme-toggle
+                        aria-label="Toggle between dark and light theme"
+                        aria-pressed="false"
+                    >
+                        <span class="dark-only u-sr-only">Light mode</span>
+                        <span class="light-only u-sr-only">Dark mode</span>
+                    </button>
+                    <span class="theme-toggle__label">Light</span>
+                </div>
                 <form action="/search" method="get" class="navigation__mobile-search" role="search">
                     <label for="mobile-search-input" class="u-sr-only">Search the bakery</label>
                     <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="Search" autocomplete="off" name="q">
@@ -44,15 +58,20 @@
                 </ul>
             </nav>
 
-            <button
-                type="button"
-                class="navigation__theme-toggle"
-                data-theme-toggle
-                aria-label="Toggle dark theme"
-                aria-pressed="false"
-            >
-                Theme
-            </button>
+            <div class="theme-toggle">
+                <span class="theme-toggle__label">Dark</span>
+                <button
+                    class="theme-toggle__button"
+                    type="button"
+                    data-theme-toggle
+                    aria-label="Toggle between dark and light theme"
+                    aria-pressed="false"
+                >
+                    <span class="dark-only u-sr-only">Light mode</span>
+                    <span class="light-only u-sr-only">Dark mode</span>
+                </button>
+                <span class="theme-toggle__label">Light</span>
+            </div>
 
             <form action="/search" method="get" class="navigation__search" role="search">
                 <label for="search-input" class="u-sr-only">Search the bakery</label>


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #750 

### Description

<!-- Please describe the problem you're fixing. -->
This PR adds light-dark theme switcher ,as part of the nav header area.

The implementation follows the approach discussed in #750, builds on the earlier exploratory work in #752, and takes reference from the [guide website](https://guide.wagtail.org/en-latest/), particularly its [blocking.js](https://github.com/wagtail/guide/blob/main/apps/frontend/static_src/js/blocking.js) theme bootstrap behavior.

 Key requirements:
- [X] Should detect theming from user preferences
- [X] Save selected theme in `localStorage`
- [X] Should set `<meta name="color-scheme" content="light dark">` to `light` or `dark` per user choice / preferences.
- [X] (minimal JS)
- [X] ideally: add theming option already proposed in #566 (if it’s still a good fit) -> https://github.com/wagtail/bakerydemo/pull/752

It use light-dark() for theme-dependent color tokens while keeping fixed-purpose tokens separate for overlays and inverse text

### Tested locally

I tested the theme switcher locally by:

  - loading the site in the browser and verifying the toggle works in the header
  - confirming the selected theme persists after reload
  - checking that the initial theme follows system preference when no saved choice exists
  - verifying that the page updates <meta name="color-scheme"> correctly
  - checking that the hero and navigation remain readable in both light and dark mode
  
  https://drive.google.com/file/d/16OD4O2iLG6MW5Q84hWd0TiuLO17SmAEU/view?usp=sharing

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used Codex to help with splitting the theme tokens and refining the implementation, and I manually reviewed the changes and tested them locally.