### PR TITLE
RTL support groundwork

### DIFF
--- a/bakerydemo/base/blocks.py
+++ b/bakerydemo/base/blocks.py
@@ -59,13 +59,12 @@ class CaptionedImageBlock(StructBlock):
 
 class HeadingBlock(StructBlock):
     """
-    Custom `StructBlock` that allows the user to select h2 - h4 sizes for headers
+    Custom `StructBlock` that allows the user to select h2 - h4 sizes for headings
     """
 
     heading_text = CharBlock(classname="title", required=True)
     size = ChoiceBlock(
         choices=[
-            ("", "Select a header size"),
             ("h2", "H2"),
             ("h3", "H3"),
             ("h4", "H4"),

--- a/bakerydemo/base/migrations/0001_initial.py
+++ b/bakerydemo/base/migrations/0001_initial.py
@@ -168,7 +168,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -288,7 +287,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -430,7 +428,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -623,7 +620,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),

--- a/bakerydemo/base/migrations/0002_auto_20170329_0055.py
+++ b/bakerydemo/base/migrations/0002_auto_20170329_0055.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -116,7 +115,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -200,7 +198,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -284,7 +281,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/base/migrations/0008_use_json_field_for_body_streamfield.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -117,7 +116,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -202,7 +200,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),
@@ -287,7 +284,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/base/migrations/0024_alter_formpage_body_alter_gallerypage_body_and_more.py
+++ b/bakerydemo/base/migrations/0024_alter_formpage_body_alter_gallerypage_body_and_more.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -118,7 +117,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -203,7 +201,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -288,7 +285,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/base/migrations/0026_alter_formpage_body_alter_gallerypage_body_and_more.py
+++ b/bakerydemo/base/migrations/0026_alter_formpage_body_alter_gallerypage_body_and_more.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -142,7 +141,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -251,7 +249,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -360,7 +357,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/blog/migrations/0001_initial.py
+++ b/bakerydemo/blog/migrations/0001_initial.py
@@ -60,7 +60,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -186,7 +185,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),

--- a/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/blog/migrations/0003_auto_20170329_0055.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/blog/migrations/0005_use_json_field_for_body_streamfield.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/blog/migrations/0007_alter_blogpage_body.py
+++ b/bakerydemo/blog/migrations/0007_alter_blogpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/blog/migrations/0008_alter_blogpage_body.py
+++ b/bakerydemo/blog/migrations/0008_alter_blogpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/breads/migrations/0001_initial.py
+++ b/bakerydemo/breads/migrations/0001_initial.py
@@ -74,7 +74,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -185,7 +184,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),

--- a/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/breads/migrations/0003_auto_20170329_0055.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/breads/migrations/0004_use_json_field_for_body_streamfield.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/breads/migrations/0008_alter_breadpage_body.py
+++ b/bakerydemo/breads/migrations/0008_alter_breadpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/breads/migrations/0009_alter_breadpage_body.py
+++ b/bakerydemo/breads/migrations/0009_alter_breadpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/breads/wagtail_hooks.py
+++ b/bakerydemo/breads/wagtail_hooks.py
@@ -28,6 +28,7 @@ class BreadIngredientSnippetViewSet(SnippetViewSet):
     search_fields = ("name",)
     filterset_class = BreadIngredientFilterSet
     inspect_view_enabled = True
+    menu_order = 999 # will place it last.
 
 
 class BreadTypeFilterSet(RevisionFilterSetMixin, WagtailFilterSet):

--- a/bakerydemo/locations/migrations/0001_initial.py
+++ b/bakerydemo/locations/migrations/0001_initial.py
@@ -104,7 +104,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -241,7 +240,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),

--- a/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
+++ b/bakerydemo/locations/migrations/0003_auto_20170329_0055.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
+++ b/bakerydemo/locations/migrations/0005_use_json_field_for_body_streamfield.py
@@ -34,7 +34,6 @@ class Migration(migrations.Migration):
                                     wagtail.blocks.ChoiceBlock(
                                         blank=True,
                                         choices=[
-                                            ("", "Select a header size"),
                                             ("h2", "H2"),
                                             ("h3", "H3"),
                                             ("h4", "H4"),

--- a/bakerydemo/locations/migrations/0007_alter_locationpage_body.py
+++ b/bakerydemo/locations/migrations/0007_alter_locationpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/locations/migrations/0008_alter_locationpage_body.py
+++ b/bakerydemo/locations/migrations/0008_alter_locationpage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/people/migrations/0001_initial.py
+++ b/bakerydemo/people/migrations/0001_initial.py
@@ -91,7 +91,6 @@ class Migration(migrations.Migration):
                                 {
                                     "blank": True,
                                     "choices": [
-                                        ("", "Select a header size"),
                                         ("h2", "H2"),
                                         ("h3", "H3"),
                                         ("h4", "H4"),

--- a/bakerydemo/recipes/migrations/0001_initial.py
+++ b/bakerydemo/recipes/migrations/0001_initial.py
@@ -86,7 +86,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),
@@ -180,7 +179,6 @@ class Migration(migrations.Migration):
                                             wagtail.blocks.ChoiceBlock(
                                                 blank=True,
                                                 choices=[
-                                                    ("", "Select a header size"),
                                                     ("h2", "H2"),
                                                     ("h3", "H3"),
                                                     ("h4", "H4"),

--- a/bakerydemo/recipes/migrations/0002_alter_recipepage_body.py
+++ b/bakerydemo/recipes/migrations/0002_alter_recipepage_body.py
@@ -39,7 +39,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/recipes/migrations/0003_alter_recipepage_backstory_alter_recipepage_body.py
+++ b/bakerydemo/recipes/migrations/0003_alter_recipepage_backstory_alter_recipepage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -124,7 +123,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/recipes/migrations/0004_alter_recipepage_backstory_alter_recipepage_body.py
+++ b/bakerydemo/recipes/migrations/0004_alter_recipepage_backstory_alter_recipepage_body.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),
@@ -148,7 +147,6 @@ class Migration(migrations.Migration):
                         {
                             "blank": True,
                             "choices": [
-                                ("", "Select a header size"),
                                 ("h2", "H2"),
                                 ("h3", "H3"),
                                 ("h4", "H4"),

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -200,6 +200,55 @@ STORAGES = {
     },
 }
 
+# Logging
+# This logging is configured to be used with Sentry and console logs. Console
+# logs are widely used by platforms offering Docker deployments, e.g. Heroku.
+# We use Sentry to only send error logs so we're notified about errors that are
+# not Python exceptions.
+# We do not use default mail or file handlers because they are of no use for
+# us.
+# https://docs.djangoproject.com/en/stable/topics/logging/
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        # Send logs with at least INFO level to the console.
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "formatters": {
+        "verbose": {
+            "format": "[%(asctime)s][%(process)d][%(levelname)s][%(name)s] %(message)s"
+        }
+    },
+    "loggers": {
+        "wagtailkit_repo_name": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "wagtail": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "django.security": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "xff": {"handlers": ["console"], "level": "WARNING", "propagate": False},
+    },
+}
+
 # Override in local settings or replace with your own key. Please don't use our demo key in production!
 GOOGLE_MAP_API_KEY = "AIzaSyD31CT9P9KxvNUJOwDq2kcFEIG8ADgaFgw"
 

--- a/bakerydemo/settings/production.py
+++ b/bakerydemo/settings/production.py
@@ -251,7 +251,7 @@ if os.environ.get("BASIC_AUTH_ENABLED", "false").lower().strip() == "true":
 
 # Force HTTPS redirect (enabled by default!)
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-ssl-redirect
-SECURE_SSL_REDIRECT = True
+SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT", "True").lower() == "true"
 
 # This will allow the cache to swallow the fact that the website is behind TLS
 # and inform the Django using "X-Forwarded-Proto" HTTP header.

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -23,6 +23,9 @@ each detail view
 :root {
   color-scheme: light dark;
 
+  --page-bg: light-dark(#fff, #11161d);
+  --surface-bg: light-dark(#fff, #11161d);
+  --surface-alt: light-dark(#f5f3e9, #1a222d);
   --dark: light-dark(#333, #f1f4f8);
   --grey: light-dark(#6e6e6e, #acb5c0);
   --border-grey: light-dark(#e1dcd3, #3e4855);
@@ -30,14 +33,14 @@ each detail view
     rgb(135 116 79 / 25%),
     rgb(164 180 201 / 30%)
   );
-  --white: light-dark(#fff, #11161d);
-  --cream: light-dark(#f5f3e9, #1a222d);
+  --white: #fff;
+  --cream: var(--surface-alt);
   --light-brown: light-dark(#87744f, #c8b083);
   --mid-brown: light-dark(#825600, #f0b45d);
   --dark-brown: light-dark(#553801, #ffe0b0);
   --orange: light-dark(#c55302, #f0b45d);
   --dark-orange: light-dark(#833701, #ffd29b);
-  --black: light-dark(#000, #d9d3d3);
+  --black: #000;
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
   --overlay-black: rgb(0 0 0 / 60%);
@@ -85,7 +88,7 @@ body {
   line-height: 1.5;
   padding-top: 0;
   padding-bottom: 0;
-  background: var(--white);
+  background: var(--page-bg);
   color: var(--dark);
   min-height: 100vh;
 }
@@ -485,7 +488,7 @@ caption {
 .header {
   padding: 0;
   width: 100%;
-  background: var(--white);
+  background: var(--surface-bg);
   z-index: 10;
 }
 
@@ -494,7 +497,7 @@ caption {
   position: absolute;
   top: -100%;
   padding: 20px;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
 }
 
 .skip-link:focus {
@@ -581,7 +584,7 @@ caption {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
   z-index: 10;
   display: flex;
   flex-direction: column;
@@ -919,7 +922,7 @@ hr {
 
 footer {
   padding: 55px 0 30px;
-  background-color: var(--white);
+  background-color: var(--surface-bg);
 }
 
 .footer__icon a {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -55,22 +55,6 @@ each detail view
   /* stylelint-enable */
   --font-sm: 1rem;
   --font-md: 1.125rem;
-  --text-on-media: #fff;
-}
-
-:root[data-theme='dark'] {
-  --dark: #f1f4f8;
-  --grey: #acb5c0;
-  --border-grey: #3e4855;
-  --transparent-border: rgb(164 180 201 / 30%);
-  --white: #11161d;
-  --cream: #1a222d;
-  --light-brown: #c8b083;
-  --mid-brown: #f0b45d;
-  --dark-brown: #ffe0b0;
-  --orange: #f0b45d;
-  --dark-orange: #ffd29b;
-  --text-on-media: #fff;
 }
 
 html {
@@ -91,10 +75,6 @@ body {
   background: var(--page-bg);
   color: var(--dark);
   min-height: 100vh;
-}
-
-html[data-theme='dark'] {
-  color-scheme: dark;
 }
 
 body.no-scroll {
@@ -383,7 +363,7 @@ caption {
 }
 
 .hero__title {
-  color: var(--text-on-media);
+  color: var(--white);
   font-weight: 400;
   font-size: 2.875rem;
   line-height: 1.09;
@@ -644,7 +624,6 @@ caption {
   position: absolute;
   right: 13px;
   top: 13px;
-  color: var(--dark);
 }
 
 @media (min-width: 768px) {
@@ -654,29 +633,11 @@ caption {
 }
 
 .navigation__search-input {
-  background-color: var(--white);
   color: var(--dark);
   font-size: var(--font-sm);
   line-height: 1.5;
   border: 1px solid var(--dark);
   padding: 10px;
-}
-
-.navigation__theme-toggle {
-  appearance: none;
-  margin: 0 0 0 10px;
-  border: 1px solid var(--dark);
-  background-color: var(--white);
-  color: var(--dark);
-  padding: 10px 12px;
-  font-size: 0.875rem;
-  line-height: 1;
-}
-
-.navigation__theme-toggle:hover,
-.navigation__theme-toggle:focus {
-  background-color: var(--dark);
-  color: var(--white);
 }
 
 .navigation__items {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -296,7 +296,7 @@ caption {
 .alert__messages {
   list-style-type: none;
   margin: 0;
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 /* Hero image area */
@@ -345,6 +345,14 @@ caption {
       var(--transparent-black) 100%
     );
   }
+
+  html[dir='rtl'] .hero-gradient-mask {
+    background: linear-gradient(
+      270deg,
+      var(--black) 11.33%,
+      var(--transparent-black) 100%
+    );
+  }
 }
 
 .hero__container {
@@ -381,14 +389,15 @@ caption {
     padding: 75px 65px;
     position: absolute;
     bottom: 0;
-    left: 0;
+    inset-inline-start: 0;
     transform: translateY(50%);
   }
 }
 
 .blockquote {
-  border-left: 3px solid var(--orange);
-  padding: 30px 0 10px 20px;
+  border-inline-start: 3px solid var(--orange);
+  padding-block: 30px 10px;
+  padding-inline: 20px 0;
   color: var(--orange);
 
   .text {
@@ -459,8 +468,7 @@ caption {
 @media screen and (min-width: 768px) {
   .header,
   .footer {
-    padding-right: 0;
-    padding-left: 0;
+    padding-inline: 0;
   }
 }
 
@@ -561,8 +569,7 @@ caption {
 .navigation__mobile {
   position: absolute;
   top: 0;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   bottom: 0;
   background-color: var(--surface-bg);
   z-index: 10;
@@ -583,7 +590,7 @@ caption {
   position: absolute;
   z-index: 15;
   top: 30px;
-  right: 20px;
+  inset-inline-end: 20px;
 }
 
 @media (min-width: 1150px) {
@@ -622,7 +629,7 @@ caption {
 .navigation__search-icon {
   display: block;
   position: absolute;
-  right: 13px;
+  inset-inline-end: 13px;
   top: 13px;
 }
 
@@ -643,7 +650,8 @@ caption {
 .navigation__items {
   list-style: none;
   margin: 0;
-  padding: 20px 0 0;
+  padding: 0;
+  padding-block-start: 20px;
 }
 
 .navigation__desktop {
@@ -657,11 +665,13 @@ caption {
 
   .navigation__search {
     display: block;
-    margin: 0 0 0 16px;
+    margin: 0;
+    margin-inline-start: 10px;
   }
 
   .navigation__items {
-    padding: 0 0 0 20px;
+    padding: 0;
+    padding-inline-start: 20px;
   }
 }
 
@@ -770,7 +780,8 @@ html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::after {
   }
 
   .navigation__items > li {
-    padding: 0 0 0 20px;
+    padding: 0;
+    padding-inline-start: 20px;
   }
 
   .navigation__items > li > a {
@@ -778,7 +789,8 @@ html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::after {
   }
 
   .navigation__items > li:first-child {
-    padding: 0 0 0 20px;
+    padding: 0;
+    padding-inline-start: 20px;
   }
 }
 
@@ -857,7 +869,7 @@ html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::after {
   .navigation__logo::after {
     content: '';
     position: absolute;
-    right: -20px;
+    inset-inline-end: -20px;
     top: -5px;
     bottom: 0;
     width: 1px;
@@ -910,15 +922,13 @@ footer {
 
 .container {
   width: auto;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-inline: 20px;
 }
 
 @media (min-width: 768px) {
   .container {
     max-width: 1400px;
-    padding-left: 40px;
-    padding-right: 40px;
+    padding-inline: 40px;
   }
 }
 
@@ -939,7 +949,7 @@ footer {
   font-size: var(--font-sm);
   line-height: 1.5;
   margin-bottom: 0;
-  padding-left: 0;
+  padding-inline-start: 0;
   background-color: transparent;
 }
 
@@ -976,7 +986,7 @@ footer {
   justify-content: center;
   gap: 20px;
   list-style-type: none;
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .pagination .page-item a {
@@ -1007,7 +1017,7 @@ footer {
 
 .search__results {
   list-style-type: none;
-  padding-left: 0;
+  padding-inline-start: 0;
   margin-bottom: 90px;
 }
 
@@ -1064,7 +1074,7 @@ footer {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  padding-left: 0;
+  padding-inline-start: 0;
   row-gap: 25px;
   column-gap: 15px;
   margin-bottom: 70px;
@@ -1080,7 +1090,7 @@ footer {
   line-height: 1.55;
   border: 1px solid var(--orange);
   border-radius: 60px;
-  margin-left: 20px;
+  margin-inline-start: 20px;
   text-transform: capitalize;
 }
 
@@ -1095,7 +1105,7 @@ footer {
 }
 
 .blog-tags__pill:first-child {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 .blog-tags__pill:hover {
@@ -1130,7 +1140,7 @@ footer {
 
 .blog-list-item .image {
   overflow: hidden;
-  background-color: var(--bright-orange);
+  background-color: var(--vivid-orange);
   flex: 1 0 auto;
 }
 
@@ -1183,7 +1193,7 @@ footer {
   border-radius: 100%;
   display: inline;
   width: unset;
-  margin-right: 10px;
+  margin-inline-end: 10px;
 }
 
 .blog__avatars {
@@ -1195,7 +1205,7 @@ footer {
   font-size: 1.375rem;
   line-height: 1.18;
   display: inline-block;
-  margin-right: 40px;
+  margin-inline-end: 40px;
   margin-bottom: 10px;
 }
 
@@ -1266,7 +1276,7 @@ footer {
 /* ---- Bread Index Page ---- */
 .bread-list {
   list-style-type: none;
-  padding-left: 0;
+  padding-inline-start: 0;
   padding-bottom: 40px;
 }
 
@@ -1314,7 +1324,7 @@ footer {
 .bread-detail__meta {
   background-color: var(--cream);
   padding: 40px;
-  margin-right: -15px;
+  margin-inline-end: -15px;
   margin-bottom: 60px;
 }
 
@@ -1352,7 +1362,7 @@ footer {
   .bread-detail__meta {
     background-color: var(--cream);
     padding: 240px 60px 60px;
-    margin-right: -40px;
+    margin-inline-end: -40px;
     margin-bottom: 0;
   }
 }
@@ -1390,7 +1400,7 @@ select {
 .form-page li input[type='checkbox'],
 input[type='radio'] {
   display: inline-block;
-  margin-right: 10px;
+  margin-inline-end: 10px;
 }
 
 .form-page__field ul,
@@ -1578,7 +1588,7 @@ input[type='radio'] {
 @media (min-width: 768px) {
   .homepage .promo-row {
     padding-top: 80px;
-    margin-right: -40px;
+    margin-inline-end: -40px;
   }
 }
 
@@ -1619,14 +1629,14 @@ input[type='radio'] {
 @media (min-width: 768px) {
   .homepage .promo {
     margin-top: -180px;
-    margin-right: -120px;
+    margin-inline-end: -120px;
     padding: 180px 60px 40px;
   }
 
   .homepage .promo figure img {
     width: calc(100% + 60px);
     height: auto;
-    margin-right: -60px;
+    margin-inline-end: -60px;
     margin-bottom: -280px;
     padding-top: 20px;
   }
@@ -1642,7 +1652,7 @@ input[type='radio'] {
 /* #region -- Featured Cards Section -- */
 .homepage .featured-cards__list {
   list-style: none;
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .homepage .featured-cards__title {
@@ -1661,7 +1671,7 @@ input[type='radio'] {
 }
 
 .homepage .featured-cards__chevron-icon {
-  margin-left: 8px;
+  margin-inline-start: 8px;
   width: 8px;
   height: 22px;
   transition: transform ease 0.1s;
@@ -1678,7 +1688,7 @@ input[type='radio'] {
 
 @media (min-width: 768px) {
   .homepage .featured-cards {
-    padding-right: 50px;
+    padding-inline-end: 50px;
   }
 
   .homepage .featured-cards__link {
@@ -1713,7 +1723,7 @@ input[type='radio'] {
 
 @media (min-width: 768px) {
   .homepage .locations-section {
-    text-align: left;
+    text-align: start;
     padding: 120px 0 160px;
   }
 
@@ -1722,7 +1732,7 @@ input[type='radio'] {
     line-height: 1.07;
 
     /* Aligns title with below cards */
-    padding-left: 10px;
+    padding-inline-start: 10px;
   }
 }
 
@@ -1783,8 +1793,7 @@ input[type='radio'] {
 
 /* No gutters */
 .row.no-gutters {
-  margin-right: 0;
-  margin-left: 0;
+  margin-inline: 0;
 }
 
 @media (max-width: 970px) {
@@ -1795,8 +1804,7 @@ input[type='radio'] {
 
 .row.no-gutters > [class^='col-'],
 .row.no-gutters > [class*=' col-'] {
-  padding-right: 0;
-  padding-left: 0;
+  padding-inline: 0;
 }
 
 /* Bootstrap Equal height rows */
@@ -1819,12 +1827,12 @@ input[type='radio'] {
 
 /* From Wagtail core */
 .richtext-image.left {
-  float: left;
+  float: inline-start;
   width: 50%;
 }
 
 .richtext-image.right {
-  float: right;
+  float: inline-end;
   width: 50%;
 }
 
@@ -1864,8 +1872,7 @@ input[type='radio'] {
   content: '';
   position: absolute;
   height: 200px;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   bottom: 0;
   background: linear-gradient(
     180deg,
@@ -1879,9 +1886,8 @@ input[type='radio'] {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
-  right: 0;
-  text-align: left;
+  inset-inline: 0;
+  text-align: start;
   display: flex;
   align-items: end;
   padding: 20px;
@@ -1920,7 +1926,7 @@ input[type='radio'] {
 
 .listing-card__contents {
   padding-top: 10px;
-  padding-left: 25px;
+  padding-inline-start: 25px;
 }
 
 .listing-card__title {
@@ -1932,7 +1938,7 @@ input[type='radio'] {
   color: var(--grey);
   font-size: 0.875rem;
   line-height: 1.57;
-  padding-right: 10px;
+  padding-inline-end: 10px;
   vertical-align: top;
 }
 
@@ -1970,7 +1976,7 @@ input[type='radio'] {
 
 @media (min-width: 768px) {
   .listing-card__contents {
-    padding-left: 45px;
+    padding-inline-start: 45px;
     padding-top: 30px;
   }
 
@@ -2065,7 +2071,7 @@ input[type='radio'] {
 
   .blog-listing-card__contents {
     padding-top: 30px;
-    padding-left: 45px;
+    padding-inline-start: 45px;
   }
 
   .blog-listing-card__title {
@@ -2094,7 +2100,7 @@ input[type='radio'] {
   display: flex;
   flex-direction: column;
   margin: 0 auto 50px;
-  text-align: left;
+  text-align: start;
 }
 
 .location-card:hover .location-card__image img {
@@ -2130,8 +2136,7 @@ input[type='radio'] {
   content: '';
   bottom: 3px;
   position: absolute;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   height: 2px;
   background-color: var(--dark-orange);
   opacity: 0;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -1373,7 +1373,7 @@ select {
 
 .form-page input[type='submit'] {
   border: none;
-  color: var(--white);
+  color: light-dark(var(--white), var(--black));
   background-color: var(--orange);
   font-weight: 700;
   padding: 15px 25px;
@@ -1495,7 +1495,7 @@ input[type='radio'] {
 }
 
 .homepage .home-hero .hero-cta-link {
-  color: var(--white);
+  color: light-dark(var(--white), var(--black));
   background-color: var(--orange);
   font-weight: 700;
   padding: 15px 25px;
@@ -1507,7 +1507,7 @@ input[type='radio'] {
 }
 
 .homepage .home-hero .hero-cta-link:hover {
-  background-color: var(--white);
+  background-color: light-dark(var(--white), var(--black));
   color: var(--dark-orange);
 }
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -37,8 +37,7 @@ each detail view
   --dark-brown: light-dark(#553801, #ffe0b0);
   --orange: light-dark(#c55302, #f0b45d);
   --dark-orange: light-dark(#833701, #ffd29b);
-  --color-text: light-dark(#333, #f1f4f8);
-  --black: #000;
+  --black: light-dark(#000, #d9d3d3);
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
   --overlay-black: rgb(0 0 0 / 60%);
@@ -112,7 +111,7 @@ h2,
 h3 {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 h1 {
@@ -136,7 +135,7 @@ h4 {
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.35;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 p {
@@ -145,7 +144,7 @@ p {
   font-weight: 400;
   font-size: var(--font-sm);
   line-height: 1.5;
-  color: var(--color-text);
+  color: var(--dark);
 }
 
 @media (min-width: 768px) {
@@ -187,7 +186,7 @@ ul {
 }
 
 .hero h1 {
-  color: var(--color-text);
+  color: var(--white);
   position: relative;
 }
 
@@ -1518,7 +1517,7 @@ input[type='radio'] {
 .homepage .home-hero .lead {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--color-text);
+  color: var(--white);
   margin: 40px auto;
   font-size: 1.625rem;
   line-height: 1.15;
@@ -1881,7 +1880,7 @@ input[type='radio'] {
 }
 
 .picture-card__title {
-  color: var(--color-text);
+  color: var(--white);
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -21,17 +21,23 @@ each detail view
 
 /* CSS Variables */
 :root {
-  --dark: #333;
-  --grey: #6e6e6e;
-  --border-grey: #e1dcd3;
-  --transparent-border: rgb(135 116 79 / 25%);
-  --white: #fff;
-  --cream: #f5f3e9;
-  --light-brown: #87744f;
-  --mid-brown: #825600;
-  --dark-brown: #553801;
-  --orange: #c55302;
-  --dark-orange: #833701;
+  color-scheme: light dark;
+
+  --dark: light-dark(#333, #f1f4f8);
+  --grey: light-dark(#6e6e6e, #acb5c0);
+  --border-grey: light-dark(#e1dcd3, #3e4855);
+  --transparent-border: light-dark(
+    rgb(135 116 79 / 25%),
+    rgb(164 180 201 / 30%)
+  );
+  --white: light-dark(#fff, #11161d);
+  --cream: light-dark(#f5f3e9, #1a222d);
+  --light-brown: light-dark(#87744f, #c8b083);
+  --mid-brown: light-dark(#825600, #f0b45d);
+  --dark-brown: light-dark(#553801, #ffe0b0);
+  --orange: light-dark(#c55302, #f0b45d);
+  --dark-orange: light-dark(#833701, #ffd29b);
+  --color-text: light-dark(#333, #f1f4f8);
   --black: #000;
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
@@ -106,7 +112,7 @@ h2,
 h3 {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 h1 {
@@ -130,7 +136,7 @@ h4 {
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.35;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 p {
@@ -139,7 +145,7 @@ p {
   font-weight: 400;
   font-size: var(--font-sm);
   line-height: 1.5;
-  color: var(--dark);
+  color: var(--color-text);
 }
 
 @media (min-width: 768px) {
@@ -181,7 +187,7 @@ ul {
 }
 
 .hero h1 {
-  color: var(--text-on-media);
+  color: var(--color-text);
   position: relative;
 }
 
@@ -688,15 +694,98 @@ caption {
 
   .navigation__search {
     display: block;
-    margin: 0 0 0 10px;
+    margin: 0 0 0 16px;
   }
 
   .navigation__items {
     padding: 0 0 0 20px;
   }
+}
 
-  .navigation__theme-toggle {
-    margin: 0 0 0 auto;
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  margin: 15px 12px 0 auto;
+}
+
+.theme-toggle--mobile {
+  margin: 20px 0 0;
+}
+
+.theme-toggle__label {
+  color: var(--dark);
+  font-family: var(--font--secondary);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.theme-toggle__button {
+  padding: 0;
+  width: 48px;
+  height: 28px;
+  border: 0;
+  outline: none;
+  overflow: hidden;
+  position: relative;
+  border-radius: 14px;
+  margin: 0 8px;
+  display: inline-block;
+  cursor: pointer;
+  background: light-dark(var(--grey), var(--light-grey));
+}
+
+.theme-toggle__button::before {
+  top: 4px;
+  inset-inline-start: 24px;
+  content: '';
+  width: 20px;
+  height: 20px;
+  display: block;
+  position: absolute;
+  border-radius: 12px;
+  background-color: light-dark(var(--light-grey), var(--black));
+  transition: inset-inline-start 0.2s ease-in-out;
+}
+
+.theme-toggle__button::after {
+  content: '';
+  top: 14px;
+  inset-inline-end: 2px;
+  width: 1px;
+  height: 1px;
+  display: block;
+  position: absolute;
+  border-radius: 0.5px;
+  background: light-dark(var(--dark), var(--light-grey));
+}
+
+.dark-only {
+  display: none;
+}
+
+html:has([name='color-scheme'][content^='dark']) .dark-only {
+  display: block;
+}
+
+html:has([name='color-scheme'][content^='dark']) .light-only {
+  display: none;
+}
+
+html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::before {
+  inset-inline-start: 4px;
+}
+
+html:has([name='color-scheme'][content^='dark']) .theme-toggle__button::after {
+  top: -2px;
+  inset-inline-end: 2px;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+}
+
+@media (min-width: 1150px) {
+  .theme-toggle {
+    margin: 0 24px 0 auto;
   }
 }
 
@@ -1429,7 +1518,7 @@ input[type='radio'] {
 .homepage .home-hero .lead {
   font-family: var(--font--primary);
   font-weight: 400;
-  color: var(--text-on-media);
+  color: var(--color-text);
   margin: 40px auto;
   font-size: 1.625rem;
   line-height: 1.15;
@@ -1792,7 +1881,7 @@ input[type='radio'] {
 }
 
 .picture-card__title {
-  color: var(--text-on-media);
+  color: var(--color-text);
   font-family: var(--font--primary);
   font-size: 1.625rem;
   line-height: 1.15;

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -44,7 +44,7 @@ each detail view
   --transparent-black: rgb(0 0 0 / 0%);
   --shadow-black: rgb(0 0 0 / 50%);
   --overlay-black: rgb(0 0 0 / 60%);
-  --bright-orange: #eb7400;
+  --vivid-orange: #eb7400;
   --light-grey: #e3e3e3;
   --font--primary: 'Marcellus', serif;
   /* stylelint-disable */
@@ -990,7 +990,6 @@ footer {
 }
 
 .pagination .page-item a {
-  text-transform: capitalize;
   text-decoration: underline;
 }
 
@@ -1091,7 +1090,6 @@ footer {
   border: 1px solid var(--orange);
   border-radius: 60px;
   margin-inline-start: 20px;
-  text-transform: capitalize;
 }
 
 .blog-tags__pill--selected {
@@ -1115,7 +1113,6 @@ footer {
 
 .blog-tags__tag {
   color: var(--orange);
-  text-transform: capitalize;
 }
 
 .blog-list {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -472,6 +472,27 @@ caption {
   }
 }
 
+html[dir='rtl'] [class^='col-'],
+html[dir='rtl'] [class*=' col-'] {
+  float: inline-start;
+}
+
+@media (min-width: 768px) {
+  html[dir='rtl'] .col-sm-offset-1 {
+    margin-inline: 8.33333333% 0;
+  }
+}
+
+@media (min-width: 992px) {
+  html[dir='rtl'] .col-md-offset-1 {
+    margin-inline: 8.33333333% 0;
+  }
+
+  html[dir='rtl'] .col-md-offset-2 {
+    margin-inline: 16.66666667% 0;
+  }
+}
+
 /* Page header */
 .header {
   padding: 0;
@@ -583,7 +604,8 @@ caption {
 .navigation__mobile-toggle {
   background-color: transparent;
   border: none;
-  margin: 0 0 0 auto;
+  margin: 0;
+  margin-inline-start: auto;
 }
 
 .navigation__mobile-toggle[aria-expanded='true'] {

--- a/bakerydemo/static/js/location-status.js
+++ b/bakerydemo/static/js/location-status.js
@@ -7,12 +7,11 @@ class LocationStatus extends HTMLElement {
   async updateStatus() {
     const data = await this.fetchPage();
     if (!data || typeof data.is_open !== 'boolean') {
-      this.textContent =
-        "Sorry, we couldn't retrieve the status of this location.";
+      this.textContent = this.dataset.unavailableLabel;
     } else if (data.is_open) {
-      this.textContent = 'This location is currently open.';
+      this.textContent = this.dataset.availableLabel;
     } else {
-      this.textContent = 'Sorry, this location is currently closed.';
+      this.textContent = this.dataset.closedLabel;
     }
   }
 

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,45 +1,59 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navigation = document.querySelector('[data-navigation]');
-  const themeToggle = document.querySelector('[data-theme-toggle]');
-  const htmlElement = document.documentElement;
-  const storage = {
-    get(key) {
-      try {
-        return localStorage.getItem(key);
-      } catch {
-        return null;
-      }
-    },
-    set(key, value) {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        // Ignore storage failures and keep the theme change in-memory only.
-      }
-    },
-  };
+  const body = document.querySelector('body');
+  const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+  const mobileNavigation = navigation?.querySelector(
+    '[data-mobile-navigation]',
+  );
+  const mobileNavigationToggle = navigation?.querySelector(
+    '[data-mobile-navigation-toggle]',
+  );
+  const themeToggles = document.querySelectorAll('[data-theme-toggle]');
 
-  function updateThemeToggleLabel() {
-    if (!themeToggle) {
-      return;
+  function getPreferredTheme() {
+    try {
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'light' || storedTheme === 'dark') {
+        return storedTheme;
+      }
+    } catch {
+      // Ignore storage access errors and fall back to the system preference.
     }
-    const isDarkTheme = htmlElement.dataset.theme === 'dark';
-    themeToggle.textContent = isDarkTheme ? 'Light theme' : 'Dark theme';
-    themeToggle.setAttribute('aria-pressed', isDarkTheme ? 'true' : 'false');
-    themeToggle.setAttribute(
-      'aria-label',
-      isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme',
-    );
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
   }
 
-  if (navigation) {
-    const mobileNavigation = navigation.querySelector(
-      '[data-mobile-navigation]',
-    );
-    const body = document.querySelector('body');
-    const mobileNavigationToggle = navigation.querySelector(
-      '[data-mobile-navigation-toggle]',
-    );
+  function applyTheme(theme) {
+    document.documentElement.style.colorScheme = theme;
+
+    if (colorSchemeMeta) {
+      colorSchemeMeta.setAttribute('content', theme);
+    }
+
+    themeToggles.forEach((toggle) => {
+      const isDark = theme === 'dark';
+
+      toggle.setAttribute('aria-pressed', String(isDark));
+      toggle.setAttribute(
+        'aria-label',
+        `Switch to ${isDark ? 'light' : 'dark'} theme`,
+      );
+    });
+  }
+
+  function toggleTheme() {
+    const nextTheme = getPreferredTheme() === 'dark' ? 'light' : 'dark';
+
+    try {
+      localStorage.setItem('theme', nextTheme);
+    } catch {
+      // Ignore storage access errors and still apply the theme for this page view.
+    }
+
+    applyTheme(nextTheme);
+  }
 
     function toggleMobileNavigation() {
       if (mobileNavigation.hidden) {
@@ -53,19 +67,17 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+  if (mobileNavigation && mobileNavigationToggle) {
     mobileNavigationToggle.addEventListener('click', () => {
       toggleMobileNavigation();
     });
   }
 
-  if (themeToggle) {
-    updateThemeToggleLabel();
+  applyTheme(getPreferredTheme());
 
-    themeToggle.addEventListener('click', () => {
-      const nextTheme = htmlElement.dataset.theme === 'dark' ? 'light' : 'dark';
-      htmlElement.dataset.theme = nextTheme;
-      storage.set('theme', nextTheme);
-      updateThemeToggleLabel();
+  themeToggles.forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      toggleTheme();
     });
-  }
+  });
 });

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navigation = document.querySelector('[data-navigation]');
   const body = document.querySelector('body');
-  const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
   const mobileNavigation = navigation?.querySelector(
     '[data-mobile-navigation]',
   );
@@ -9,51 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     '[data-mobile-navigation-toggle]',
   );
   const themeToggles = document.querySelectorAll('[data-theme-toggle]');
-
-  function getPreferredTheme() {
-    try {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'light' || storedTheme === 'dark') {
-        return storedTheme;
-      }
-    } catch {
-      // Ignore storage access errors and fall back to the system preference.
-    }
-
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light';
-  }
-
-  function applyTheme(theme) {
-    document.documentElement.style.colorScheme = theme;
-
-    if (colorSchemeMeta) {
-      colorSchemeMeta.setAttribute('content', theme);
-    }
-
-    themeToggles.forEach((toggle) => {
-      const isDark = theme === 'dark';
-
-      toggle.setAttribute('aria-pressed', String(isDark));
-      toggle.setAttribute(
-        'aria-label',
-        `Switch to ${isDark ? 'light' : 'dark'} theme`,
-      );
-    });
-  }
-
-  function toggleTheme() {
-    const nextTheme = getPreferredTheme() === 'dark' ? 'light' : 'dark';
-
-    try {
-      localStorage.setItem('theme', nextTheme);
-    } catch {
-      // Ignore storage access errors and still apply the theme for this page view.
-    }
-
-    applyTheme(nextTheme);
-  }
 
     function toggleMobileNavigation() {
       if (mobileNavigation.hidden) {
@@ -73,11 +27,31 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  applyTheme(getPreferredTheme());
+  function updateThemeToggleState() {
+    const isDark =
+      document.documentElement.style.colorScheme === 'dark' ||
+      document.querySelector('meta[name="color-scheme"]')?.content === 'dark';
+
+    themeToggles.forEach((toggle) => {
+      toggle.setAttribute('aria-pressed', String(isDark));
+      toggle.setAttribute(
+        'aria-label',
+        `Switch to ${isDark ? 'light' : 'dark'} theme`,
+      );
+    });
+  }
+
+  document.addEventListener('theme:toggle-theme-mode', () => {
+    window.requestAnimationFrame(() => {
+      updateThemeToggleState();
+    });
+  });
+
+  updateThemeToggleState();
 
   themeToggles.forEach((toggle) => {
     toggle.addEventListener('click', () => {
-      toggleTheme();
+      document.dispatchEvent(new CustomEvent('theme:toggle-theme-mode'));
     });
   });
 });

--- a/bakerydemo/static/js/main.js
+++ b/bakerydemo/static/js/main.js
@@ -9,17 +9,17 @@ document.addEventListener('DOMContentLoaded', () => {
   );
   const themeToggles = document.querySelectorAll('[data-theme-toggle]');
 
-    function toggleMobileNavigation() {
-      if (mobileNavigation.hidden) {
-        body.classList.add('no-scroll');
-        mobileNavigation.hidden = false;
-        mobileNavigationToggle.setAttribute('aria-expanded', 'true');
-      } else {
-        body.classList.remove('no-scroll');
-        mobileNavigation.hidden = true;
-        mobileNavigationToggle.setAttribute('aria-expanded', 'false');
-      }
+  function toggleMobileNavigation() {
+    if (mobileNavigation.hidden) {
+      body.classList.add('no-scroll');
+      mobileNavigation.hidden = false;
+      mobileNavigationToggle.setAttribute('aria-expanded', 'true');
+    } else {
+      body.classList.remove('no-scroll');
+      mobileNavigation.hidden = true;
+      mobileNavigationToggle.setAttribute('aria-expanded', 'false');
     }
+  }
 
   if (mobileNavigation && mobileNavigationToggle) {
     mobileNavigationToggle.addEventListener('click', () => {

--- a/bakerydemo/templates/404.html
+++ b/bakerydemo/templates/404.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}404 - Page not found{% endblock %}
+{% block title %}{% translate "404 - Page not found" %}{% endblock %}
 
-{% block search_description %}Sorry, this page could not be found{% endblock %}
+{% block search_description %}{% translate "Sorry, this page could not be found" %}{% endblock %}
 
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}
-    <h1>Page not found</h1>
+    <h1>{% translate "Page not found" %}</h1>
 
-    <h2>Sorry, this page could not be found.</h2>
+    <h2>{% translate "Sorry, this page could not be found." %}</h2>
 {% endblock content %}

--- a/bakerydemo/templates/500.html
+++ b/bakerydemo/templates/500.html
@@ -1,13 +1,16 @@
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8" />
-        <title>Internal server error</title>
+        <title>{% translate "Internal server error" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>
-        <h1>Internal server error</h1>
+        <h1>{% translate "Internal server error" %}</h1>
 
-        <h2>Sorry, there seems to be an error. Please try again soon.</h2>
+        <h2>{% translate "Sorry, there seems to be an error. Please try again soon." %}</h2>
     </body>
 </html>

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -17,6 +17,7 @@
         </title>
         <meta name="description" content="{% block search_description %}{% if page.search_description %}{{ page.search_description }}{% endif %}{% endblock %}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="light dark">
 
         {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}
@@ -32,7 +33,12 @@
                     storedTheme = null;
                 }
                 const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-                document.documentElement.dataset.theme = storedTheme || (prefersDark ? "dark" : "light");
+                const theme = storedTheme || (prefersDark ? "dark" : "light");
+                document.documentElement.style.colorScheme = theme;
+                const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+                if (colorSchemeMeta) {
+                    colorSchemeMeta.setAttribute("content", theme);
+                }
             })();
         </script>
 

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -25,20 +25,60 @@
         {% endif %}
 
         <script>
-            (() => {
-                let storedTheme = null;
+            /**
+             * IMPORTANT: This script runs before the rest of the page to avoid
+             * showing the wrong theme on first paint.
+             */
+            function updateThemeMode(event, { isInitial = false } = {}) {
+                const DARK = "dark";
+                const LIGHT = "light";
+                const STORAGE_KEY = "wagtail-theme";
+
+                let currentMode;
+                let applyMode;
+                let savedThemeMode;
+
                 try {
-                    storedTheme = localStorage.getItem("theme");
+                    savedThemeMode = localStorage.getItem(STORAGE_KEY);
                 } catch (error) {
-                    storedTheme = null;
+                    savedThemeMode = null;
                 }
-                const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-                const theme = storedTheme || (prefersDark ? "dark" : "light");
-                document.documentElement.style.colorScheme = theme;
+
+                if (savedThemeMode) {
+                    currentMode = savedThemeMode === LIGHT ? LIGHT : DARK;
+                } else {
+                    const prefersDarkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
+                    currentMode = prefersDarkMode ? DARK : LIGHT;
+                }
+
+                if (isInitial) {
+                    applyMode = currentMode === DARK ? DARK : LIGHT;
+                } else {
+                    applyMode = currentMode === DARK ? LIGHT : DARK;
+                }
+
+                document.documentElement.style.colorScheme = applyMode;
+
                 const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
                 if (colorSchemeMeta) {
-                    colorSchemeMeta.setAttribute("content", theme);
+                    colorSchemeMeta.setAttribute("content", applyMode);
                 }
+
+                if (savedThemeMode || event) {
+                    try {
+                        localStorage.setItem(STORAGE_KEY, applyMode);
+                    } catch (error) {
+                        // Ignore storage write failures and continue with the in-memory choice.
+                    }
+                }
+            }
+
+            document.addEventListener("theme:toggle-theme-mode", updateThemeMode, {
+                passive: true,
+            });
+
+            (() => {
+                updateThemeMode(null, { isInitial: true });
             })();
         </script>
 

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -32,7 +32,7 @@
             function updateThemeMode(event, { isInitial = false } = {}) {
                 const DARK = "dark";
                 const LIGHT = "light";
-                const STORAGE_KEY = "wagtail-theme";
+                const STORAGE_KEY = "demo-theme";
 
                 let currentMode;
                 let applyMode;

--- a/bakerydemo/templates/base.html
+++ b/bakerydemo/templates/base.html
@@ -1,6 +1,8 @@
-{% load navigation_tags static wagtailuserbar %}
+{% load i18n navigation_tags static wagtailuserbar %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8">
         <title>

--- a/bakerydemo/templates/base/basic_auth.html
+++ b/bakerydemo/templates/base/basic_auth.html
@@ -1,8 +1,11 @@
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8">
-        <title>Authentication Required</title>
+        <title>{% translate "Authentication Required" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         {# Prevent the demo site from being indexed #}
@@ -19,9 +22,9 @@
 
     <body>
         <article>
-            <h1>Authentication Required</h1>
-            <p>You must login to view this site</p>
-            <h3>Looking for Wagtail? Visit <a href="https://wagtail.org">wagtail.org</a>.</h3>
+            <h1>{% translate "Authentication Required" %}</h1>
+            <p>{% translate "You must login to view this site" %}</p>
+            <h3>{% blocktranslate trimmed %}Looking for Wagtail? Visit <a href="https://wagtail.org">wagtail.org</a>.{% endblocktranslate %}</h3>
         </article>
     </body>
 </html>

--- a/bakerydemo/templates/base/preview/static_embed_block.html
+++ b/bakerydemo/templates/base/preview/static_embed_block.html
@@ -1,9 +1,9 @@
 {% extends "wagtailcore/shared/block_preview.html" %}
-{% load static %}
+{% load i18n static %}
 
 {% block content %}
     <svg class="static-block-preview" viewBox="0 0 360 246">
-        <title>Preview of an embedded video</title>
+        <title>{% translate "Preview of an embedded video" %}</title>
         <rect fill="light-dark(#fff, #1d1d1d)" height="245.5" rx="10" width="360" y=".5" />
         <rect fill="light-dark(#e0e0e0, #464646)" height="211.5" rx="7" width="340" x="10" y="10.5" />
         <path

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -1,12 +1,16 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags wagtail_cache %}
 
 {% if tag %}
     {% block title %}
         {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}: {{ tag }}
     {% endblock %}
 
-    {% block search_description %}Viewing all blog posts sorted by the tag {{ tag }}{% endblock %}
+    {% block search_description %}
+        {% blocktranslate trimmed with tag_name=tag %}
+            Viewing all blog posts sorted by the tag {{ tag_name }}
+        {% endblocktranslate %}
+    {% endblock %}
 {% endif %}
 
 {% block content %}
@@ -18,18 +22,22 @@
         {% if tag %}
             <div class="row">
                 <div class="col-md-12">
-                    <h1 class="index-header__title">Blog</h1>
+                    <h1 class="index-header__title">{{ self.title }}</h1>
                 </div>
                 <div class="col-md-12">
-                    <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag }}</span>.</p>
+                    <p class="index-header__introduction">
+                        {% blocktranslate trimmed with tag_name=tag %}
+                            Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag_name }}</span>.
+                        {% endblocktranslate %}
+                    </p>
                 </div>
             </div>
         {% endif %}
 
         {% if page.get_child_tags %}
-            <nav aria-label="Blog tag filters">
+            <nav aria-label="{% translate 'Blog tag filters' %}">
                 <ul class="blog-tags">
-                    <li><span class="blog-tags__pill blog-tags__pill--selected">All</span></li>
+                    <li><span class="blog-tags__pill blog-tags__pill--selected">{% translate "All" %}</span></li>
                     {% for tag in page.get_child_tags %}
                         <li><a class="blog-tags__pill" href="{{ tag.url }}">{{ tag }}</a></li>
                     {% endfor %}
@@ -46,7 +54,7 @@
                 {% endwagtailcache %}
             {% else %}
                 <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry.</p>
+                    <p>{% translate "Oh, snap. Looks like we were too busy baking to write any blog posts. Sorry." %}</p>
                 </div>
             {% endif %}
         </div>

--- a/bakerydemo/templates/blog/blog_page.html
+++ b/bakerydemo/templates/blog/blog_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load navigation_tags wagtailimages_tags %}
+{% load i18n navigation_tags wagtailimages_tags %}
 
 {% block content %}
 
@@ -22,9 +22,9 @@
                 {{ page.body }}
 
                 {% if page.get_tags %}
-                    <p class="blog__tag-introduction">Find more blog posts with similar tags</p>
+                    <p class="blog__tag-introduction">{% translate "Find more blog posts with similar tags" %}</p>
                     <div class="blog-tags blog-tags--condensed">
-                        <span class="u-sr-only">Filter blog posts by tag</span>
+                        <span class="u-sr-only">{% translate "Filter blog posts by tag" %}</span>
                         {% for tag in page.get_tags %}
                             <a href="{{ tag.url }}" class="blog-tags__pill">{{ tag }}</a>
                         {% endfor %}

--- a/bakerydemo/templates/breads/bread_page.html
+++ b/bakerydemo/templates/breads/bread_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -25,16 +25,16 @@
                     <div class="row">
                         <div class="bread-detail__meta">
                             {% if page.origin %}
-                                <p class="bread-detail__meta-title">Origin</p>
+                                <p class="bread-detail__meta-title">{% translate "Origin" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.origin }}</p>
                             {% endif %}
                             {% if page.bread_type %}
-                                <p class="bread-detail__meta-title">Type</p>
+                                <p class="bread-detail__meta-title">{% translate "Type" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.bread_type }}</p>
                             {% endif %}
                             {% with ingredients=page.ordered_ingredients %}
                                 {% if ingredients %}
-                                    <h4>Ingredients</h4>
+                                    <h4>{% translate "Ingredients" %}</h4>
                                     <ul>
                                         {% for ingredient in ingredients %}
                                             <li>
@@ -44,9 +44,9 @@
                                                 {% else %}
                                                     {# EXAMPLE: we can show a placeholder element for instances that are not live #}
                                                     <span class="bread-detail__meta-ingredient--draft">
-                                                        Draft ingredient
+                                                        {% translate "Draft ingredient" %}
                                                     </span>
-                                                    (draft)
+                                                    ({% translate "draft" %})
                                                 {% endif %}
                                             </li>
                                         {% endfor %}

--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-index.html" %}
@@ -14,7 +14,7 @@
                 {% endfor %}
             </ul>
         {% else %}
-            <p>No breads available at the moment.</p>
+            <p>{% translate "No breads available at the moment." %}</p>
         {% endif %}
     </div>
 

--- a/bakerydemo/templates/includes/card/listing-card.html
+++ b/bakerydemo/templates/includes/card/listing-card.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 <div class="listing-card">
     <a class="listing-card__link" href="{{ page.url }}">
@@ -17,13 +17,13 @@
                 <table class="listing-card__meta">
                     {% if page.origin %}
                         <tr>
-                            <th scope="row" class="listing-card__meta-category">Origin</th>
+                            <th scope="row" class="listing-card__meta-category">{% translate "Origin" %}</th>
                             <td class="listing-card__meta-content">{{ page.origin }}</td>
                         </tr>
                     {% endif %}
                     {% if page.bread_type %}
                         <tr>
-                            <th scope="row" class="listing-card__meta-category">Type</th>
+                            <th scope="row" class="listing-card__meta-category">{% translate "Type" %}</th>
                             <td class="listing-card__meta-content">{{ page.bread_type }}</td>
                         </tr>
                     {% endif %}

--- a/bakerydemo/templates/includes/footer.html
+++ b/bakerydemo/templates/includes/footer.html
@@ -1,4 +1,4 @@
-{% load navigation_tags static %}
+{% load i18n navigation_tags static %}
 
 <footer class="container">
     <div class="row">
@@ -8,21 +8,21 @@
                     <ul class="list-inline">
                         {% if github_url %}
                             <li class="footer__icon">
-                                <a href="{{ github_url }}" target="_blank" rel="noreferrer" aria-label="View Wagtail's source code on GitHub">
+                                <a href="{{ github_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "View Wagtail's source code on GitHub" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 496 512"><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
                                 </a>
                             </li>
                         {% endif %}
                         {% if mastodon_url %}
                             <li class="footer__icon">
-                                <a href="{{ mastodon_url }}" target="_blank" rel="noreferrer" aria-label="Wagtail's official Mastodon account">
+                                <a href="{{ mastodon_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "Wagtail's official Mastodon account" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M433 179.1c0-97.2-63.7-125.7-63.7-125.7-62.5-28.7-228.6-28.4-290.5 0 0 0-63.7 28.5-63.7 125.7 0 115.7-6.6 259.4 105.6 289.1 40.5 10.7 75.3 13 103.3 11.4 50.8-2.8 79.3-18.1 79.3-18.1l-1.7-36.9s-36.3 11.4-77.1 10.1c-40.4-1.4-83-4.4-89.6-54a102.5 102.5 0 0 1 -.9-13.9c85.6 20.9 158.7 9.1 178.8 6.7 56.1-6.7 105-41.3 111.2-72.9 9.8-49.8 9-121.5 9-121.5zm-75.1 125.2h-46.6v-114.2c0-49.7-64-51.6-64 6.9v62.5h-46.3V197c0-58.5-64-56.6-64-6.9v114.2H90.2c0-122.1-5.2-147.9 18.4-175 25.9-28.9 79.8-30.8 103.8 6.1l11.6 19.5 11.6-19.5c24.1-37.1 78.1-34.8 103.8-6.1 23.7 27.3 18.4 53 18.4 175z"/></svg>
                                 </a>
                             </li>
                         {% endif %}
                         {% if organisation_url %}
                             <li class="footer__icon">
-                                <a href="{{ organisation_url }}" target="_blank" rel="noreferrer" aria-label="Wagtail's official website">
+                                <a href="{{ organisation_url }}" target="_blank" rel="noreferrer" aria-label="{% translate "Wagtail's official website" %}">
                                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 640 512"><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M579.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L422.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C206.5 251.2 213 330 263 380c56.5 56.5 148 56.5 204.5 0L579.8 267.7zM60.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C74 372 74 321 105.5 289.5L217.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C433.5 260.8 427 182 377 132c-56.5-56.5-148-56.5-204.5 0L60.2 244.3z"/></svg>
                                 </a>
                             </li>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -26,6 +26,20 @@
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}
                     {% top_menu parent=site_root calling_page=self %}
                 </ul>
+                <div class="theme-toggle theme-toggle--mobile">
+                    <span class="theme-toggle__label">Dark</span>
+                    <button
+                        class="theme-toggle__button"
+                        type="button"
+                        data-theme-toggle
+                        aria-label="Toggle between dark and light theme"
+                        aria-pressed="false"
+                    >
+                        <span class="dark-only u-sr-only">Light mode</span>
+                        <span class="light-only u-sr-only">Dark mode</span>
+                    </button>
+                    <span class="theme-toggle__label">Light</span>
+                </div>
                 <form action="/search" method="get" class="navigation__mobile-search" role="search">
                     <label for="mobile-search-input" class="u-sr-only">Search the bakery</label>
                     <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="Search" autocomplete="off" name="q">
@@ -44,15 +58,20 @@
                 </ul>
             </nav>
 
-            <button
-                type="button"
-                class="navigation__theme-toggle"
-                data-theme-toggle
-                aria-label="Toggle dark theme"
-                aria-pressed="false"
-            >
-                Theme
-            </button>
+            <div class="theme-toggle">
+                <span class="theme-toggle__label">Dark</span>
+                <button
+                    class="theme-toggle__button"
+                    type="button"
+                    data-theme-toggle
+                    aria-label="Toggle between dark and light theme"
+                    aria-pressed="false"
+                >
+                    <span class="dark-only u-sr-only">Light mode</span>
+                    <span class="light-only u-sr-only">Dark mode</span>
+                </button>
+                <span class="theme-toggle__label">Light</span>
+            </div>
 
             <form action="/search" method="get" class="navigation__search" role="search">
                 <label for="search-input" class="u-sr-only">Search the bakery</label>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -1,9 +1,9 @@
-{% load wagtailcore_tags navigation_tags %}
+{% load i18n wagtailcore_tags navigation_tags %}
 
 {% get_site_root as site_root %}
 
 <header class="header clearfix">
-    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <a href="#main-content" class="skip-link">{% translate "Skip to main content" %}</a>
     <div class="container">
         <div class="navigation" data-navigation>
             <a href="{% pageurl site_root %}" class="navigation__logo">The Wagtail Bakery</a>
@@ -11,7 +11,7 @@
             <button
                 type="button"
                 class="navigation__mobile-toggle"
-                aria-label="Toggle mobile menu"
+                aria-label="{% translate "Toggle mobile menu" %}"
                 aria-expanded="false"
                 data-mobile-navigation-toggle
             >
@@ -41,8 +41,8 @@
                     <span class="theme-toggle__label">Light</span>
                 </div>
                 <form action="/search" method="get" class="navigation__mobile-search" role="search">
-                    <label for="mobile-search-input" class="u-sr-only">Search the bakery</label>
-                    <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="Search" autocomplete="off" name="q">
+                    <label for="mobile-search-input" class="u-sr-only">{% translate "Search the bakery" %}</label>
+                    <input class="navigation__search-input" id="mobile-search-input" type="text" placeholder="{% translate "Search" %}" autocomplete="off" name="q">
                     <div aria-hidden="true" class="navigation__search-icon">
                         <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="currentColor" />
@@ -51,7 +51,7 @@
                 </form>
             </nav>
 
-            <nav class="navigation__desktop" aria-label="Main">
+            <nav class="navigation__desktop" aria-label="{% translate "Main" %}">
                 <ul class="navigation__items nav-pills">
                     {# main_menu is defined in base/templatetags/navigation_tags.py #}
                     {% top_menu parent=site_root calling_page=self %}
@@ -74,8 +74,8 @@
             </div>
 
             <form action="/search" method="get" class="navigation__search" role="search">
-                <label for="search-input" class="u-sr-only">Search the bakery</label>
-                <input class="navigation__search-input" id="search-input" type="text" placeholder="Search" autocomplete="off" name="q">
+                <label for="search-input" class="u-sr-only">{% translate "Search the bakery" %}</label>
+                <input class="navigation__search-input" id="search-input" type="text" placeholder="{% translate "Search" %}" autocomplete="off" name="q">
                 <div aria-hidden="true" class="navigation__search-icon">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="currentColor" />

--- a/bakerydemo/templates/includes/messages.html
+++ b/bakerydemo/templates/includes/messages.html
@@ -1,6 +1,7 @@
+{% load i18n %}
 {% if messages %}
     <div class="alert">
-        <p class="alert__title">Error</p>
+        <p class="alert__title">{% translate "Error" %}</p>
         <ul class="alert__messages">
             {% for message in messages %}
                 <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>

--- a/bakerydemo/templates/includes/pagination.html
+++ b/bakerydemo/templates/includes/pagination.html
@@ -1,20 +1,20 @@
-{% load navigation_tags %}
+{% load i18n navigation_tags %}
 
-<nav class="pagination" aria-label="Pagination">
+<nav class="pagination" aria-label="{% translate 'Pagination' %}">
     <ul class="pagination__list">
         {% if subpages.has_previous %}
             <li class="page-item">
-                <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">previous</a>
+                <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">{% translate "Previous" %}</a>
             </li>
         {% else %}
             <li class="page-item disabled">
-                <a class="page-link">previous</a>
+                <a class="page-link">{% translate "Previous" %}</a>
             </li>
         {% endif %}
 
         {% for i in subpages.paginator.page_range %}
             {% if subpages.number == i %}
-                <li class="page-item active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                <li class="page-item active"><span>{{ i }} <span class="sr-only">({% translate "current" %})</span></span></li>
             {% else %}
                 <li class="page-item"><a href="?page={{ i }}" class="page-link">{{ i }}</a></li>
             {% endif %}
@@ -22,11 +22,11 @@
 
         {% if subpages.has_next %}
             <li class="page-item">
-                <a href="?page={{ subpages.next_page_number }}" class="page-link next arrows">next</a>
+                <a href="?page={{ subpages.next_page_number }}" class="page-link next arrows">{% translate "Next" %}</a>
             </li>
         {% else %}
             <li class="page-item disabled">
-                <a class="page-link">next</a>
+                <a class="page-link">{% translate "Next" %}</a>
             </li>
         {% endif %}
     </ul>

--- a/bakerydemo/templates/locations/location_page.html
+++ b/bakerydemo/templates/locations/location_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags navigation_tags static %}
+{% load i18n wagtailimages_tags navigation_tags static %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -24,7 +24,7 @@
                 <div class="col-md-4 col-md-offset-1">
                     <div class="row">
                         <div class="bread-detail__meta">
-                            <h2 class="location__meta-title">Operating Status</h2>
+                            <h2 class="location__meta-title">{% translate "Operating status" %}</h2>
                             {% comment %}
                                 Fetch the status of the location on the client side
                                 as a Wagtail API usage example and to allow for
@@ -32,28 +32,33 @@
                             {% endcomment %}
                             {% if request.is_preview %}
                                 {% if page.is_open %}
-                                    This location is currently open.
+                                    {% translate "This location is currently open." %}
                                 {% else %}
-                                    Sorry, this location is currently closed.
+                                    {% translate "Sorry, this location is currently closed." %}
                                 {% endif %}
                             {% else %}
-                                <location-status url="{% url 'wagtailapi:pages:detail' page.pk %}">
-                                    Please wait…
+                                <location-status
+                                    url="{% url 'wagtailapi:pages:detail' page.pk %}"
+                                    data-open-label="{% translate 'This location is currently open.' %}"
+                                    data-closed-label="{% translate 'Sorry, this location is currently closed.' %}"
+                                    data-unavailable-label="{% translate "Sorry, we couldn't retrieve the status of this location." %}"
+                                >
+                                    {% translate "Please wait…" %}
                                 </location-status>
                             {% endif %}
 
 
-                            <h2 class="location__meta-title">Address</h2>
+                            <h2 class="location__meta-title">{% translate "Address" %}</h2>
                             <address>{{ page.address|linebreaks }}</address>
 
                             {% if page.operating_hours %}
-                                <h2 class="location__meta-title">Opening hours</h2>
+                                <h2 class="location__meta-title">{% translate "Opening hours" %}</h2>
                                 {% for hours in page.operating_hours %}
                                     <time itemprop="openingHours" datetime="{{ hours }}" class="location__time">
                                         <span class="location__day">{{ hours.day }}</span>:
                                         <span class="location__hours">
                                             {% if hours.closed == True %}
-                                                Closed
+                                                {% translate "Closed" %}
                                             {% else %}
                                                 {% if hours.opening_time %}
                                                     {{ hours.opening_time }}

--- a/bakerydemo/templates/people/person_page.html
+++ b/bakerydemo/templates/people/person_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailimages_tags %}
+{% load i18n wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-hero.html" %}
@@ -25,11 +25,11 @@
                     <div class="row">
                         <div class="bread-detail__meta">
                             {% if page.location %}
-                                <p class="bread-detail__meta-title">Location</p>
+                                <p class="bread-detail__meta-title">{% translate "Location" %}</p>
                                 <p class="bread-detail__meta-content">{{ page.location }}</p>
                             {% endif %}
                             {% if page.social_links %}
-                                <p class="bread-detail__meta-title">Socials</p>
+                                <p class="bread-detail__meta-title">{% translate "Socials" %}</p>
                                 <div class="social-links">
                                     {% for block in page.social_links %}
                                         <a href="{{ block.value.url }}" target="_blank" rel="noopener noreferrer" title="{{ block.value.get_platform_label }}">

--- a/bakerydemo/templates/recipes/recipe_index_page.html
+++ b/bakerydemo/templates/recipes/recipe_index_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags navigation_tags wagtailimages_tags %}
+{% load i18n wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
     {% include "base/include/header-index.html" %}
@@ -12,7 +12,7 @@
                 {% endfor %}
             {% else %}
                 <div class="col-md-12">
-                    <p>Oh, snap. Looks like we were too busy baking to write any recipes. Sorry.</p>
+                    <p>{% translate "Oh, snap. Looks like we were too busy baking to write any recipes. Sorry." %}</p>
                 </div>
             {% endif %}
         </div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -1,9 +1,21 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags wagtailimages_tags wagtailsearchpromotions_tags %}
+{% load i18n wagtailcore_tags wagtailimages_tags wagtailsearchpromotions_tags %}
 
-{% block title %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block title %}
+    {% if search_query %}
+        {% blocktranslate trimmed with query=search_query %}Search results for “{{ query }}”{% endblocktranslate %}
+    {% else %}
+        {% translate "Search" %}
+    {% endif %}
+{% endblock %}
 
-{% block search_description %}Search{% if search_results %} results{% endif %}{% if search_query %} for “{{ search_query }}”{% endif %}{% endblock %}
+{% block search_description %}
+    {% if search_query %}
+        {% blocktranslate trimmed with query=search_query %}Search results for “{{ query }}”{% endblocktranslate %}
+    {% else %}
+        {% translate "Search" %}
+    {% endif %}
+{% endblock %}
 
 {% block body_class %}template-search-results{% endblock %}
 
@@ -11,9 +23,15 @@
     <div class="container">
         <div class="row">
             <div class="col-md-8">
-                <h1>Search results</h1>
+                <h1>{% translate "Search results" %}</h1>
                 {% if search_results %}
-                    <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} result{{ search_results|length|pluralize }} found.</p>
+                    <p class="search__introduction">
+                        {% blocktranslate trimmed count result_count=search_results | length with query=search_query %}
+                            You searched for “{{ query }}”, {{ result_count }} result found.
+                        {% plural %}
+                            You searched for “{{ query }}”, {{ result_count }} results found.
+                        {% endblocktranslate %}
+                    </p>
                     <ul class="search__results">
                         {% for result in search_results %}
                             <li class="listing-card">
@@ -62,11 +80,11 @@
                                                 <h2 class="listing-card__title">{{ search_promotion.page.specific }}</h2>
                                                 <p class="listing-card__content-type">
                                                     {% if search_promotion.page.specific.content_type.model == "blogpage" %}
-                                                        Blog Post
+                                                        {% translate "Blog post" %}
                                                     {% elif search_promotion.page.specific.content_type.model == "locationpage" %}
-                                                        Location
+                                                        {% translate "Location" %}
                                                     {% else %}
-                                                        Bread
+                                                        {% translate "Bread" %}
                                                     {% endif %}
                                                 </p>
                                                 <p class="listing-card__description">
@@ -82,7 +100,7 @@
                                             <div class="listing-card__contents">
                                                 <h2 class="listing-card__title">{{ search_promotion.external_link_text }}</h2>
                                                 <p class="listing-card__content-type">
-                                                    External link
+                                                    {% translate "External link" %}
                                                 </p>
                                                 <p class="listing-card__description">
                                                     {% if search_promotion.description %}{{ search_promotion.description|richtext }}{% endif %}
@@ -94,10 +112,14 @@
                             {% endfor %}
                         </ul>
                     {% else %}
-                        <p class="search__introduction">No results found for “{{ search_query }}”.</p>
+                        <p class="search__introduction">
+                            {% blocktranslate trimmed with query=search_query %}
+                                No results found for “{{ query }}”.
+                            {% endblocktranslate %}
+                        </p>
                     {% endif %}
                 {% else %}
-                    <p class="search__introduction">You didn&apos;t search for anything!</p>
+                    <p class="search__introduction">{% translate "You didn&apos;t search for anything!" %}</p>
                 {% endif %}
             </div>
         </div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -26,7 +26,7 @@
                 <h1>{% translate "Search results" %}</h1>
                 {% if search_results %}
                     <p class="search__introduction">
-                        {% blocktranslate trimmed count result_count=search_results | length with query=search_query %}
+                        {% blocktranslate trimmed count result_count=search_results|length with query=search_query %}
                             You searched for “{{ query }}”, {{ result_count }} result found.
                         {% plural %}
                             You searched for “{{ query }}”, {{ result_count }} results found.

--- a/bakerydemo/templates/tags/breadcrumbs.html
+++ b/bakerydemo/templates/tags/breadcrumbs.html
@@ -1,7 +1,7 @@
-{% load wagtailcore_tags %}
+{% load i18n wagtailcore_tags %}
 
 {% if ancestors %}
-    <nav class="breadcrumb-container" aria-label="Breadcrumb">
+    <nav class="breadcrumb-container" aria-label="{% translate 'Breadcrumb' %}">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12">
@@ -10,7 +10,7 @@
                             {% if forloop.last %}
                                 <li aria-current="page">{{ ancestor }}</li>
                             {% else %}
-                                <li><a href="{% pageurl ancestor %}">{% if forloop.first %}Home{% else %}{{ ancestor }}{% endif %}</a>
+                                <li><a href="{% pageurl ancestor %}">{% if forloop.first %}{% translate "Home" %}{% else %}{{ ancestor }}{% endif %}</a>
                                     {% include "includes/chevron-icon.html" with class="breadcrumb__chevron-icon" %}</li>
                             {% endif %}
                         {% endfor %}

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   },
   "scripts": {
     "fix:js": "eslint --ext .js --fix .",
-    "fix:css": "stylelint --fix **/*.css",
+    "fix:css": "stylelint --fix \"bakerydemo/static/css/**/*.css\"",
     "format": "prettier --write \"**/?(.)*.{css,js,json,yaml,yml}\"",
     "lint:js": "eslint --ext .js --report-unused-disable-directives .",
-    "lint:css": "stylelint **/*.css",
+    "lint:css": "stylelint \"bakerydemo/static/css/**/*.css\"",
     "lint:format": "prettier --check \"**/?(.)*.{css,js,json,yaml,yml}\"",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:format"
   }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -11,10 +11,8 @@ export default {
 
     'scss/media-feature-value-dollar-variable': null, // Bakerydemo uses plain CSS media queries, not SCSS variables.
     'scss/selector-class-pattern': null, // Existing bakerydemo/Wagtail block class names do not fully match this stricter pattern.
-    'declaration-property-value-allowed-list': null, // Current CSS still uses values like text-align: left.
     'declaration-property-value-disallowed-list': null, // Current CSS still uses values like border: none.
     'declaration-no-important': null, // Allow existing !important usage for now.
-    'property-disallowed-list': null, // Allow current physical positioning properties.
     'scale-unlimited/declaration-strict-value': null, // Too strict until tokenization is further along.
     'selector-max-specificity': null, // Relax strict specificity limits for existing CSS.
   },


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Task of #758 

### Description

<!-- Please describe the problem you're fixing. -->
This PR  has been  rebased onto the branch `Srishti-j18:light-dark-theme` and `Srishti-j18:multilingual-theme-groundwork` as those branches are needed for RTL support changes. So this PR should be merged after the merge of https://github.com/wagtail/bakerydemo/pull/754 and  https://github.com/wagtail/bakerydemo/pull/761

The commits related to this PR are:

1. Refactored `main.css` from physical inline CSS to logical properties/values, like `padding-inline-start`, `margin-inline-end`, `inset-inline`, `border-inline-start`, `text-align: start`, and `logical floats`.https://github.com/wagtail/bakerydemo/pull/763/changes/aa940896590c2d0603fcf643ba8133cbba6434cd 

2. Re-enabled Wagtail’s logical CSS linting by removing the local overrides for `property-disallowed-list `and `declaration-property-value-allowed-list` in `stylelint.config.mjs`. + Narrowed `lint:css / fix:css` in `package.json` so local virtualenv CSS does not get linted accidentally. https://github.com/wagtail/bakerydemo/pull/763/changes/1e9c42fdfb73e41c1ea90adea1671c64ba385f01

3. https://github.com/wagtail/bakerydemo/pull/763/changes/b35bef666cf1937b746e60b738c61bcb85908982

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None
