### PR TITLE
Fix nav links wrapping to second line on desktop

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -711,12 +711,20 @@ caption {
 }
 
 @media (min-width: 1150px) {
-  .navigation__items {
-    display: block;
-  }
+    .navigation__desktop .navigation__items {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        padding: 0 0 0 10px;
+    }
 
+    .navigation__desktop .navigation__items > li {
+        float: none;
+        padding: 0 0 0 10px;
+    }
+}
   .navigation__items > li {
-    padding: 0 0 0 20px;
+    padding: 0 0 0 10px;
   }
 
   .navigation__items > li > a {


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...
## What does this fix?
The "About" nav link was wrapping to second line on desktop view instead of staying inline with other navigation items.
Also did a bit of UI changes.

### Description
Bootstrap 3's nav-pills class applies float:left to li 
elements which conflicted with the navigation's flex layout.

Fix:
- Override Bootstrap's float with display:flex on desktop nav
- Added float:none on li elements
- Reduced padding from 20px to 10px to give items enough space

Before:
<img width="1812" height="1084" alt="Before" src="https://github.com/user-attachments/assets/8a1dac1f-5c46-44cc-8835-d81c8a7d6772" />

After:
<img width="1843" height="1107" alt="After" src="https://github.com/user-attachments/assets/082075c4-cfe0-4bcf-8a13-4023fae2b587" />



<!-- Please describe the problem you're fixing. -->


### AI usage
I'm new to open source contributions and used  AI as a learning aid while debugging this issue. 
The fix and testing were done by me.

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
