### PR TITLE
add agent skills for frontend tooling maintenance

### DIFF
--- a/.agents/skills/frontend-tooling-maintenance/SKILL.md
+++ b/.agents/skills/frontend-tooling-maintenance/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: frontend-tooling-maintenance
+description: Maintain or upgrade bakerydemo frontend linting, formatting, and theme-related tooling with minimal churn
+license: MIT
+---
+
+## Overview
+
+Use this skill for `bakerydemo` frontend tooling tasks such as Prettier, Stylelint, ESLint, prek integration, and small native-CSS theme infrastructure updates.
+
+## Methodology
+
+### Preferred approach
+
+- Keep changes minimal and reviewable.
+- Prefer the repo's actual commands and workflows: `make lint`, `make format`, `npm run ...`, `prek`.
+- When adopting stricter lint rules, use incremental overrides rather than forcing large unrelated CSS rewrites in one PR.
+
+### Useful commands
+
+- Install frontend dependencies with `npm ci`.
+- Run repo-wide frontend checks with:
+  - `npm run lint:css`
+  - `npm run lint:js`
+  - `npm run lint:format`
+- Run targeted checks when only a few files changed or repo-wide tooling is noisy:
+  - `npx stylelint bakerydemo/static/css/main.css`
+  - `npx stylelint --fix bakerydemo/static/css/main.css`
+  - `npx eslint bakerydemo/static/js/main.js`
+  - `npx prettier --check bakerydemo/static/css/main.css bakerydemo/static/js/main.js`
+- Use `make lint` or `make format` when you need the broader project-level workflow, not only frontend checks.
+
+### Quality checks
+
+- Run the smallest targeted lint commands needed for confidence.
+- If repo-wide tooling is mid-migration, document any blocked checks and run focused file-level validation instead.
+
+### Pitfalls
+
+- Local environment directories such as `uvenv/` inside the repo can confuse glob-based frontend scripts.
+- Keep theme tokens for text, surfaces, borders, and links separate from fixed effect tokens such as overlays, gradients, shadows, and inverse-on-image text.


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->


### Description

<!-- Please describe the problem you're fixing. -->
This adds a `frontend-tooling-maintenance` agent skill for bakerydemo.

The skill provides focused guidance for frontend tooling tasks such as:

  - Stylelint, ESLint, and Prettier updates
  - prek / frontend lint workflow changes
  - targeted CSS and JavaScript checks
  - theme-related tooling changes with minimal churn
  
It also documents frontend-specific pitfalls, including:

  - local environment directories such as `uvenv`/ interfering with glob-based frontend scripts
  - keeping theme tokens separate from fixed visual effect tokens such as overlays and inverse-on-image text

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used AI to help document the frontend tooling workflow and pitfalls, and I manually wrote and reviewed the final content.