### PR TITLE
Language switcher UI

### DIFF
--- a/bakerydemo/base/templatetags/navigation_tags.py
+++ b/bakerydemo/base/templatetags/navigation_tags.py
@@ -1,9 +1,65 @@
 from django import template
+from django.utils.translation import get_language_info
 from wagtail.models import Page, Site
 
 from bakerydemo.base.models import FooterText
 
 register = template.Library()
+
+
+def get_current_page(context):
+    return context.get("page") or context.get("self")
+
+
+def get_page_language_entries(page, request):
+    if page is None or not hasattr(page, "locale"):
+        return []
+
+    translated_pages = [page, *page.get_translations().live().public()]
+    entries_by_code = {}
+
+    for translated_page in translated_pages:
+        language_code = translated_page.locale.language_code
+        language_info = get_language_info(language_code)
+
+        entries_by_code[language_code] = {
+            "code": language_code,
+            "name_local": language_info["name_local"],
+            "name_translated": language_info["name_translated"],
+            "url": request.build_absolute_uri(translated_page.url),
+            "is_current": translated_page.pk == page.pk,
+        }
+
+    return list(entries_by_code.values())
+
+
+@register.inclusion_tag("tags/hreflangs.html", takes_context=True)
+def hreflangs(context):
+    page = get_current_page(context)
+    entries = get_page_language_entries(page, context["request"])
+
+    return {
+        "translations": [entry for entry in entries if not entry["is_current"]],
+    }
+
+
+@register.inclusion_tag("includes/language_switcher.html", takes_context=True)
+def language_switcher(context):
+    page = get_current_page(context)
+    entries = get_page_language_entries(page, context["request"])
+
+    if len(entries) <= 1:
+        return {"render_language_switcher": False}
+
+    current_language = next(entry for entry in entries if entry["is_current"])
+
+    return {
+        "render_language_switcher": True,
+        "current_language": current_language,
+        "languages": entries,
+    }
+
+
 # https://docs.djangoproject.com/en/stable/howto/custom-template-tags/
 
 

--- a/bakerydemo/base/templatetags/navigation_tags.py
+++ b/bakerydemo/base/templatetags/navigation_tags.py
@@ -44,7 +44,7 @@ def hreflangs(context):
 
 
 @register.inclusion_tag("includes/language_switcher.html", takes_context=True)
-def language_switcher(context):
+def language_switcher(context, placement="desktop"):
     page = get_current_page(context)
     entries = get_page_language_entries(page, context["request"])
 
@@ -52,11 +52,14 @@ def language_switcher(context):
         return {"render_language_switcher": False}
 
     current_language = next(entry for entry in entries if entry["is_current"])
+    popover_id = f"language-switcher-{placement}-{page.pk}"
 
     return {
         "render_language_switcher": True,
         "current_language": current_language,
         "languages": entries,
+        "placement": placement,
+        "popover_id": popover_id,
     }
 
 

--- a/bakerydemo/breads/wagtail_hooks.py
+++ b/bakerydemo/breads/wagtail_hooks.py
@@ -28,7 +28,7 @@ class BreadIngredientSnippetViewSet(SnippetViewSet):
     search_fields = ("name",)
     filterset_class = BreadIngredientFilterSet
     inspect_view_enabled = True
-    menu_order = 999 # will place it last.
+    menu_order = 999  # will place it last.
 
 
 class BreadTypeFilterSet(RevisionFilterSetMixin, WagtailFilterSet):

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     # "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -159,7 +159,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/stable/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "en"
 
 TIME_ZONE = "UTC"
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -625,6 +625,85 @@ caption {
   position: relative;
 }
 
+.language-switcher {
+  position: relative;
+}
+
+.language-switcher--desktop {
+  display: none;
+}
+
+.language-switcher--mobile {
+  margin-top: 20px;
+}
+
+.language-switcher__toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--dark);
+  background-color: var(--white);
+  color: var(--dark);
+  padding: 10px 12px;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.language-switcher__toggle:hover,
+.language-switcher__toggle:focus {
+  background-color: var(--dark);
+  color: var(--white);
+}
+
+.language-switcher__icon {
+  flex-shrink: 0;
+}
+
+.language-switcher__popover {
+  inset: auto auto auto 0;
+  margin: 8px 0 0;
+  min-width: 10rem;
+  border: 1px solid var(--border-grey);
+  background-color: var(--white);
+  color: var(--dark);
+  padding: 8px 0;
+  box-shadow: 0 10px 30px var(--shadow-black);
+}
+
+.language-switcher__popover::backdrop {
+  background: transparent;
+}
+
+.language-switcher__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.language-switcher__item {
+  padding: 0;
+}
+
+.language-switcher__link,
+.language-switcher__link:visited {
+  display: block;
+  padding: 8px 14px;
+  color: var(--dark);
+  font-size: 0.875rem;
+  line-height: 1.3;
+}
+
+.language-switcher__link:hover,
+.language-switcher__link:focus {
+  background-color: var(--cream);
+  color: var(--dark-orange);
+}
+
+.language-switcher__link--current {
+  font-weight: 700;
+}
+
 .navigation__search {
   display: none;
   margin: 15px 0 0;
@@ -682,6 +761,11 @@ caption {
 }
 
 @media (min-width: 1150px) {
+  .language-switcher--desktop {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+
   .navigation__desktop {
     display: block;
   }
@@ -696,7 +780,7 @@ caption {
   }
 
   .navigation__theme-toggle {
-    margin: 0 0 0 auto;
+    margin: 0 0 0 10px;
   }
 }
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -625,10 +625,6 @@ caption {
   position: relative;
 }
 
-.language-switcher {
-  position: relative;
-}
-
 .language-switcher--desktop {
   display: none;
 }
@@ -661,8 +657,6 @@ caption {
 }
 
 .language-switcher__popover {
-  inset: auto auto auto 0;
-  margin: 8px 0 0;
   min-width: 10rem;
   border: 1px solid var(--border-grey);
   background-color: var(--white);

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navigation = document.querySelector('[data-navigation]');
   const themeToggle = document.querySelector('[data-theme-toggle]');
+  const languageSwitcherToggles = document.querySelectorAll(
+    '[data-language-switcher-toggle]',
+  );
   const htmlElement = document.documentElement;
   const storage = {
     get(key) {
@@ -68,4 +71,20 @@ document.addEventListener('DOMContentLoaded', () => {
       updateThemeToggleLabel();
     });
   }
+
+  languageSwitcherToggles.forEach((toggle) => {
+    const popoverId = toggle.getAttribute('aria-controls');
+    const popover = popoverId ? document.getElementById(popoverId) : null;
+
+    if (!popover) {
+      return;
+    }
+
+    popover.addEventListener('toggle', (event) => {
+      toggle.setAttribute(
+        'aria-expanded',
+        event.newState === 'open' ? 'true' : 'false',
+      );
+    });
+  });
 });

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,8 +1,9 @@
 {% load navigation_tags static wagtailuserbar %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{% if page %}{{ page.locale.language_code }}{% elif self %}{{ self.locale.language_code }}{% else %}en{% endif %}">
     <head>
         <meta charset="utf-8">
+        {% hreflangs %}
         <title>
             {% block title %}
                 {% if page.seo_title %}

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,6 +1,8 @@
-{% load navigation_tags static wagtailuserbar %}
+{% load i18n navigation_tags static wagtailuserbar %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="{% if page %}{{ page.locale.language_code }}{% elif self %}{{ self.locale.language_code }}{% else %}en{% endif %}">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8">
         {% hreflangs %}

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -44,6 +44,8 @@
                 </ul>
             </nav>
 
+            {% language_switcher %}
+
             <button
                 type="button"
                 class="navigation__theme-toggle"

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -26,6 +26,7 @@
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}
                     {% top_menu parent=site_root calling_page=self %}
                 </ul>
+                {% language_switcher "mobile" %}
                 <form action="/search" method="get" class="navigation__mobile-search" role="search">
                     <label for="mobile-search-input" class="u-sr-only">Search the bakery</label>
                     <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="Search" autocomplete="off" name="q">
@@ -44,7 +45,7 @@
                 </ul>
             </nav>
 
-            {% language_switcher %}
+            {% language_switcher "desktop" %}
 
             <button
                 type="button"

--- a/bakerydemo/templates/includes/language_switcher.html
+++ b/bakerydemo/templates/includes/language_switcher.html
@@ -1,0 +1,25 @@
+{% if render_language_switcher %}
+    <div class="language-switcher">
+        <span class="language-switcher__current" lang="{{ current_language.code }}">
+            {{ current_language.name_local }}
+        </span>
+
+        <ul class="language-switcher__list">
+            {% for language in languages %}
+                {% if not language.is_current %}
+                    <li class="language-switcher__item">
+                        <a
+                            href="{{ language.url }}"
+                            class="language-switcher__link"
+                            rel="alternate"
+                            hreflang="{{ language.code }}"
+                            lang="{{ language.code }}"
+                        >
+                            {{ language.name_local }}
+                        </a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}

--- a/bakerydemo/templates/includes/language_switcher.html
+++ b/bakerydemo/templates/includes/language_switcher.html
@@ -1,25 +1,56 @@
 {% if render_language_switcher %}
-    <div class="language-switcher">
-        <span class="language-switcher__current" lang="{{ current_language.code }}">
-            {{ current_language.name_local }}
-        </span>
+    <div class="language-switcher language-switcher--{{ placement }}">
+        <button
+            type="button"
+            class="language-switcher__toggle"
+            id="{{ popover_id }}-toggle"
+            popovertarget="{{ popover_id }}"
+            popovertargetaction="toggle"
+            aria-controls="{{ popover_id }}"
+            aria-expanded="false"
+            data-language-switcher-toggle
+        >
+            <span class="language-switcher__current" lang="{{ current_language.code }}">
+                {{ current_language.name_local }}
+            </span>
+            <span class="u-sr-only">Open language switcher</span>
+            <svg class="language-switcher__icon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                <path d="M3 5.25 7 9.25 11 5.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </button>
 
-        <ul class="language-switcher__list">
-            {% for language in languages %}
-                {% if not language.is_current %}
+        <div
+            id="{{ popover_id }}"
+            class="language-switcher__popover"
+            popover
+            aria-labelledby="{{ popover_id }}-toggle"
+            data-language-switcher-popover
+        >
+            <ul class="language-switcher__list">
+                {% for language in languages %}
                     <li class="language-switcher__item">
-                        <a
-                            href="{{ language.url }}"
-                            class="language-switcher__link"
-                            rel="alternate"
-                            hreflang="{{ language.code }}"
-                            lang="{{ language.code }}"
-                        >
-                            {{ language.name_local }}
-                        </a>
+                        {% if language.is_current %}
+                            <span
+                                class="language-switcher__link language-switcher__link--current"
+                                aria-current="page"
+                                lang="{{ language.code }}"
+                            >
+                                {{ language.name_local }}
+                            </span>
+                        {% else %}
+                            <a
+                                href="{{ language.url }}"
+                                class="language-switcher__link"
+                                rel="alternate"
+                                hreflang="{{ language.code }}"
+                                lang="{{ language.code }}"
+                            >
+                                {{ language.name_local }}
+                            </a>
+                        {% endif %}
                     </li>
-                {% endif %}
-            {% endfor %}
-        </ul>
+                {% endfor %}
+            </ul>
+        </div>
     </div>
 {% endif %}

--- a/bakerydemo/templates/includes/language_switcher.html
+++ b/bakerydemo/templates/includes/language_switcher.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% if render_language_switcher %}
     <div class="language-switcher language-switcher--{{ placement }}">
         <button
@@ -13,7 +14,7 @@
             <span class="language-switcher__current" lang="{{ current_language.code }}">
                 {{ current_language.name_local }}
             </span>
-            <span class="u-sr-only">Open language switcher</span>
+            <span class="u-sr-only">{% translate "Open language switcher" %}</span>
             <svg class="language-switcher__icon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
                 <path d="M3 5.25 7 9.25 11 5.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
             </svg>

--- a/bakerydemo/templates/tags/hreflangs.html
+++ b/bakerydemo/templates/tags/hreflangs.html
@@ -1,0 +1,3 @@
+{% for translation in translations %}
+    <link rel="alternate" hreflang="{{ translation.code }}" href="{{ translation.url }}">
+{% endfor %}

--- a/bakerydemo/urls.py
+++ b/bakerydemo/urls.py
@@ -1,5 +1,6 @@
 import debug_toolbar
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path, re_path
 from wagtail import urls as wagtail_urls
@@ -21,7 +22,6 @@ urlpatterns = [
         ServeView.as_view(),
         name="wagtailimages_serve",
     ),
-    path("search/", search_views.search, name="search"),
     path("sitemap.xml", sitemap),
     path("api/v2/", api_router.urls),
     path("__debug__/", include(debug_toolbar.urls)),
@@ -50,6 +50,7 @@ if settings.DEBUG:
         path("test500/", TemplateView.as_view(template_name="500.html")),
     ]
 
-urlpatterns += [
+urlpatterns += i18n_patterns(
+    path("search/", search_views.search, name="search"),
     path("", include(wagtail_urls)),
-]
+)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #757, and this PR builds on #759 

### Description

<!-- Please describe the problem you're fixing. -->
This adds the visible `language switcher UI` for `bakerydemo`, building on the earlier translation metadata and locale-aware routing groundwork. It uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/) for the language list UI and adds desktop and mobile placements for the switcher.

### Tested locally 

https://github.com/user-attachments/assets/53befd52-7213-4cfe-8f39-49d61840801e




### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used AI to help with the component structure, and I manually applied and verified the changes locally.