### PR TITLE
Multilingual theme groundwork

### DIFF
--- a/bakerydemo/static/js/location-status.js
+++ b/bakerydemo/static/js/location-status.js
@@ -7,12 +7,11 @@ class LocationStatus extends HTMLElement {
   async updateStatus() {
     const data = await this.fetchPage();
     if (!data || typeof data.is_open !== 'boolean') {
-      this.textContent =
-        "Sorry, we couldn't retrieve the status of this location.";
+      this.textContent = this.dataset.unavailableLabel;
     } else if (data.is_open) {
-      this.textContent = 'This location is currently open.';
+      this.textContent = this.dataset.availableLabel;
     } else {
-      this.textContent = 'Sorry, this location is currently closed.';
+      this.textContent = this.dataset.closedLabel;
     }
   }
 

--- a/bakerydemo/templates/404.html
+++ b/bakerydemo/templates/404.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}404 - Page not found{% endblock %}
+{% block title %}{% translate "404 - Page not found" %}{% endblock %}
 
-{% block search_description %}Sorry, this page could not be found{% endblock %}
+{% block search_description %}{% translate "Sorry, this page could not be found" %}{% endblock %}
 
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}
-    <h1>Page not found</h1>
+    <h1>{% translate "Page not found" %}</h1>
 
-    <h2>Sorry, this page could not be found.</h2>
+    <h2>{% translate "Sorry, this page could not be found." %}</h2>
 {% endblock content %}

--- a/bakerydemo/templates/500.html
+++ b/bakerydemo/templates/500.html
@@ -1,13 +1,16 @@
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8" />
-        <title>Internal server error</title>
+        <title>{% translate "Internal server error" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>
-        <h1>Internal server error</h1>
+        <h1>{% translate "Internal server error" %}</h1>
 
-        <h2>Sorry, there seems to be an error. Please try again soon.</h2>
+        <h2>{% translate "Sorry, there seems to be an error. Please try again soon." %}</h2>
     </body>
 </html>

--- a/bakerydemo/templates/base/basic_auth.html
+++ b/bakerydemo/templates/base/basic_auth.html
@@ -1,8 +1,11 @@
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8">
-        <title>Authentication Required</title>
+        <title>{% translate "Authentication Required" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         {# Prevent the demo site from being indexed #}
@@ -19,9 +22,9 @@
 
     <body>
         <article>
-            <h1>Authentication Required</h1>
-            <p>You must login to view this site</p>
-            <h3>Looking for Wagtail? Visit <a href="https://wagtail.org">wagtail.org</a>.</h3>
+            <h1>{% translate "Authentication Required" %}</h1>
+            <p>{% translate "You must login to view this site" %}</p>
+            <h3>{% blocktranslate trimmed %}Looking for Wagtail? Visit <a href="https://wagtail.org">wagtail.org</a>.{% endblocktranslate %}</h3>
         </article>
     </body>
 </html>

--- a/bakerydemo/templates/base/preview/static_embed_block.html
+++ b/bakerydemo/templates/base/preview/static_embed_block.html
@@ -1,9 +1,9 @@
 {% extends "wagtailcore/shared/block_preview.html" %}
-{% load static %}
+{% load i18n static %}
 
 {% block content %}
     <svg class="static-block-preview" viewBox="0 0 360 246">
-        <title>Preview of an embedded video</title>
+        <title>{% translate "Preview of an embedded video" %}</title>
         <rect fill="light-dark(#fff, #1d1d1d)" height="245.5" rx="10" width="360" y=".5" />
         <rect fill="light-dark(#e0e0e0, #464646)" height="211.5" rx="7" width="340" x="10" y="10.5" />
         <path

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -1,12 +1,16 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
 
 {% if tag %}
     {% block title %}
         {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
     {% endblock %}
 
-    {% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
+    {% block search_description %}
+        {% blocktranslate trimmed with tag_name=tag %}
+            Viewing all blog posts sorted by the tag {{ tag_name }}
+        {% endblocktranslate %}
+    {% endblock %}
 {% endif %}
 
 {% block content %}
@@ -18,18 +22,22 @@
         {% if tag %}
             <div class="row">
                 <div class="col-md-12">
-                    <h1 class="index-header__title">Blog</h1>
+                    <h1 class="index-header__title">{{ self.title }}</h1>
                 </div>
                 <div class="col-md-12">
-                    <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag }}</span>.</p>
+                    <p class="index-header__introduction">
+                        {% blocktranslate trimmed with tag_name=tag %}
+                            Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag_name }}</span>.
+                        {% endblocktranslate %}
+                    </p>
                 </div>
             </div>
         {% endif %}
 
         {% if page.get_child_tags %}
-            <nav aria-label="Blog tag filters">
+            <nav aria-label="{% translate 'Blog tag filters' %}">
                 <ul class="blog-tags">
-                    <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
+                    <li><span class="blog-tags__pill blog-tags__pill--selected">{% translate "All" %}</span></li>
                     {% for tag in page.get_child_tags %}
                         <li><a class="blog-tags__pill" href="{{ tag.url }}">{{ tag }}</a></li>
                     {% endfor %}
@@ -46,7 +54,7 @@
                 {% endwagtailcache %}
             {% else %}
                 <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
+                    <p>{% translate "Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry." %}</p>
                 </div>
             {% endif %}
         </div>

--- a/bakerydemo/templates/blog/blog_page.html
+++ b/bakerydemo/templates/blog/blog_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load navigation_tags wagtailimages_tags %}
+{% load i18n navigation_tags wagtailimages_tags %}
 
 {% block content %}
 
@@ -22,9 +22,9 @@
                 {{ page.body }}
 
                 {% if page.get_tags %}
-                    <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
+                    <p class="blog__tag-introduction">{% translate "Find more blog posts with similar tags" %}</p>
                     <div class="blog-tags blog-tags--condensed">
-                        <span class="u-sr-only">Filter blog posts by tag</span>
+                        <span class="u-sr-only">{% translate "Filter blog posts by tag" %}</span>
                         {% for tag in page.get_tags %}
                             <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
                         {% endfor %}

--- a/bakerydemo/templates/breads/bread_page.html
+++ b/bakerydemo/templates/breads/bread_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -25,16 +25,16 @@
                     <div class="row">
                         <div class="bread-detail__meta">
                             {% if page.origin %}
-                                <p class="bread-detail__meta-title">Origin</p>
+                                <p class="bread-detail__meta-title">{% translate "Origin" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.origin }}</p>
                             {% endif %}
                             {% if page.bread_type %}
-                                <p class="bread-detail__meta-title">Type</p>
+                                <p class="bread-detail__meta-title">{% translate "Type" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.bread_type }}</p>
                             {% endif %}
                             {% with ingredients=page.ordered_ingredients %}
                                 {% if ingredients %}
-                                    <h4>Ingredients</h4>
+                                    <h4>{% translate "Ingredients" %}</h4>
                                     <ul>
                                         {% for ingredient in ingredients %}
                                             <li>
@@ -44,9 +44,9 @@
                                                 {% else %}
                                                     {# EXAMPLE: we can show a placeholder element for instances that are not live #}
                                                     <span class="bread-detail__meta-ingredient--draft">
-                                                        Draft ingredient
+                                                        {% translate "Draft ingredient" %}
                                                     </span>
-                                                    (draft)
+                                                    ({% translate "draft" %})
                                                 {% endif %}
                                             </li>
                                         {% endfor %}

--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-index.html" %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% else %}
-            <p>No breads available at the moment.</p>
+            <p>{% translate "No breads available at the moment." %}</p>
         {% endif %}
     </div>
 

--- a/bakerydemo/templates/includes/card/listing-card.html
+++ b/bakerydemo/templates/includes/card/listing-card.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 <div class="listing-card">
     <a class="listing-card__link" href="{{ page.url }}">
@@ -17,13 +17,13 @@
                 <table class="listing-card__meta">
                     {% if page.origin %}
                         <tr>
-                            <th scope="row" class="listing-card__meta-category">Origin</th>
+                            <th scope="row" class="listing-card__meta-category">{% translate "Origin" %}</th>
                             <td class="listing-card__meta-content">{{ page.origin }}</td>
                         </tr>
                     {% endif %}
                     {% if page.bread_type %}
                         <tr>
-                            <th scope="row" class="listing-card__meta-category">Type</th>
+                            <th scope="row" class="listing-card__meta-category">{% translate "Type" %}</th>
                             <td class="listing-card__meta-content">{{ page.bread_type }}</td>
                         </tr>
                     {% endif %}

--- a/bakerydemo/templates/includes/footer.html
+++ b/bakerydemo/templates/includes/footer.html
@@ -1,4 +1,4 @@
-{% load navigation_tags static %}
+{% load i18n navigation_tags static %}
 
 <footer class="container">
     <div class="row">
@@ -8,21 +8,21 @@
                     <ul class="list-inline">
                         {% if github_url %}
                             <li class="footer__icon">
-                                <a href="{{ github_url }}" target="_blank" rel="noreferrer" aria-label="View Wagtail's source code on GitHub">
+                                <a href="{{ github_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "View Wagtail's source code on GitHub" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 496 512"><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
                                 </a>
                             </li>
                         {% endif %}
                         {% if mastodon_url %}
                             <li class="footer__icon">
-                                <a href="{{ mastodon_url }}" target="_blank" rel="noreferrer" aria-label="Wagtail's official Mastodon account">
+                                <a href="{{ mastodon_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "Wagtail's official Mastodon account" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M433 179.1c0-97.2-63.7-125.7-63.7-125.7-62.5-28.7-228.6-28.4-290.5 0 0 0-63.7 28.5-63.7 125.7 0 115.7-6.6 259.4 105.6 289.1 40.5 10.7 75.3 13 103.3 11.4 50.8-2.8 79.3-18.1 79.3-18.1l-1.7-36.9s-36.3 11.4-77.1 10.1c-40.4-1.4-83-4.4-89.6-54a102.5 102.5 0 0 1 -.9-13.9c85.6 20.9 158.7 9.1 178.8 6.7 56.1-6.7 105-41.3 111.2-72.9 9.8-49.8 9-121.5 9-121.5zm-75.1 125.2h-46.6v-114.2c0-49.7-64-51.6-64 6.9v62.5h-46.3V197c0-58.5-64-56.6-64-6.9v114.2H90.2c0-122.1-5.2-147.9 18.4-175 25.9-28.9 79.8-30.8 103.8 6.1l11.6 19.5 11.6-19.5c24.1-37.1 78.1-34.8 103.8-6.1 23.7 27.3 18.4 53 18.4 175z"/></svg>
                                 </a>
                             </li>
                         {% endif %}
                         {% if organisation_url %}
                             <li class="footer__icon">
-                                <a href="{{ organisation_url }}" target="_blank" rel="noreferrer" aria-label="Wagtail's official website">
+                                <a href="{{ organisation_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "Wagtail's official website" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 640 512"><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M579.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L422.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C206.5 251.2 213 330 263 380c56.5 56.5 148 56.5 204.5 0L579.8 267.7zM60.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C74 372 74 321 105.5 289.5L217.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C433.5 260.8 427 182 377 132c-56.5-56.5-148-56.5-204.5 0L60.2 244.3z"/></svg>
                                 </a>
                             </li>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -1,9 +1,9 @@
-{% load wagtailcore_tags navigation_tags %}
+{% load i18n wagtailcore_tags navigation_tags %}
 
 {% get_site_root as site_root %}
 
 <header class="header clearfix">
-    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <a href="#main-content" class="skip-link">{% translate "Skip to main content" %}</a>
     <div class="container">
         <div class="navigation" data-navigation>
             <a href="{% pageurl site_root %}" class="navigation__logo">The Wagtail Bakery</a>
@@ -11,7 +11,7 @@
             <button
                 type="button"
                 class="navigation__mobile-toggle"
-                aria-label="Toggle mobile menu"
+                aria-label="{% translate "Toggle mobile menu" %}"
                 aria-expanded="false"
                 data-mobile-navigation-toggle
             >
@@ -27,8 +27,8 @@
                     {% top_menu parent=site_root calling_page=self %}
                 </ul>
                 <form action="/search" method="get" class="navigation__mobile-search" role="search">
-                    <label for="mobile-search-input" class="u-sr-only">Search the bakery</label>
-                    <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="Search" autocomplete="off" name="q">
+                    <label for="mobile-search-input" class="u-sr-only">{% translate "Search the bakery" %}</label>
+                    <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="{% translate "Search" %}" autocomplete="off" name="q">
                     <div aria-hidden="true" class="navigation__search-icon">
                         <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="currentColor" />
@@ -37,7 +37,7 @@
                 </form>
             </nav>
 
-            <nav class="navigation__desktop" aria-label="Main">
+            <nav class="navigation__desktop" aria-label="{% translate "Main" %}">
                 <ul class="navigation__items nav-pills">
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}
                     {% top_menu parent=site_root calling_page=self %}
@@ -51,12 +51,12 @@
                 aria-label="Toggle dark theme"
                 aria-pressed="false"
             >
-                Theme
+                {% translate "Theme" %}
             </button>
 
             <form action="/search" method="get" class="navigation__search" role="search">
-                <label for="search-input" class="u-sr-only">Search the bakery</label>
-                <input class="navigation__search-input" id="search-input" type="text" placeholder="Search" autocomplete="off" name="q">
+                <label for="search-input" class="u-sr-only">{% translate "Search the bakery" %}</label>
+                <input class="navigation__search-input" id="search-input" type="text" placeholder="{% translate "Search" %}" autocomplete="off" name="q">
                 <div aria-hidden="true" class="navigation__search-icon">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="currentColor" />

--- a/bakerydemo/templates/includes/messages.html
+++ b/bakerydemo/templates/includes/messages.html
@@ -1,6 +1,7 @@
+{% load i18n %}
 {% if messages %}
     <div class="alert">
-        <p class="alert__title">Error</p>
+        <p class="alert__title">{% translate "Error" %}</p>
         <ul class="alert__messages">
             {% for message in messages %}
                 <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>

--- a/bakerydemo/templates/includes/pagination.html
+++ b/bakerydemo/templates/includes/pagination.html
@@ -1,20 +1,20 @@
-{% load navigation_tags %}
+{% load i18n navigation_tags %}
 
-<nav class="pagination" aria-label="Pagination">
+<nav class="pagination" aria-label="{% translate 'Pagination' %}">
     <ul class="pagination__list">
         {% if subpages.has_previous %}
             <li class="page-item">
-                <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">previous</a>
+                <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">{% translate "Previous" %}</a>
             </li>
         {% else %}
             <li class="page-item disabled">
-                <a class="page-link">previous</a>
+                <a class="page-link">{% translate "Previous" %}</a>
             </li>
         {% endif %}
 
         {% for i in subpages.paginator.page_range %}
             {% if subpages.number == i %}
-                <li class="page-item active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                <li class="page-item active"><span>{{ i }} <span class="sr-only">({% translate "current" %})</span></span></li>
             {% else %}
                 <li class="page-item"><a href="?page={{ i }}" class="page-link">{{ i }}</a></li>
             {% endif %}
@@ -22,11 +22,11 @@
 
         {% if subpages.has_next %}
             <li class="page-item">
-                <a href="?page={{ subpages.next_page_number }}" class="page-link next arrows">next</a>
+                <a href="?page={{ subpages.next_page_number }}" class="page-link next arrows">{% translate "Next" %}</a>
             </li>
         {% else %}
             <li class="page-item disabled">
-                <a class="page-link">next</a>
+                <a class="page-link">{% translate "Next" %}</a>
             </li>
         {% endif %}
     </ul>

--- a/bakerydemo/templates/locations/location_page.html
+++ b/bakerydemo/templates/locations/location_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags navigation_tags static %}
+{% load i18n wagtailimages_tags navigation_tags static %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -24,7 +24,7 @@
                 <div class="col-md-4 col-md-offset-1">
                     <div class="row">
                         <div class="bread-detail__meta">
-                            <h2 class="location__meta-title">Operating Status</h2>
+                            <h2 class="location__meta-title">{% translate "Operating status" %}</h2>
                             {% comment %}
                                 Fetch the status of the location on the client side
                                 as a Wagtail API usage example and to allow for
@@ -32,28 +32,33 @@
                             {% endcomment %}
                             {% if request.is_preview %}
                                 {% if page.is_open %}
-                                    This location is currently open.
+                                    {% translate "This location is currently open." %}
                                 {% else %}
-                                    Sorry, this location is currently closed.
+                                    {% translate "Sorry, this location is currently closed." %}
                                 {% endif %}
                             {% else %}
-                                <location-status url="{% url 'wagtailapi:pages:detail' page.pk %}">
-                                    Please wait…
+                                <location-status
+                                    url="{% url 'wagtailapi:pages:detail' page.pk %}"
+                                    data-open-label="{% translate 'This location is currently open.' %}"
+                                    data-closed-label="{% translate 'Sorry, this location is currently closed.' %}"
+                                    data-unavailable-label="{% translate "Sorry, we couldn't retrieve the status of this location." %}"
+                                >
+                                    {% translate "Please wait…" %}
                                 </location-status>
                             {% endif %}
 
 
-                            <h2 class="location__meta-title">Address</h2>
+                            <h2 class="location__meta-title">{% translate "Address" %}</h2>
                             <address>{{ page.address|linebreaks }}</address>
 
                             {% if page.operating_hours %}
-                                <h2 class="location__meta-title">Opening hours</h2>
+                                <h2 class="location__meta-title">{% translate "Opening hours" %}</h2>
                                 {% for hours in page.operating_hours %}
                                     <time itemprop="openingHours" datetime="{{ hours }}" class="location__time">
                                         <span class="location__day">{{ hours.day }}</span>:
                                         <span class="location__hours">
                                             {% if hours.closed == True %}
-                                                Closed
+                                                {% translate "Closed" %}
                                             {% else %}
                                                 {% if hours.opening_time %}
                                                     {{ hours.opening_time }}

--- a/bakerydemo/templates/people/person_page.html
+++ b/bakerydemo/templates/people/person_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -25,11 +25,11 @@
                     <div class="row">
                         <div class="bread-detail__meta">
                             {% if page.location %}
-                                <p class="bread-detail__meta-title">Location</p>
+                                <p class="bread-detail__meta-title">{% translate "Location" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.location }}</p>
                             {% endif %}
                             {% if page.social_links %}
-                                <p class="bread-detail__meta-title">Socials</p>
+                                <p class="bread-detail__meta-title">{% translate "Socials" %}</p>
                                 <div class="social-links">
                                     {% for block in page.social_links %}
                                         <a href="{{ block.value.url }}" target="_blank" rel="noopener noreferrer" title="{{ block.value.get_platform_label }}">

--- a/bakerydemo/templates/recipes/recipe_index_page.html
+++ b/bakerydemo/templates/recipes/recipe_index_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-index.html" %}
@@ -12,7 +12,7 @@
                 {% endfor %}
             {% else %}
                 <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any recipes. Sorry.</p>
+                    <p>{% translate "Oh, snap. Looks like we were too busy baking to write any recipes. Sorry." %}</p>
                 </div>
             {% endif %}
         </div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -1,9 +1,21 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags wagtailimages_tags wagtailsearchpromotions_tags %}
+{% load i18n wagtailcore_tags wagtailimages_tags wagtailsearchpromotions_tags %}
 
-{% block title %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block title %}
+    {% if search_query %}
+        {% blocktranslate trimmed with query=search_query %}Search results for “{{ query }}”{% endblocktranslate %}
+    {% else %}
+        {% translate "Search" %}
+    {% endif %}
+{% endblock %}
 
-{% block search_description %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block search_description %}
+    {% if search_query %}
+        {% blocktranslate trimmed with query=search_query %}Search results for “{{ query }}”{% endblocktranslate %}
+    {% else %}
+        {% translate "Search" %}
+    {% endif %}
+{% endblock %}
 
 {% block body_class %}template-search-results{% endblock %}
 
@@ -11,9 +23,15 @@
     <div class="container">
         <div class="row">
             <div class="col-md-8">
-                <h1>Search results</h1>
+                <h1>{% translate "Search results" %}</h1>
                 {% if search_results %}
-                    <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} result{{ search_results|length|pluralize }} found.</p>
+                    <p class="search__introduction">
+                        {% blocktranslate trimmed count result_count=search_results | length with query=search_query %}
+                            You searched for “{{ query }}”, {{ result_count }} result found.
+                        {% plural %}
+                            You searched for “{{ query }}”, {{ result_count }} results found.
+                        {% endblocktranslate %}
+                    </p>
                     <ul class="search__results">
                         {% for result in search_results %}
                             <li class="listing-card">
@@ -62,11 +80,11 @@
                                                 <h2 class="listing-card__title">{{ search_promotion.page.specific }}</h2>
                                                 <p class="listing-card__content-type">
                                                     {% if search_promotion.page.specific.content_type.model == "blogpage" %}
-                                                        Blog Post
+                                                        {% translate "Blog post" %}
                                                     {% elif search_promotion.page.specific.content_type.model == "locationpage" %}
-                                                        Location
+                                                        {% translate "Location" %}
                                                     {% else %}
-                                                        Bread
+                                                        {% translate "Bread" %}
                                                     {% endif %}
                                                 </p>
                                                 <p class="listing-card__description">
@@ -82,7 +100,7 @@
                                             <div class="listing-card__contents">
                                                 <h2 class="listing-card__title">{{ search_promotion.external_link_text }}</h2>
                                                 <p class="listing-card__content-type">
-                                                    External link
+                                                    {% translate "External link" %}
                                                 </p>
                                                 <p class="listing-card__description">
                                                     {% if search_promotion.description %}{{ search_promotion.description|richtext }}{% endif %}
@@ -94,10 +112,14 @@
                             {% endfor %}
                         </ul>
                     {% else %}
-                        <p class="search__introduction">No results found for “{{ search_query }}”.</p>
+                        <p class="search__introduction">
+                            {% blocktranslate trimmed with query=search_query %}
+                                No results found for “{{ query }}”.
+                            {% endblocktranslate %}
+                        </p>
                     {% endif %}
                 {% else %}
-                    <p class="search__introduction">You didn&apos;t search for anything!</p>
+                    <p class="search__introduction">{% translate "You didn&apos;t search for anything!" %}</p>
                 {% endif %}
             </div>
         </div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -26,7 +26,7 @@
                 <h1>{% translate "Search results" %}</h1>
                 {% if search_results %}
                     <p class="search__introduction">
-                        {% blocktranslate trimmed count result_count=search_results | length with query=search_query %}
+                        {% blocktranslate trimmed count result_count=search_results|length with query=search_query %}
                             You searched for “{{ query }}”, {{ result_count }} result found.
                         {% plural %}
                             You searched for “{{ query }}”, {{ result_count }} results found.

--- a/bakerydemo/templates/tags/breadcrumbs.html
+++ b/bakerydemo/templates/tags/breadcrumbs.html
@@ -1,7 +1,7 @@
-{% load wagtailcore_tags %}
+{% load i18n wagtailcore_tags %}
 
 {% if ancestors %}
-    <nav class="breadcrumb-container" aria-label="Breadcrumb">
+    <nav class="breadcrumb-container" aria-label="{% translate 'Breadcrumb' %}">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12">
@@ -10,7 +10,7 @@
                             {% if forloop.last %}
                                 <li aria-current="page">{{ ancestor }}</li>
                             {% else %}
-                                <li><a href="{% pageurl ancestor %}">{% if forloop.first %}Home{% else %}{{ ancestor }}{% endif %}</a>
+                                <li><a href="{% pageurl ancestor %}">{% if forloop.first %}{% translate "Home" %}{% else %}{{ ancestor }}{% endif %}</a>
                                     {% include "includes/chevron-icon.html" with class="breadcrumb__chevron-icon" %}</li>
                             {% endif %}
                         {% endfor %}


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Task of #758 

### Description

<!-- Please describe the problem you're fixing. -->
This PR adds the multilingual theme groundwork for `bakerydemo` as part of `#758`. It focuses on making shared site UI strings translation-ready. 

### Tested locally

Manually verified shared translated UI strings in the browser, including header and pagination changes. Added some screenshots :

<img width="1470" height="922" alt="Screenshot 2026-06-22 at 5 01 21 PM" src="https://github.com/user-attachments/assets/b64bf72e-22e1-413d-8854-676be400e8f1" />

<img width="1467" height="925" alt="Screenshot 2026-06-22 at 5 03 14 PM" src="https://github.com/user-attachments/assets/6d22bd71-e210-4ad4-90b7-555e0b81bbd9" />


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
I used AI to help with some of the code changes, especially in files such as the `search_results page` where direct change {%...%} was not working. I manually reviewed the final changes and verified them locally.
