### PR TITLE
Add locale-aware translation metadata and routing

### DIFF
--- a/bakerydemo/base/templatetags/navigation_tags.py
+++ b/bakerydemo/base/templatetags/navigation_tags.py
@@ -1,9 +1,65 @@
 from django import template
+from django.utils.translation import get_language_info
 from wagtail.models import Page, Site
 
 from bakerydemo.base.models import FooterText
 
 register = template.Library()
+
+
+def get_current_page(context):
+    return context.get("page") or context.get("self")
+
+
+def get_page_language_entries(page, request):
+    if page is None or not hasattr(page, "locale"):
+        return []
+
+    translated_pages = [page, *page.get_translations().live().public()]
+    entries_by_code = {}
+
+    for translated_page in translated_pages:
+        language_code = translated_page.locale.language_code
+        language_info = get_language_info(language_code)
+
+        entries_by_code[language_code] = {
+            "code": language_code,
+            "name_local": language_info["name_local"],
+            "name_translated": language_info["name_translated"],
+            "url": request.build_absolute_uri(translated_page.url),
+            "is_current": translated_page.pk == page.pk,
+        }
+
+    return list(entries_by_code.values())
+
+
+@register.inclusion_tag("tags/hreflangs.html", takes_context=True)
+def hreflangs(context):
+    page = get_current_page(context)
+    entries = get_page_language_entries(page, context["request"])
+
+    return {
+        "translations": [entry for entry in entries if not entry["is_current"]],
+    }
+
+
+@register.inclusion_tag("includes/language_switcher.html", takes_context=True)
+def language_switcher(context):
+    page = get_current_page(context)
+    entries = get_page_language_entries(page, context["request"])
+
+    if len(entries) <= 1:
+        return {"render_language_switcher": False}
+
+    current_language = next(entry for entry in entries if entry["is_current"])
+
+    return {
+        "render_language_switcher": True,
+        "current_language": current_language,
+        "languages": entries,
+    }
+
+
 # https://docs.djangoproject.com/en/stable/howto/custom-template-tags/
 
 

--- a/bakerydemo/breads/wagtail_hooks.py
+++ b/bakerydemo/breads/wagtail_hooks.py
@@ -28,7 +28,7 @@ class BreadIngredientSnippetViewSet(SnippetViewSet):
     search_fields = ("name",)
     filterset_class = BreadIngredientFilterSet
     inspect_view_enabled = True
-    menu_order = 999 # will place it last.
+    menu_order = 999  # will place it last.
 
 
 class BreadTypeFilterSet(RevisionFilterSetMixin, WagtailFilterSet):

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     # "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -159,7 +159,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/stable/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "en"
 
 TIME_ZONE = "UTC"
 

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,8 +1,9 @@
 {% load navigation_tags static wagtailuserbar %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{% if page %}{{ page.locale.language_code }}{% elif self %}{{ self.locale.language_code }}{% else %}en{% endif %}">
     <head>
         <meta charset="utf-8">
+        {% hreflangs %}
         <title>
             {% block title %}
                 {% if page.seo_title %}

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -44,6 +44,8 @@
                 </ul>
             </nav>
 
+            {% language_switcher %}
+
             <button
                 type="button"
                 class="navigation__theme-toggle"

--- a/bakerydemo/templates/includes/language_switcher.html
+++ b/bakerydemo/templates/includes/language_switcher.html
@@ -1,0 +1,25 @@
+{% if render_language_switcher %}
+    <div class="language-switcher">
+        <span class="language-switcher__current" lang="{{ current_language.code }}">
+            {{ current_language.name_local }}
+        </span>
+
+        <ul class="language-switcher__list">
+            {% for language in languages %}
+                {% if not language.is_current %}
+                    <li class="language-switcher__item">
+                        <a
+                            href="{{ language.url }}"
+                            class="language-switcher__link"
+                            rel="alternate"
+                            hreflang="{{ language.code }}"
+                            lang="{{ language.code }}"
+                        >
+                            {{ language.name_local }}
+                        </a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}

--- a/bakerydemo/templates/tags/hreflangs.html
+++ b/bakerydemo/templates/tags/hreflangs.html
@@ -1,0 +1,3 @@
+{% for translation in translations %}
+    <link rel="alternate" hreflang="{{ translation.code }}" href="{{ translation.url }}">
+{% endfor %}

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -1,5 +1,6 @@
 import debug_toolbar
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path, re_path
 from wagtail import urls as wagtail_urls
@@ -21,7 +22,6 @@ urlpatterns = [
         ServeView.as_view(),
         name="wagtailimages_serve",
     ),
-    path("search/", search_views.search, name="search"),
     path("sitemap.xml", sitemap),
     path("api/v2/", api_router.urls),
     path("__debug__/", include(debug_toolbar.urls)),
@@ -50,6 +50,7 @@ if settings.DEBUG:
         path("test500/", TemplateView.as_view(template_name="500.html")),
     ]
 
-urlpatterns += [
+urlpatterns += i18n_patterns(
+    path("search/", search_views.search, name="search"),
     path("", include(wagtail_urls)),
-]
+)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Task of #757 

### Description

<!-- Please describe the problem you're fixing. -->
This adds the first part of the language-switcher work for `bakerydemo` by wiring page translation metadata and locale-aware URLs.

Changes in this PR:
- add helpers to collect available translations for the current page
- add alternate `hreflang` links in the document head
- set the document `lang` attribute from the current page locale
- render basic language links for the current page in the header
- enable locale-aware public URLs so translated pages resolve under language-prefixed paths such as `/en/` and `/de/`

This PR is intentionally limited to the translation data and routing groundwork. It does not yet implement the final switcher UI or Popover API interaction.

### Tested locally

I tested this locally by:
- verifying the homepage resolves under locale-prefixed URLs
- confirming `/` redirects to `/en/`
- confirming translated pages resolve at `/en/` and `/de/`
- checking that the document `<html lang="...">` value matches the current page locale
- checking that alternate `hreflang` links are rendered in the page head
- confirming the header only renders languages available for the current page


https://github.com/user-attachments/assets/22cea150-f4c1-4cad-95d4-14ece3569fd7



### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

I used AI to help with the translation metadata and routing approach, and I manually applied and verified the changes locally.
