### PR TITLE
Add Playwright E2E test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,21 @@ jobs:
       - run: uv run ./manage.py check
       - run: uv run ./manage.py makemigrations --check --noinput
       - run: uv run ./manage.py test
+  test-client-integration:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: bakerydemo.settings.test
+      PLAYWRIGHT_WEB_SERVER_COMMAND: uv run python manage.py runserver 127.0.0.1:8000 --noreload
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+      - run: uv venv
+      - run: uv pip install -r requirements/development.txt
+      - run: uv run ./manage.py migrate
+      - run: uv run ./manage.py load_initial_data
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ bakerydemo/settings/local.py
 bakerydemodb
 *.db
 node_modules
+playwright-report
+test-results
+uvenv
 venv
 .venv
 __pycache__

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 # Irrelevant files ignored for performance reasons.
 node_modules
+playwright-report
+test-results
+uvenv
 venv
 .venv
 *.min.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,4 +1,7 @@
 node_modules
+playwright-report
+test-results
+uvenv
 venv
 .venv
 *.min.css

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,19 @@ You can also run the project test suite with:
 ./manage.py test
 ```
 
+The browser integration tests use Playwright and the demo fixture data:
+
+```bash
+npm ci
+npx playwright install chromium
+./manage.py migrate
+./manage.py load_initial_data
+npm run test:e2e
+
+# To open HTML report run below commmand
+npx playwright show-report
+```
+
 ### Demo data management
 
 If you change content or images in this repo and need to prepare a new fixture file for export, do the following on a branch:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,15 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['node_modules', 'venv', '.venv', 'bakerydemo/collect_static'],
+    ignores: [
+      'node_modules',
+      'playwright-report',
+      'test-results',
+      'uvenv',
+      'venv',
+      '.venv',
+      'bakerydemo/collect_static',
+    ],
   },
   {
     ...js.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@playwright/test": "^1.61.1",
         "@wagtail/stylelint-config-wagtail": "^2.0.0",
         "eslint": "^9.39.2",
         "globals": "^16.5.0",
@@ -516,6 +517,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -1210,6 +1227,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -1863,6 +1895,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.61.1",
     "@wagtail/stylelint-config-wagtail": "^2.0.0",
     "eslint": "^9.39.2",
     "globals": "^16.5.0",
@@ -23,6 +24,7 @@
     "lint:js": "eslint --ext .js --report-unused-disable-directives .",
     "lint:css": "stylelint **/*.css",
     "lint:format": "prettier --check \"**/?(.)*.{css,js,json,yaml,yml}\"",
-    "lint": "npm run lint:js && npm run lint:css && npm run lint:format"
+    "lint": "npm run lint:js && npm run lint:css && npm run lint:format",
+    "test:e2e": "playwright test"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = process.env.PORT || '8000';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${port}`;
+const webServerCommand =
+  process.env.PLAYWRIGHT_WEB_SERVER_COMMAND ||
+  `python3 manage.py runserver 127.0.0.1:${port} --noreload`;
+
+const webServer =
+  process.env.PLAYWRIGHT_SKIP_WEB_SERVER === '1'
+    ? {}
+    : {
+        webServer: {
+          command: webServerCommand,
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
+      };
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  ...webServer,
+});

--- a/tests/e2e/fixture-backed-pages.spec.mjs
+++ b/tests/e2e/fixture-backed-pages.spec.mjs
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('fixture-backed pages', () => {
+  test('home page renders demo content', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', { name: 'Welcome to the Wagtail Bakery!' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Learn more about Wagtail' }),
+    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Breads' })).toBeVisible();
+  });
+
+  test('desktop search returns fixture content', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('#search-input').fill('Anadama');
+    await page.locator('#search-input').press('Enter');
+
+    await expect(page).toHaveURL(/\/search\/\?q=Anadama/);
+    await expect(
+      page.getByRole('heading', { name: 'Search results' }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: /Anadama/ })).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #765 

### Description

<!-- Please describe the problem you're fixing. -->
This PR sets up Playwright for E2E integration testing in `bakerydemo`.

It adds the Playwright Node runner, a basic fixture-backed browser test suite, and CI coverage for running the tests against the existing demo data loaded by `load_initial_data`.

The initial tests verify that:

- the home page renders expected demo fixture content
- the desktop search flow works with existing fixture data

This provides a foundation for testing interactive frontend work such as the language switcher in #757 .

### Tested locally

```bash
npm ci
npx playwright install chromium
./manage.py migrate
./manage.py load_initial_data
npm run test:e2e
```

<img width="1168" height="693" alt="Screenshot 2026-07-20 at 12 36 22 AM" src="https://github.com/user-attachments/assets/308f39da-f7b3-42d7-af95-3daa97210b23" />

To open HTML report:

```bash
npx playwright show-report
```

<img width="1344" height="554" alt="Screenshot 2026-07-20 at 12 37 50 AM" src="https://github.com/user-attachments/assets/b085f0cd-e68d-4d21-95ab-a6babe73d1ef" />

<img width="1267" height="897" alt="Screenshot 2026-07-20 at 12 38 22 AM" src="https://github.com/user-attachments/assets/e7464381-b5a9-42ce-bf7e-189ce432aab5" />

**Note:**

`npm run lint:css` is currently blocked by existing data-theme Stylelint errors in `bakerydemo/static/css/main.css`, unrelated to this Playwright setup.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

I used AI to help set up the Playwright configuration. I manually reviewed and tested the final changes locally.


